### PR TITLE
feature: add a JSON observer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
   "metrics-exporter-http",
   "metrics-observer-text",
   "metrics-observer-prometheus",
+  "metrics-observer-json",
 ]

--- a/metrics-exporter-log/Cargo.toml
+++ b/metrics-exporter-log/Cargo.toml
@@ -11,6 +11,7 @@ description = "metric exporter for outputting to logs"
 homepage = "https://github.com/metrics-rs/metrics"
 repository = "https://github.com/metrics-rs/metrics"
 documentation = "https://docs.rs/metrics-exporter-log"
+readme = "README.md"
 
 [dependencies]
 metrics-core = { path = "../metrics-core", version = "^0.4" }

--- a/metrics-observer-json/.gitignore
+++ b/metrics-observer-json/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/metrics-observer-json/CODE_OF_CONDUCT.md
+++ b/metrics-observer-json/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# The Code of Conduct
+
+This document is based on the [Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and outlines the standard of conduct which is both expected and enforced as part of this project.
+
+## Conduct
+
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+* Avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+* Please be kind and courteous. There's no need to be mean or rude.
+* Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+* Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
+* We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behaviour. We interpret the term "harassment" as including the definition in the [Citizen Code of Conduct](http://citizencodeofconduct.org/); if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the repository Owners immediately. Whether you're a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your back.
+* Likewise any spamming, trolling, flaming, baiting or other attention-stealing behaviour is not welcome.
+
+## Moderation
+
+These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please use the contact information above, or mention @tobz or @LucioFranco in the thread.
+
+1. Remarks that violate this Code of Conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
+2. Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
+
+In the Rust community we strive to go the extra step to look out for each other. Don't just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they're off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.
+
+And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
+
+## Contacts:
+
+- Toby Lawrence ([toby@nuclearfurnace.com](mailto:toby@nuclearfurnace.com))
+- Lucio Franco ([luciofranco14@gmail.com](mailto:luciofranco14@gmail.com))

--- a/metrics-observer-json/Cargo.toml
+++ b/metrics-observer-json/Cargo.toml
@@ -1,19 +1,22 @@
 [package]
-name = "metrics-exporter-http"
-version = "0.1.2"
+name = "metrics-observer-json"
+version = "0.1.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
 
 license = "MIT"
 
-description = "metric exporter for serving metrics over HTTP"
+description = "metric observer for JSON output"
 
 homepage = "https://github.com/metrics-rs/metrics"
 repository = "https://github.com/metrics-rs/metrics"
-documentation = "https://docs.rs/metrics-exporter-http"
+documentation = "https://docs.rs/metrics-observer-text"
 readme = "README.md"
+
+keywords = ["metrics", "telemetry", "json"]
 
 [dependencies]
 metrics-core = { path = "../metrics-core", version = "^0.4" }
-hyper = "^0.12"
-log = "^0.4"
+metrics-util = { path = "../metrics-util", version = "^0.3" }
+hdrhistogram = "^6.1"
+serde_json = "^1.0"

--- a/metrics-observer-json/LICENSE
+++ b/metrics-observer-json/LICENSE
@@ -1,0 +1,17 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.

--- a/metrics-observer-json/README.md
+++ b/metrics-observer-json/README.md
@@ -1,0 +1,18 @@
+# metrics-observer-json
+
+[![conduct-badge][]][conduct] [![downloads-badge][] ![release-badge][]][crate] [![docs-badge][]][docs] [![license-badge][]](#license)
+
+[conduct-badge]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
+[downloads-badge]: https://img.shields.io/crates/d/metrics-observer-json.svg
+[release-badge]: https://img.shields.io/crates/v/metrics-observer-json.svg
+[license-badge]: https://img.shields.io/crates/l/metrics-observer-json.svg
+[docs-badge]: https://docs.rs/metrics-observer-json/badge.svg
+[conduct]: https://github.com/metrics-rs/metrics-observer-json/blob/master/CODE_OF_CONDUCT.md
+[crate]: https://crates.io/crates/metrics-observer-json
+[docs]: https://docs.rs/metrics-observer-json
+
+__metrics-observer-json__ is a metric observer that outputs JSON.
+
+## code of conduct
+
+**NOTE**: All conversations and contributions to this project shall adhere to the [Code of Conduct][conduct].

--- a/metrics-observer-prometheus/Cargo.toml
+++ b/metrics-observer-prometheus/Cargo.toml
@@ -1,18 +1,21 @@
 [package]
 name = "metrics-observer-prometheus"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
 
 license = "MIT"
 
-description = "metric recorder for Prometheus exposition output"
+description = "metric observer for Prometheus exposition output"
 
 homepage = "https://github.com/metrics-rs/metrics"
 repository = "https://github.com/metrics-rs/metrics"
-documentation = "https://docs.rs/metrics-recorder-prometheus"
+documentation = "https://docs.rs/metrics-observer-prometheus"
+readme = "README.md"
+
+keywords = ["metrics", "telemetry", "prometheus"]
 
 [dependencies]
 metrics-core = { path = "../metrics-core", version = "^0.4" }
-metrics-util = { path = "../metrics-util", version = "^0.2" }
+metrics-util = { path = "../metrics-util", version = "^0.3" }
 hdrhistogram = "^6.1"

--- a/metrics-observer-prometheus/README.md
+++ b/metrics-observer-prometheus/README.md
@@ -1,17 +1,17 @@
-# metrics-recorder-prometheus
+# metrics-observer-prometheus
 
 [![conduct-badge][]][conduct] [![downloads-badge][] ![release-badge][]][crate] [![docs-badge][]][docs] [![license-badge][]](#license)
 
 [conduct-badge]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
-[downloads-badge]: https://img.shields.io/crates/d/metrics-recorder-prometheus.svg
-[release-badge]: https://img.shields.io/crates/v/metrics-recorder-prometheus.svg
-[license-badge]: https://img.shields.io/crates/l/metrics-recorder-prometheus.svg
-[docs-badge]: https://docs.rs/metrics-recorder-prometheus/badge.svg
-[conduct]: https://github.com/metrics-rs/metrics-recorder-prometheus/blob/master/CODE_OF_CONDUCT.md
-[crate]: https://crates.io/crates/metrics-recorder-prometheus
-[docs]: https://docs.rs/metrics-recorder-prometheus
+[downloads-badge]: https://img.shields.io/crates/d/metrics-observer-prometheus.svg
+[release-badge]: https://img.shields.io/crates/v/metrics-observer-prometheus.svg
+[license-badge]: https://img.shields.io/crates/l/metrics-observer-prometheus.svg
+[docs-badge]: https://docs.rs/metrics-observer-prometheus/badge.svg
+[conduct]: https://github.com/metrics-rs/metrics-observer-prometheus/blob/master/CODE_OF_CONDUCT.md
+[crate]: https://crates.io/crates/metrics-observer-prometheus
+[docs]: https://docs.rs/metrics-observer-prometheus
 
-__metrics-recorder-prometheus__ is a metric recorder that outputs a Prometheus exposition format.
+__metrics-observer-prometheus__ is a metric observer that outputs a Prometheus exposition format.
 
 ## code of conduct
 

--- a/metrics-observer-text/Cargo.toml
+++ b/metrics-observer-text/Cargo.toml
@@ -1,18 +1,22 @@
 [package]
 name = "metrics-observer-text"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
 
 license = "MIT"
 
-description = "metric recorder for hierarchical, text-based output"
+description = "metric observer for hierarchical, text-based output"
 
 homepage = "https://github.com/metrics-rs/metrics"
 repository = "https://github.com/metrics-rs/metrics"
-documentation = "https://docs.rs/metrics-recorder-text"
+documentation = "https://docs.rs/metrics-observer-text"
+readme = "README.md"
+
+keywords = ["metrics", "telemetry", "yaml"]
 
 [dependencies]
 metrics-core = { path = "../metrics-core", version = "^0.4" }
-metrics-util = { path = "../metrics-util", version = "^0.2" }
+metrics-util = { path = "../metrics-util", version = "^0.3" }
 hdrhistogram = "^6.1"
+serde_yaml = "^0.8"

--- a/metrics-observer-text/README.md
+++ b/metrics-observer-text/README.md
@@ -1,17 +1,17 @@
-# metrics-recorder-text
+# metrics-observer-text
 
 [![conduct-badge][]][conduct] [![downloads-badge][] ![release-badge][]][crate] [![docs-badge][]][docs] [![license-badge][]](#license)
 
 [conduct-badge]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
-[downloads-badge]: https://img.shields.io/crates/d/metrics-recorder-text.svg
-[release-badge]: https://img.shields.io/crates/v/metrics-recorder-text.svg
-[license-badge]: https://img.shields.io/crates/l/metrics-recorder-text.svg
-[docs-badge]: https://docs.rs/metrics-recorder-text/badge.svg
-[conduct]: https://github.com/metrics-rs/metrics-recorder-text/blob/master/CODE_OF_CONDUCT.md
-[crate]: https://crates.io/crates/metrics-recorder-text
-[docs]: https://docs.rs/metrics-recorder-text
+[downloads-badge]: https://img.shields.io/crates/d/metrics-observer-text.svg
+[release-badge]: https://img.shields.io/crates/v/metrics-observer-text.svg
+[license-badge]: https://img.shields.io/crates/l/metrics-observer-text.svg
+[docs-badge]: https://docs.rs/metrics-observer-text/badge.svg
+[conduct]: https://github.com/metrics-rs/metrics-observer-text/blob/master/CODE_OF_CONDUCT.md
+[crate]: https://crates.io/crates/metrics-observer-text
+[docs]: https://docs.rs/metrics-observer-text
 
-__metrics-recorder-text__ is a metric recorder that outputs a hierarchical, text-based format.
+__metrics-observer-text__ is a metric observer that outputs a hierarchical, text-based format.
 
 ## code of conduct
 

--- a/metrics-runtime/Cargo.toml
+++ b/metrics-runtime/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["metrics", "telemetry", "histogram", "counter", "gauge"]
 [features]
 default = ["exporters", "observers"]
 exporters = ["metrics-exporter-log", "metrics-exporter-http"]
-observers = ["metrics-observer-text", "metrics-observer-prometheus"]
+observers = ["metrics-observer-text", "metrics-observer-json", "metrics-observer-prometheus"]
 
 [[bench]]
 name = "histogram"
@@ -27,7 +27,7 @@ harness = false
 
 [dependencies]
 metrics-core = { path = "../metrics-core", version = "^0.4" }
-metrics-util = { path = "../metrics-util", version = "^0.2" }
+metrics-util = { path = "../metrics-util", version = "^0.3" }
 metrics = { path = "../metrics", version = "^0.11", features = ["std"] }
 im = "^12"
 arc-swap = "^0.3"
@@ -38,8 +38,9 @@ futures = "^0.1"
 crossbeam-utils = "^0.6"
 metrics-exporter-log = { path = "../metrics-exporter-log", version = "^0.2", optional = true }
 metrics-exporter-http = { path = "../metrics-exporter-http", version = "^0.1", optional = true }
-metrics-observer-text = { path = "../metrics-observer-text", version = "^0.2", optional = true }
-metrics-observer-prometheus = { path = "../metrics-observer-prometheus", version = "^0.2", optional = true }
+metrics-observer-text = { path = "../metrics-observer-text", version = "^0.3", optional = true }
+metrics-observer-prometheus = { path = "../metrics-observer-prometheus", version = "^0.3", optional = true }
+metrics-observer-json = { path = "../metrics-observer-json", version = "^0.1", optional = true }
 
 [dev-dependencies]
 log = "^0.4"

--- a/metrics-runtime/src/observers.rs
+++ b/metrics-runtime/src/observers.rs
@@ -4,5 +4,8 @@
 #[cfg(feature = "metrics-observer-text")]
 pub use metrics_observer_text::TextBuilder;
 
+#[cfg(feature = "metrics-observer-json")]
+pub use metrics_observer_json::JsonBuilder;
+
 #[cfg(feature = "metrics-observer-prometheus")]
 pub use metrics_observer_prometheus::PrometheusBuilder;

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-util"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
 
@@ -26,6 +26,7 @@ harness = false
 
 [dependencies]
 crossbeam-epoch = "^0.7"
+serde = "^1.0"
 
 [dev-dependencies]
 crossbeam = "^0.7"

--- a/metrics-util/src/lib.rs
+++ b/metrics-util/src/lib.rs
@@ -8,3 +8,6 @@ pub use streaming::StreamingIntegers;
 
 mod quantile;
 pub use quantile::{parse_quantiles, Quantile};
+
+mod tree;
+pub use tree::{Integer, MetricsTree};

--- a/metrics-util/src/tree.rs
+++ b/metrics-util/src/tree.rs
@@ -1,0 +1,122 @@
+use serde::ser::{Serialize, Serializer};
+use std::collections::HashMap;
+
+/// An integer metric value.
+pub enum Integer {
+    /// A signed value.
+    Signed(i64),
+
+    /// An unsigned value.
+    Unsigned(u64),
+}
+
+impl From<i64> for Integer {
+    fn from(i: i64) -> Integer {
+        Integer::Signed(i)
+    }
+}
+
+impl From<u64> for Integer {
+    fn from(i: u64) -> Integer {
+        Integer::Unsigned(i)
+    }
+}
+
+enum TreeEntry {
+    Value(Integer),
+    Nested(MetricsTree),
+}
+
+impl Serialize for TreeEntry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            TreeEntry::Value(value) => match value {
+                Integer::Signed(i) => serializer.serialize_i64(*i),
+                Integer::Unsigned(i) => serializer.serialize_u64(*i),
+            },
+            TreeEntry::Nested(tree) => tree.serialize(serializer),
+        }
+    }
+}
+
+/// A tree-structured metrics container.
+///
+/// Used for building a tree structure out of scoped metrics, where each level in the tree
+/// represents a nested scope.
+#[derive(Default)]
+pub struct MetricsTree {
+    contents: HashMap<String, TreeEntry>,
+}
+
+impl MetricsTree {
+    /// Inserts a single value into the tree.
+    pub fn insert_value<V: Into<Integer>>(
+        &mut self,
+        mut levels: Vec<String>,
+        key: String,
+        value: V,
+    ) {
+        match levels.len() {
+            0 => {
+                self.contents.insert(key, TreeEntry::Value(value.into()));
+            }
+            _ => {
+                let name = levels.remove(0);
+                let inner = self
+                    .contents
+                    .entry(name)
+                    .or_insert_with(|| TreeEntry::Nested(MetricsTree::default()));
+
+                if let TreeEntry::Nested(tree) = inner {
+                    tree.insert_value(levels, key, value);
+                }
+            }
+        }
+    }
+
+    /// Inserts multiple values into the tree.
+    pub fn insert_values<V: Into<Integer>>(
+        &mut self,
+        mut levels: Vec<String>,
+        values: Vec<(String, V)>,
+    ) {
+        match levels.len() {
+            0 => {
+                for v in values.into_iter() {
+                    self.contents.insert(v.0, TreeEntry::Value(v.1.into()));
+                }
+            }
+            _ => {
+                let name = levels.remove(0);
+                let inner = self
+                    .contents
+                    .entry(name)
+                    .or_insert_with(|| TreeEntry::Nested(MetricsTree::default()));
+
+                if let TreeEntry::Nested(tree) = inner {
+                    tree.insert_values(levels, values);
+                }
+            }
+        }
+    }
+
+    /// Clears all entries in the tree.
+    pub fn clear(&mut self) {
+        self.contents.clear();
+    }
+}
+
+impl Serialize for MetricsTree {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut sorted = self.contents.iter().collect::<Vec<_>>();
+        sorted.sort_by_key(|p| p.0);
+
+        serializer.collect_map(sorted)
+    }
+}


### PR DESCRIPTION
This adds a brand-new JSON observer to the mix.

We've refactored a bit, making the builder for the observers actually function like a builder, where methods to set the configuration update the builder fluently.

We've also extracted MetricsTree which is now serializable by serde. This means anything based on MetricsTree can implicitly be serialized by any serde serializer, which should make it easier for us to spin up new output formats in the future.

Closes #37