### PR TITLE
Better escape prometheus label values

### DIFF
--- a/metrics-observer-prometheus/src/lib.rs
+++ b/metrics-observer-prometheus/src/lib.rs
@@ -181,7 +181,15 @@ fn key_to_parts(key: Key) -> (String, Vec<String>) {
     let labels = labels
         .into_iter()
         .map(Label::into_parts)
-        .map(|(k, v)| format!("{}=\"{}\"", k, v.escape_default().collect::<String>()))
+        .map(|(k, v)| {
+            format!(
+                "{}=\"{}\"",
+                k,
+                v.replace("\\", "\\\\")
+                    .replace("\"", "\\\"")
+                    .replace("\n", "\\n")
+            )
+        })
         .collect();
 
     (name, labels)


### PR DESCRIPTION
`.escape_default()` would escape too much, prometheus does not like anything other than `\`, `"` and `\n`  to be escaped according to [this](https://prometheus.io/docs/instrumenting/exposition_formats/)

> `label_value` can be any sequence of UTF-8 characters, but the backslash (`\`), double-quote (`"`), and line feed (`\n`) characters have to be escaped as `\\`, `\"`, and `\n`, respectively.