### PR TITLE
Don't evaluate macro arguments with no recorder

### DIFF
--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -33,13 +33,17 @@
 #[macro_export]
 macro_rules! counter {
     ($name:expr, $value:expr) => {
-        $crate::__private_api_increment_counter($crate::Key::from_name($name), $value);
+        if let Some(recorder) = $crate::try_recorder() {
+            recorder.increment_counter($crate::Key::from_name($name), $value);
+        }
     };
 
     ($name:expr, $value:expr, $($labels:tt)*) => {
-        let labels = $crate::labels!( $($labels)* );
-        let key = $crate::Key::from_name_and_labels($name, labels);
-        $crate::__private_api_increment_counter(key, $value);
+        if let Some(recorder) = $crate::try_recorder() {
+            let labels = $crate::labels!( $($labels)* );
+            let key = $crate::Key::from_name_and_labels($name, labels);
+            recorder.increment_counter(key, $value);
+        }
     };
 }
 
@@ -78,13 +82,17 @@ macro_rules! counter {
 #[macro_export]
 macro_rules! gauge {
     ($name:expr, $value:expr) => {
-        $crate::__private_api_update_gauge($crate::Key::from_name($name), $value);
+        if let Some(recorder) = $crate::try_recorder() {
+            $crate::__private_api_update_gauge(recorder, $crate::Key::from_name($name), $value);
+        }
     };
 
     ($name:expr, $value:expr, $($labels:tt)*) => {
-        let labels = $crate::labels!( $($labels)* );
-        let key = $crate::Key::from_name_and_labels($name, labels);
-        $crate::__private_api_update_gauge(key, $value);
+        if let Some(recorder) = $crate::try_recorder() {
+            let labels = $crate::labels!( $($labels)* );
+            let key = $crate::Key::from_name_and_labels($name, labels);
+            $crate::__private_api_update_gauge(recorder, key, $value);
+        }
     };
 }
 
@@ -163,7 +171,9 @@ macro_rules! gauge {
 #[macro_export]
 macro_rules! timing {
     ($name:expr, $value:expr) => {
-        $crate::__private_api_record_histogram($crate::Key::from_name($name), $value);
+        if let Some(recorder) = $crate::try_recorder() {
+            $crate::__private_api_record_histogram(recorder, $crate::Key::from_name($name), $value);
+        }
     };
 
     ($name:expr, $start:expr, $end:expr) => {
@@ -175,9 +185,11 @@ macro_rules! timing {
     };
 
     ($name:expr, $value:expr, $($labels:tt)*) => {
-        let labels = $crate::labels!( $($labels)* );
-        let key = $crate::Key::from_name_and_labels($name, labels);
-        $crate::__private_api_record_histogram(key, $value);
+        if let Some(recorder) = $crate::try_recorder() {
+            let labels = $crate::labels!( $($labels)* );
+            let key = $crate::Key::from_name_and_labels($name, labels);
+            $crate::__private_api_record_histogram(recorder, key, $value);
+        }
     };
 }
 
@@ -217,12 +229,16 @@ macro_rules! timing {
 #[macro_export]
 macro_rules! value {
     ($name:expr, $value:expr) => {
-        $crate::__private_api_record_histogram($crate::Key::from_name($name), $value);
+        if let Some(recorder) = $crate::try_recorder() {
+            $crate::__private_api_record_histogram(recorder, $crate::Key::from_name($name), $value);
+        }
     };
 
     ($name:expr, $value:expr, $($labels:tt)*) => {
-        let labels = $crate::labels!( $($labels)* );
-        let key = $crate::Key::from_name_and_labels($name, labels);
-        $crate::__private_api_record_histogram(key, $value);
+        if let Some(recorder) = $crate::try_recorder() {
+            let labels = $crate::labels!( $($labels)* );
+            let key = $crate::Key::from_name_and_labels($name, labels);
+            $crate::__private_api_record_histogram(recorder, key, $value);
+        }
     };
 }


### PR DESCRIPTION
Modified the macros to not evaluate their arguments when no recorder is set. This avoids any `.to_string()` calls the user may be making for label values and avoids the `Vec` allocation for labels.

The benchmark, modified to convert a `usize` to a string for a label value, shows the following:

```
counter/no labels       time:   [2.5911 ns 2.6012 ns 2.6118 ns]
                        change: [-74.045% -73.926% -73.818%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
counter/with labels     time:   [1.7592 ns 1.7649 ns 1.7710 ns]
                        change: [-99.396% -99.384% -99.374%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
```

This brings the cost of using the macros when there is no recorder set close to nothing. I have been evaluating using `metrics` to instrument [legion](https://github.com/TomGillen/legion), and the not totally insignificant overhead of hitting the system allocator a few times on each metric update even in the (highly likely) case where the host application is not actually collecting them, is not ideal. I would be much more comfortable including metrics if there was negligable impact when they were at least not being used.

It would be even better if we could cache the counter references, like the `metrics-runtime` API allows, but that would be a much more involved change.