### PR TITLE
Add project layout information to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ The number of reasons why you'd want to collect metrics is too large to list out
 - Scoped metrics for effortless nesting.
 - Bundled with Prometheus pull endpoint capabilities by default.
 
+## project layout
+
+Metrics provide a way to gather metrics from your application. Exporters provide a way to get data outside of the application and observers tell the exporters what format to use.
+
+Application developers can use the `metrics-runtime` crate to get running quickly.
+
+* [`metrics`]: Provides macros similar to the `log` crate.
+
+* [`metrics-core`]: Defines foundational traits for interoperable metrics libraries.
+
+* [`metrics-exporter-http`]: Exports metrics over an HTTP server.
+
+* [`metrics-exporter-log`]: Exports metrics by outputting to console using the `log` crate.
+
+* [`metrics-observer-json`]: Encodes metrics in the JSON format.
+
+* [`metrics-observer-prometheus`]: Encodes metrics in the Prometheus exposition format.
+
+* [`metrics-observer-text`]: Encodes metrics as text suitable for console logging.
+
+* [`metrics-runtime`]: A batteries included metrics library.
+
+* [`metrics-util`]: Helper library used in the metrics ecosystem.
+
 ## performance
 
 High. `metrics` is fast enough that you'll barely notice the overhead.

--- a/metrics-runtime/README.md
+++ b/metrics-runtime/README.md
@@ -41,4 +41,4 @@ The number of reasons why you'd want to collect metrics is too large to list out
 
 High. `metrics` is fast enough that you'll barely notice the overhead.
 
-There is a `benchmark` example in the crate that can be run to see the type of performance acheivable on your system.  A 2015 MacBook Pro (4c/8t, 2.1GHz) can push over 5 million samples per second from a single thread.
+There is a `benchmark` example in the crate that can be run to see the type of performance achievable on your system.  A 2015 MacBook Pro (4c/8t, 2.1GHz) can push over 5 million samples per second from a single thread.


### PR DESCRIPTION
## Motivation

Discoverability of the ecosystem and what crates are responsible for what can be difficult for new comers. We need to provide a way to make it easy for new users to discover how the ecosystem fits together.

## Solution

Provide a project layout guide to the repositories README describing in slight detail what each crate provides and hint towards using the runtime crate to get started quickly.