### PR TITLE
core: add Builder trait for recorders

### DIFF
--- a/metrics-core/src/lib.rs
+++ b/metrics-core/src/lib.rs
@@ -284,6 +284,23 @@ pub trait Recorder {
     fn record_histogram(&mut self, key: Key, values: &[u64]);
 }
 
+/// A value that can build a recorder.
+///
+/// Recorders are intended to be single-use containers for rendering a snapshot in a particular
+/// format. As many systems are multi-threaded, we can't easily share a single recorder amongst
+/// multiple threads, and so we create a recorder per snapshot, tying them together.
+///
+/// A builder allows us to generate a recorder on demand, giving each specific recorder an
+/// interface by which they can do any necessary configuration, initialization, etc of the recorder
+/// before handing it over to the exporter.
+pub trait Builder {
+    /// The recorder created by this builder.
+    type Output: Recorder;
+
+    /// Creates a new recorder.
+    fn build(&self) -> Self::Output;
+}
+
 /// A value that holds a point-in-time view of collected metrics.
 pub trait Snapshot {
     /// Records the snapshot to the given recorder.

--- a/metrics-runtime/src/data/histogram.rs
+++ b/metrics-runtime/src/data/histogram.rs
@@ -130,7 +130,7 @@ impl AtomicWindowedHistogram {
             // so go ahead and wait until the index is caught up with the upkeep index: the upkeep
             // index will be ahead of index until upkeep is complete.
             let mut upkeep_in_progress = false;
-            let mut index = 0;
+            let mut index;
             loop {
                 index = self.index.load(Ordering::Acquire);
                 let upkeep_index = self.upkeep_index.load(Ordering::Acquire);

--- a/metrics-runtime/src/lib.rs
+++ b/metrics-runtime/src/lib.rs
@@ -181,7 +181,7 @@
 //! `log!`:
 //! ```rust
 //! # extern crate metrics_runtime;
-//! use metrics_runtime::{Receiver, recorders::TextRecorder, exporters::LogExporter};
+//! use metrics_runtime::{Receiver, recorders::TextBuilder, exporters::LogExporter};
 //! use log::Level;
 //! use std::{thread, time::Duration};
 //! let receiver = Receiver::builder().build().expect("failed to create receiver");
@@ -203,7 +203,7 @@
 //! sink.record_value("db.queries.select_products_num_rows", num_rows);
 //!
 //! // Now create our exporter/recorder configuration, and wire it up.
-//! let exporter = LogExporter::new(receiver.get_controller(), TextRecorder::new(), Level::Info);
+//! let exporter = LogExporter::new(receiver.get_controller(), TextBuilder::new(), Level::Info);
 //!
 //! // This exporter will now run every 5 seconds, taking a snapshot, rendering it, and writing it
 //! // via `log!` at the informational level. This particular exporter is running directly on the

--- a/metrics-runtime/src/recorders.rs
+++ b/metrics-runtime/src/recorders.rs
@@ -2,7 +2,7 @@
 //!
 //! Recorders define the format of the metric output: text, JSON, etc.
 #[cfg(feature = "metrics-recorder-text")]
-pub use metrics_recorder_text::TextRecorder;
+pub use metrics_recorder_text::TextBuilder;
 
 #[cfg(feature = "metrics-recorder-prometheus")]
-pub use metrics_recorder_prometheus::PrometheusRecorder;
+pub use metrics_recorder_prometheus::PrometheusBuilder;


### PR DESCRIPTION
This change adds a new trait -- `Builder` -- which defines a value that can create new recorder instances.

As we have a need to generate owned recorders, in particular for futures-based code, the `Builder` trait provides a way to do so without any jankiness, such as the prior Clone-based approach.

As such, all exporters now expect a builder to be passed in, rather than the recorder itself.

Closes #11.