### PR TITLE
Add snapshot traits and expose exporters/recorders from metrics.

### DIFF
--- a/metrics-core/Cargo.toml
+++ b/metrics-core/Cargo.toml
@@ -15,3 +15,6 @@ documentation = "https://docs.rs/metrics-core"
 readme = "README.md"
 
 keywords = ["metrics", "interface", "common"]
+
+[dependencies]
+futures = "^0.1"

--- a/metrics-core/src/lib.rs
+++ b/metrics-core/src/lib.rs
@@ -32,10 +32,11 @@
 //!
 //! Histograms are a convenient way to measure behavior not only at the median, but at the edges of
 //! normal operating behavior.
+use std::fmt::Display;
 use futures::future::Future;
 
 /// A value that records metrics.
-pub trait MetricsRecorder {
+pub trait Recorder {
     /// Records a counter.
     ///
     /// From the perspective of an recorder, a counter and gauge are essentially identical, insofar
@@ -62,15 +63,15 @@ pub trait MetricsRecorder {
 }
 
 /// A value that holds a point-in-time view of collected metrics.
-pub trait MetricsSnapshot {
+pub trait Snapshot {
     /// Records the snapshot to the given recorder.
-    fn record<R: MetricsRecorder>(&self, recorder: &mut R);
+    fn record<R: Recorder>(&self, recorder: &mut R);
 }
 
 /// A value that can provide on-demand snapshots.
 pub trait SnapshotProvider {
-    type Snapshot;
-    type SnapshotError;
+    type Snapshot: Snapshot;
+    type SnapshotError: Display;
 
     /// Gets a snapshot.
     fn get_snapshot(&self) -> Result<Self::Snapshot, Self::SnapshotError>;
@@ -78,8 +79,8 @@ pub trait SnapshotProvider {
 
 /// A value that can provide on-demand snapshots asynchronously.
 pub trait AsyncSnapshotProvider {
-    type Snapshot;
-    type SnapshotError;
+    type Snapshot: Snapshot;
+    type SnapshotError: Display;
     type SnapshotFuture: Future<Item = Self::Snapshot, Error = Self::SnapshotError>;
 
     /// Gets a snapshot asynchronously.

--- a/metrics-core/src/lib.rs
+++ b/metrics-core/src/lib.rs
@@ -71,7 +71,7 @@ pub trait Snapshot {
 /// A value that can provide on-demand snapshots.
 pub trait SnapshotProvider {
     type Snapshot: Snapshot;
-    type SnapshotError: Display;
+    type SnapshotError;
 
     /// Gets a snapshot.
     fn get_snapshot(&self) -> Result<Self::Snapshot, Self::SnapshotError>;
@@ -80,7 +80,7 @@ pub trait SnapshotProvider {
 /// A value that can provide on-demand snapshots asynchronously.
 pub trait AsyncSnapshotProvider {
     type Snapshot: Snapshot;
-    type SnapshotError: Display;
+    type SnapshotError;
     type SnapshotFuture: Future<Item = Self::Snapshot, Error = Self::SnapshotError>;
 
     /// Gets a snapshot asynchronously.

--- a/metrics-exporter-log/Cargo.toml
+++ b/metrics-exporter-log/Cargo.toml
@@ -14,7 +14,6 @@ documentation = "https://docs.rs/metrics-exporter-log"
 
 [dependencies]
 metrics-core = { path = "../metrics-core", version = "^0.2" }
-metrics = { path = "../metrics", version = "^0.9" }
 log = "^0.4"
 futures = "^0.1"
 tokio-timer = "^0.2"

--- a/metrics-exporter-log/src/lib.rs
+++ b/metrics-exporter-log/src/lib.rs
@@ -7,35 +7,39 @@
 //! # Run Modes
 //! - `run` can be used to block the current thread, taking snapshots and exporting them on an
 //! interval
-//! - `turn` can be used to take a single snapshot and log it
 //! - `into_future` will return a [`Future`] that when driven will take a snapshot on the 
 //! configured interval and log it
 #[macro_use]
 extern crate log;
 
+use std::fmt::Display;
 use std::thread;
 use std::time::Duration;
-use metrics::Controller;
-use metrics_core::MetricsRecorder;
+use metrics_core::{MetricsRecorder, MetricsSnapshot, SnapshotProvider, AsyncSnapshotProvider};
 use log::Level;
 use futures::prelude::*;
 use tokio_timer::Interval;
 
 /// Exports metrics by converting them to a textual representation and logging them.
-pub struct LogExporter<R> {
-    controller: Controller,
+pub struct LogExporter<C, R> {
+    controller: C,
     recorder: R,
     level: Level,
 }
 
-impl<R> LogExporter<R>
+impl<C, R> LogExporter<C, R>
 where
-    R: MetricsRecorder + Clone + Into<String>
+    C: SnapshotProvider + AsyncSnapshotProvider,
+    <C as SnapshotProvider>::Snapshot: MetricsSnapshot,
+    <C as SnapshotProvider>::SnapshotError: Display,
+    <C as AsyncSnapshotProvider>::Snapshot: MetricsSnapshot,
+    <C as AsyncSnapshotProvider>::SnapshotError: Display,
+    R: MetricsRecorder + Clone + Into<String>,
 {
     /// Creates a new [`LogExporter`] that logs at the configurable level.
     ///
     /// Recorders expose their output by being converted into strings.
-    pub fn new(controller: Controller, recorder: R, level: Level) -> Self {
+    pub fn new(controller: C, recorder: R, level: Level) -> Self {
         LogExporter {
             controller,
             recorder,
@@ -54,7 +58,15 @@ where
 
     /// Run this exporter, logging output only once.
     pub fn turn(&self) {
-        run_once(&self.controller, self.recorder.clone(), self.level);
+        match self.controller.get_snapshot() {
+            Ok(snapshot) => {
+                let mut recorder = self.recorder.clone();
+                snapshot.record(&mut recorder);
+                let output = recorder.into();
+                log!(self.level, "{}", output);
+            },
+            Err(e) => log!(Level::Error, "failed to get snapshot: {}", e),
+        }
     }
 
     /// Converts this exporter into a future which logs output on the given interval.
@@ -66,23 +78,16 @@ where
         Interval::new_interval(interval)
             .map_err(|_| ())
             .for_each(move |_| {
-                let recorder = recorder.clone();
-                run_once(&controller, recorder, level);
-                Ok(())
-            })
-    }
-}
+                let mut recorder = recorder.clone();
 
-fn run_once<R>(controller: &Controller, mut recorder: R, level: Level)
-where
-    R: MetricsRecorder + Into<String>
-{
-    match controller.get_snapshot() {
-        Ok(snapshot) => {
-            snapshot.record(&mut recorder);
-            let output = recorder.into();
-            log!(level, "{}", output);
-        },
-        Err(e) => log!(Level::Error, "failed to capture snapshot: {}", e),
+                controller.get_snapshot_async()
+                    .and_then(move |snapshot| {
+                        snapshot.record(&mut recorder);
+                        let output = recorder.into();
+                        log!(level, "{}", output);
+                        Ok(())
+                    })
+                    .map_err(|e| log!(Level::Error, "failed to get snapshot: {}", e))
+            })
     }
 }

--- a/metrics-exporter-log/src/lib.rs
+++ b/metrics-exporter-log/src/lib.rs
@@ -82,7 +82,7 @@ where
                         log!(level, "{}", output);
                         Ok(())
                     })
-                    .map_err(|e| log!(Level::Error, "failed to get snapshot: {}", e))
+                    .map_err(|e| error!("failed to get snapshot: {}", e))
             })
     }
 }

--- a/metrics-exporter-log/src/lib.rs
+++ b/metrics-exporter-log/src/lib.rs
@@ -12,10 +12,9 @@
 #[macro_use]
 extern crate log;
 
-use std::fmt::Display;
 use std::thread;
 use std::time::Duration;
-use metrics_core::{MetricsRecorder, MetricsSnapshot, SnapshotProvider, AsyncSnapshotProvider};
+use metrics_core::{Recorder, Snapshot, SnapshotProvider, AsyncSnapshotProvider};
 use log::Level;
 use futures::prelude::*;
 use tokio_timer::Interval;
@@ -30,11 +29,7 @@ pub struct LogExporter<C, R> {
 impl<C, R> LogExporter<C, R>
 where
     C: SnapshotProvider + AsyncSnapshotProvider,
-    <C as SnapshotProvider>::Snapshot: MetricsSnapshot,
-    <C as SnapshotProvider>::SnapshotError: Display,
-    <C as AsyncSnapshotProvider>::Snapshot: MetricsSnapshot,
-    <C as AsyncSnapshotProvider>::SnapshotError: Display,
-    R: MetricsRecorder + Clone + Into<String>,
+    R: Recorder + Clone + Into<String>,
 {
     /// Creates a new [`LogExporter`] that logs at the configurable level.
     ///

--- a/metrics-recorder-prometheus/src/lib.rs
+++ b/metrics-recorder-prometheus/src/lib.rs
@@ -1,7 +1,7 @@
 //! Records metrics in the Prometheus exposition format.
 use std::time::SystemTime;
 use hdrhistogram::Histogram;
-use metrics_core::MetricsRecorder;
+use metrics_core::Recorder;
 use metrics_util::{Quantile, parse_quantiles};
 
 /// Records metrics in the Prometheus exposition format.
@@ -30,7 +30,7 @@ impl PrometheusRecorder {
     }
 }
 
-impl MetricsRecorder for PrometheusRecorder {
+impl Recorder for PrometheusRecorder {
     fn record_counter<K: AsRef<str>>(&mut self, key: K, value: u64) {
         let label = key.as_ref().replace('.', "_");
         self.output.push_str("\n# TYPE ");

--- a/metrics-recorder-text/src/lib.rs
+++ b/metrics-recorder-text/src/lib.rs
@@ -45,7 +45,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Display;
 use hdrhistogram::Histogram;
-use metrics_core::MetricsRecorder;
+use metrics_core::Recorder;
 use metrics_util::{Quantile, parse_quantiles};
 
 /// Records metrics in a hierarchical, text-based format.
@@ -75,7 +75,7 @@ impl TextRecorder {
     }
 }
 
-impl MetricsRecorder for TextRecorder {
+impl Recorder for TextRecorder {
     fn record_counter<K: AsRef<str>>(&mut self, key: K, value: u64) {
         let (name_parts, name) = name_to_parts(key.as_ref());
         let mut values = single_value_to_values(name, value);

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -21,6 +21,11 @@ debug = true
 opt-level = 3
 lto = true
 
+[features]
+default = ["exporters", "recorders"]
+exporters = ["metrics-exporter-log"]
+recorders = ["metrics-recorder-text", "metrics-recorder-prometheus"]
+
 [dependencies]
 metrics-core = { path = "../metrics-core", version = "^0.2" }
 crossbeam-channel = "^0.3"
@@ -28,7 +33,11 @@ parking_lot = "^0.7"
 fnv = "^1.0"
 hashbrown = "^0.1"
 quanta = "^0.2"
+futures = "^0.1"
 tokio-sync = "^0.1"
+metrics-exporter-log = { path = "../metrics-exporter-log", version = "^0.1", optional = true }
+metrics-recorder-text = { path = "../metrics-recorder-text", version = "^0.1", optional = true }
+metrics-recorder-prometheus = { path = "../metrics-recorder-prometheus", version = "^0.1", optional = true }
 
 [dev-dependencies]
 log = "^0.4"

--- a/metrics/examples/benchmark.rs
+++ b/metrics/examples/benchmark.rs
@@ -9,6 +9,7 @@ extern crate metrics_core;
 use getopts::Options;
 use hdrhistogram::Histogram;
 use metrics::{snapshot::TypedMeasurement, Receiver, Sink};
+use metrics_core::SnapshotProvider;
 use std::{
     env,
     sync::{
@@ -45,13 +46,13 @@ impl Generator {
             }
 
             self.gauge += 1;
-            let t1 = self.stats.clock().now();
+            let t1 = self.stats.now();
 
             if let Some(t0) = self.t0 {
-                let start = self.stats.clock().now();
+                let start = self.stats.now();
                 let _ = self.stats.record_timing("ok", t0, t1);
                 let _ = self.stats.record_gauge("total", self.gauge);
-                let delta = self.stats.clock().now() - start;
+                let delta = self.stats.now() - start;
                 self.hist.saturating_record(delta);
             }
             self.t0 = Some(t1);

--- a/metrics/src/data/snapshot.rs
+++ b/metrics/src/data/snapshot.rs
@@ -1,5 +1,5 @@
 use super::histogram::HistogramSnapshot;
-use metrics_core::{MetricsSnapshot, MetricsRecorder};
+use metrics_core::{Snapshot as MetricsSnapshot, Recorder};
 use std::fmt::Display;
 
 /// A typed metric measurement, used in snapshots.
@@ -70,7 +70,7 @@ impl Snapshot {
 
 impl MetricsSnapshot for Snapshot {
     /// Records the snapshot to the given recorder.
-    fn record<R: MetricsRecorder>(&self, recorder: &mut R) {
+    fn record<R: Recorder>(&self, recorder: &mut R) {
         for measurement in &self.measurements {
             match measurement {
                 TypedMeasurement::Counter(key, value) => recorder.record_counter(key, *value),
@@ -88,9 +88,8 @@ impl MetricsSnapshot for Snapshot {
 
 #[cfg(test)]
 mod tests {
-    use super::{HistogramSnapshot, MetricsRecorder, Snapshot, TypedMeasurement};
+    use super::{HistogramSnapshot, MetricsSnapshot, Recorder, Snapshot, TypedMeasurement};
     use std::collections::HashMap;
-    use metrics_core::MetricsSnapshot;
 
     #[derive(Default)]
     struct MockRecorder {
@@ -113,7 +112,7 @@ mod tests {
         }
     }
 
-    impl MetricsRecorder for MockRecorder {
+    impl Recorder for MockRecorder {
         fn record_counter<K: AsRef<str>>(&mut self, key: K, value: u64) {
             let _ = self.counter.insert(key.as_ref().to_owned(), value);
         }

--- a/metrics/src/exporters.rs
+++ b/metrics/src/exporters.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "metrics-exporter-log")]
+pub use metrics_exporter_log::LogExporter;

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -50,13 +50,14 @@
 //! // to, so you need to track the overall value on your own.
 //! sink.record_gauge("red_balloons", 99);
 //!
-//! // We can update a timing histogram.  For timing, you also must measure the start and end
-//! // time using the built-in `Clock` exposed by the sink.  The receiver internally converts the
-//! // raw values to calculate the actual wall clock time (in nanoseconds) on your behalf, so you
-//! // can't just pass in any old number.. otherwise you'll get erroneous measurements!
-//! let start = sink.clock().start();
+//! // We can update a timing histogram.  For timing, we're using the built-in `Sink::now` method
+//! // which utilizes a high-speed internal clock.  This method returns the time in nanoseconds, so
+//! // we get great resolution, but giving the time in nanoseconds isn't required!  If you want to
+//! // send it in another unit, that's fine, but just pay attention to that fact when viewing and
+//! // using those metrics once exported.
+//! let start = sink.now();
 //! thread::sleep(Duration::from_millis(10));
-//! let end = sink.clock().end();
+//! let end = sink.now();
 //! sink.record_timing("db.gizmo_query", start, end);
 //!
 //! // Finally, we can update a value histogram.  Technically speaking, value histograms aren't
@@ -119,6 +120,12 @@ mod helper;
 mod receiver;
 mod scopes;
 mod sink;
+
+#[cfg(any(feature = "metrics-exporter-log"))]
+pub mod exporters;
+
+#[cfg(any(feature = "metrics-recorder-text", feature = "metrics-recorder-prometheus"))]
+pub mod recorders;
 
 pub use self::{
     configuration::Configuration,

--- a/metrics/src/recorders.rs
+++ b/metrics/src/recorders.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "metrics-recorder-text")]
+pub use metrics_recorder_text::TextRecorder;
+
+#[cfg(feature = "metrics-recorder-prometheus")]
+pub use metrics_recorder_prometheus::PrometheusRecorder;


### PR DESCRIPTION
We now expose all exporters and recorders via facade modules in the `metrics` crate, called `metrics::exporters` and `metrics::recorders`, respectively.  This means that the metrics crate itself has these as optional dependencies, which are included by the default set of features, and so can be turned off by consumers.

To curtail the issue of cyclical dependencies, we've also introduced three new traits: `Snapshot`, `SnapshotProvider`, and `AsyncSnapshotProvider`.

These traits let us represent `metrics::Controller` and `metrics::data::snapshot::Snapshot` in the exporter, allowing us to get around the cyclical dependency but also expose more flexibility and modularity.