### PR TITLE
Use absolute macro path for labels! invocation

### DIFF
--- a/metrics-core/src/lib.rs
+++ b/metrics-core/src/lib.rs
@@ -334,14 +334,14 @@ macro_rules! labels {
     };
 
     (@ { } $k:expr => $v:expr, $($rest:tt)*) => {
-        labels!(@ { $crate::Label::new($k, $v) } $($rest)*)
+        $crate::labels!(@ { $crate::Label::new($k, $v) } $($rest)*)
     };
 
     (@ { $($out:expr),+ } $k:expr => $v:expr, $($rest:tt)*) => {
-        labels!(@ { $($out),+, $crate::Label::new($k, $v) } $($rest)*)
+        $crate::labels!(@ { $($out),+, $crate::Label::new($k, $v) } $($rest)*)
     };
 
     ($($args:tt)*) => {
-        labels!(@ { } $($args)*, )
+        $crate::labels!(@ { } $($args)*, )
     };
 }

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fixed a bug with macros calling inner macros without a fully qualified name.
 
 ## [0.11.0] - 2019-07-29
 ### Added


### PR DESCRIPTION
Otherwise code similar to this:

```rust
metrics::gauge!("cpu", stats.ctx_switches() as i64, "key" => "ctx_switches");
```

will fail with an error

```rust
error: cannot find macro `labels!` in this scope
  --> src/collectors/cpu.rs:19:5
   |
19 |     metrics::gauge!("cpu", stats.ctx_switches() as i64, "key" => "ctx_switches");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

which expands into
```rust
error: cannot find macro `labels!` in this scope
  --> <::metrics_core::labels macros>:9:34
   |
1  | /  ( @ { $ ( $ out : expr ) , * $ ( , ) * } $ ( , ) * ) => {
2  | |  std :: vec ! [ $ ( $ out ) , * ] } ; (
3  | |  @ {  } $ k : expr => $ v : expr , $ ( $ rest : tt ) * ) => {
4  | |  labels ! ( @ { $ crate :: Label :: new ( $ k , $ v ) } $ ( $ rest ) * ) } ; (
...  |
8  | |  @ { $ ( $ out ) , + , $ crate :: Label :: new ( $ k , $ v ) } $ ( $ rest ) * )
9  | |  } ; ( $ ( $ args : tt ) * ) => { labels ! ( @ {  } $ ( $ args ) * , ) } ;
   | |___________________________________^^^^^^_________________________________- in this expansion of `$crate::labels!`
   | 
  ::: <::metrics::macros::gauge macros>:1:1
   |
1  |  / ( $ name : expr , $ value : expr ) => {
2  |  | $ crate :: __private_api_record_gauge (
3  |  | $ crate :: Key :: from_name ( $ name ) , $ value ) ; } ; (
4  |  | $ name : expr , $ value : expr , $ ( $ labels : tt ) * ) => {
5  |  | let labels = $ crate :: labels ! ( $ ( $ labels ) * ) ; let key = $ crate ::
   |  |              ---------------------------------------- in this macro invocation
6  |  | Key :: from_name_and_labels ( $ name , labels ) ; $ crate ::
7  |  | __private_api_record_gauge ( key , $ value ) ; } ;
   |  |__________________________________________________- in this expansion of `metrics::gauge!`
   | 
  ::: src/collectors/cpu.rs:19:5
   |
19 |        metrics::gauge!("cpu", stats.ctx_switches() as i64, "key" => "ctx_switches");
   |        --------------------------------------------------------------------------- in this macro invocation
```