### PR TITLE
Add buckets (histogram) to Prometheus observer

### DIFF
--- a/metrics-observer-prometheus/src/lib.rs
+++ b/metrics-observer-prometheus/src/lib.rs
@@ -39,6 +39,8 @@ impl PrometheusBuilder {
     /// Sets the buckets to use when rendering summaries.
     ///
     /// Buckets values represent the higher bound of each buckets.
+    ///
+    /// This option changes the observer's output of histogram-type metric into summaries.
     pub fn set_buckets(mut self, values: &[u64]) -> Self {
         self.buckets = values.to_vec();
         self
@@ -46,7 +48,10 @@ impl PrometheusBuilder {
 
     /// Sets the buckets for a specific metric, overidding the default.
     ///
-    /// Matches the metric name using `ends_with`.
+    /// Matches the metric name's suffix, the longest match will be used.
+    ///
+    /// This option changes the observer's output of histogram-type metric into summaries.
+    /// It only affects matching metrics if set_buckets was not used.
     pub fn set_buckets_for_metric(mut self, name: &str, values: &[u64]) -> Self {
         let buckets = self.buckets_by_name.get_or_insert_with(|| HashMap::new());
         buckets.insert(name.to_owned(), values.to_vec());

--- a/metrics-observer-prometheus/src/lib.rs
+++ b/metrics-observer-prometheus/src/lib.rs
@@ -221,7 +221,7 @@ impl Drain<String> for PrometheusObserver {
                         output.push_str("\n");
                     }
                     let mut labels = labels.clone();
-                    labels.push("le=\"Inf+\"".to_owned());
+                    labels.push("le=\"+Inf\"".to_owned());
                     let bucket_name = format!("{}_bucket", name);
                     let full_name = render_labeled_name(&bucket_name, &labels);
                     output.push_str(full_name.as_str());

--- a/metrics-observer-prometheus/src/lib.rs
+++ b/metrics-observer-prometheus/src/lib.rs
@@ -38,13 +38,15 @@ impl PrometheusBuilder {
 
     /// Sets the buckets to use when rendering summaries.
     ///
-    /// Buckets values represent the higher bound of each buckets
+    /// Buckets values represent the higher bound of each buckets.
     pub fn set_buckets(mut self, values: &[u64]) -> Self {
         self.buckets = values.to_vec();
         self
     }
 
     /// Sets the buckets for a specific metric, overidding the default.
+    ///
+    /// Matches the metric name using `ends_with`.
     pub fn set_buckets_for_metric(mut self, name: &str, values: &[u64]) -> Self {
         let buckets = self.buckets_by_name.get_or_insert_with(|| HashMap::new());
         buckets.insert(name.to_owned(), values.to_vec());


### PR DESCRIPTION
The API is awkward, I'm definitely open to suggestions!

Overriding buckets requires knowing the "rendered" name of the metric which is probably not  desirable.

```rust
let observer = metrics_observer_prometheus::PrometheusBuilder::new()
    .set_buckets(&[
        5_000_000,     // 5ms
        25_000_000,    // 25ms
        50_000_000,    // 50ms
        100_000_000,   // 100ms
        200_000_000,   // 200ms
        1_000_000_000, // 1s
    ])
    .set_buckets_for_metric(
        "my_sometimes_fast_metric",
        &[
            1_000_000,   // 1ms
            5_000_000,   // 5ms
            25_000_000,  // 25ms
            50_000_000,  // 50ms
            100_000_000, // 100ms
            200_000_000, // 200ms
        ],
    )
    .set_buckets_for_metric(
        "my_usually_fast_metric",
        &[
            1_000,     // 1us
            20_000,    // 20us
            100_000,   // 100us
            1_000_000, // 1ms
            5_000_000, // 5ms
        ],
    );
```