### PR TITLE
Migrate to core::futures

### DIFF
--- a/ci/azure-test-minimum.yaml
+++ b/ci/azure-test-minimum.yaml
@@ -15,6 +15,6 @@ jobs:
   steps:
   - template: azure-install-rust.yml
     parameters:
-      rust_version: 1.34.0
+      rust_version: 1.39.0
   - script: cargo test
     displayName: cargo test

--- a/metrics-exporter-http/Cargo.toml
+++ b/metrics-exporter-http/Cargo.toml
@@ -17,5 +17,5 @@ keywords = ["metrics", "metrics-core", "exporter", "http"]
 
 [dependencies]
 metrics-core = { path = "../metrics-core", version = "^0.5" }
-hyper = "^0.12"
+hyper = "^0.13"
 log = "^0.4"

--- a/metrics-exporter-http/src/lib.rs
+++ b/metrics-exporter-http/src/lib.rs
@@ -3,9 +3,7 @@
 //! This exporter can utilize observers that are able to be converted to a textual representation
 //! via [`Drain<String>`].  It will respond to any requests, regardless of the method or path.
 //!
-//! # Run Modes
-//! - `into_future` will return a [`Future`] that when driven will run the HTTP server on the
-//! configured address
+//! Awaiting on `async_run` will drive an HTTP server listening on the configured address.
 #![deny(missing_docs)]
 
 use hyper::{
@@ -39,11 +37,9 @@ where
         }
     }
 
-    /// Converts this exporter into a future which can be driven externally.
-    ///
-    /// This starts an HTTP server on the `address` the exporter was originally configured with,
+    /// Starts an HTTP server on the `address` the exporter was originally configured with,
     /// responding to any request with the output of the configured observer.
-    pub async fn into_future(self) -> hyper::error::Result<()> {
+    pub async fn async_run(self) -> hyper::error::Result<()> {
         let builder = Arc::new(self.builder);
         let controller = Arc::new(self.controller);
 

--- a/metrics-exporter-log/Cargo.toml
+++ b/metrics-exporter-log/Cargo.toml
@@ -18,5 +18,4 @@ keywords = ["metrics", "metrics-core", "exporter", "log"]
 [dependencies]
 metrics-core = { path = "../metrics-core", version = "^0.5" }
 log = "^0.4"
-futures = "^0.1"
-tokio-timer = "^0.2"
+tokio = { version = "0.2", features = ["time"] }

--- a/metrics-exporter-log/src/lib.rs
+++ b/metrics-exporter-log/src/lib.rs
@@ -5,10 +5,10 @@
 //! level.
 //!
 //! # Run Modes
-//! - `run` can be used to block the current thread, taking snapshots and exporting them on an
-//! interval
-//! - `into_future` will return a [`Future`] that when driven will take a snapshot on the
-//! configured interval and log it
+//! - Using `run` will block the current thread, capturing a snapshot and logging it based on the
+//! configured interval.
+//! - Using `async_run` will return a future that can be awaited on, mimicing the behavior of
+//! `run`.
 #![deny(missing_docs)]
 #[macro_use]
 extern crate log;
@@ -66,7 +66,7 @@ where
 
     /// Converts this exporter into a future which logs output at the interval
     /// given on construction.
-    pub async fn into_future(mut self) {
+    pub async fn async_run(mut self) {
         let mut interval = time::interval(self.interval);
         loop {
             interval.tick().await;

--- a/metrics-runtime/Cargo.toml
+++ b/metrics-runtime/Cargo.toml
@@ -32,7 +32,6 @@ im = "^12"
 arc-swap = "^0.3"
 parking_lot = "^0.9"
 quanta = "^0.3"
-futures = "^0.1"
 crossbeam-utils = "^0.6"
 metrics-exporter-log = { path = "../metrics-exporter-log", version = "^0.3", optional = true }
 metrics-exporter-http = { path = "../metrics-exporter-http", version = "^0.2", optional = true }
@@ -47,3 +46,4 @@ getopts = "^0.2"
 hdrhistogram = "^6.1"
 criterion = "^0.2.9"
 lazy_static = "^1.3"
+tokio = { version = "^0.2", features = ["macros", "rt-core"] }

--- a/metrics-runtime/examples/facade.rs
+++ b/metrics-runtime/examples/facade.rs
@@ -170,7 +170,7 @@ async fn main() {
         .expect("failed to parse http listen address");
     let builder = JsonBuilder::new().set_pretty_json(true);
     let exporter = HttpExporter::new(controller.clone(), builder, addr);
-    tokio::spawn(exporter.into_future());
+    tokio::spawn(exporter.async_run());
 
     receiver.install();
     info!("receiver configured");

--- a/metrics-runtime/examples/facade.rs
+++ b/metrics-runtime/examples/facade.rs
@@ -5,6 +5,7 @@ extern crate getopts;
 extern crate hdrhistogram;
 extern crate metrics_core;
 extern crate metrics_runtime;
+extern crate tokio;
 
 #[macro_use]
 extern crate metrics;
@@ -119,7 +120,8 @@ pub fn opts() -> Options {
     opts
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
 
     let args: Vec<String> = env::args().collect();
@@ -168,7 +170,7 @@ fn main() {
         .expect("failed to parse http listen address");
     let builder = JsonBuilder::new().set_pretty_json(true);
     let exporter = HttpExporter::new(controller.clone(), builder, addr);
-    thread::spawn(move || exporter.run());
+    tokio::spawn(exporter.into_future());
 
     receiver.install();
     info!("receiver configured");


### PR DESCRIPTION
This drops all dependencies on the 'futures' crate, and upgrades to
hyper-0.13 and tokio-0.2. Methods that return futures now use
async/await.

Since hyper has removed hyper_run(), I have in turn removed the
HttpExporter::run() method. The user should just call into_future()
and spawn or await the result however they wish.