### PR TITLE
Group prometheus series by type

### DIFF
--- a/metrics-observer-prometheus/src/lib.rs
+++ b/metrics-observer-prometheus/src/lib.rs
@@ -70,7 +70,7 @@ impl Observer for PrometheusObserver {
             .entry(labels)
             .or_insert_with(|| 0);
 
-        *entry = value;
+        *entry += value;
     }
 
     fn observe_gauge(&mut self, key: Key, value: i64) {

--- a/metrics-observer-prometheus/src/lib.rs
+++ b/metrics-observer-prometheus/src/lib.rs
@@ -181,7 +181,7 @@ fn key_to_parts(key: Key) -> (String, Vec<String>) {
     let labels = labels
         .into_iter()
         .map(Label::into_parts)
-        .map(|(k, v)| format!("{}=\"{}\"", k, v))
+        .map(|(k, v)| format!("{}=\"{}\"", k, v.escape_default().collect::<String>()))
         .collect();
 
     (name, labels)


### PR DESCRIPTION
This PR fixes #61 by storing counters, gauges and histograms by type first and then by labels allowing the output to be grouped by type.