### PR TITLE
Update our README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,28 @@ __metrics__ is a high-quality, batteries-included metrics library for Rust.
 
 **NOTE**: All conversations and contributions to this project shall adhere to the [Code of Conduct][conduct].
 
-# caveat emptor
+# what's it all about?
 
-This crate is currently materializing! We are in the process of switching over [hotmic](https://github.com/nuclearfurnace/hotmic) to `metrics` after successfully acquiring ownership of the `metrics` crate on crates.io!
+Running applications in production can be hard when you don't have insight into what the application is doing.  We're lucky to have so many good system monitoring programs and services to show us how are servers are performing, but we still have to do the work of instrumenting our applications to gain deep insight into their behavior and performance.
 
-We apologize for the README/documentation that will reference things that don't exist yet until the switchover is complete.  Thank you for your understanding!
+`metrics` makes it easy to instrument your application to provide real-time insight into what's happening.  It provides a straight-forward interface for you to collect metrics at different points, and a flexible approach to exporting those metrics in a way that meets your needs.
 
-## general features
-- Provides counter, gauge, and histogram support.
+Some of the most common scenarios for collecting metrics from an application:
+- see how many times a codepath was hit
+- track the time it takes for a piece of code to execute
+- expose internal counters and values in a standardized way
+
+The number of reasons why you'd want to collect metrics is too large to list out here, and some applications emit metrics that have nothing to do with the application performance itself!  Ultimately, `metrics` strives to simply provide support for the most basic types of metrics so that you can spend more time focusing on the data you'd like to collect and less time on how you're going to accomplish that.
+
+## high-level technical features
+- Supports the three most common metric types: counters, gauges, and histograms.
+- Based on `metrics-core` for composability at the exporter level.
 - Access to ultra-high-speed timing facilities out-of-the-box with [quanta](https://github.com/nuclearfurnace/quanta).
 - Scoped metrics for effortless nesting.
-- Speed and API ergonomics allow for usage in both synchronous and asynchronous contexts.
-- Based on `metrics-core` for bring-your-own-collector/bring-your-own-exporter flexibility!
+- Bundled with Prometheus pull endpoint capabilities by default.
 
 ## performance
 
-High. Tens of millions of metrics per second with metric ingest times at sub-200ns p99 on modern systems.
+High. `metrics` is fast enough that you'll barely notice the overhead.
+
+There is a `benchmark` example in the crate that can be run to see the type of performance acheivable on your system.  A 2015 MacBook Pro (4c/8t, 2.1GHz) can push over 5 million samples per second from a single thread.


### PR DESCRIPTION
It's time to get rid fo the caveat emptor and fully embrace our new crate home.

This README likely also needs to be copypasta'd into the actual `metrics` crate in the workspace so they're basically both the same.