### PR TITLE
Add atomic_shim to support platforms without 64-bit atomics

### DIFF
--- a/metrics-runtime/Cargo.toml
+++ b/metrics-runtime/Cargo.toml
@@ -38,6 +38,7 @@ metrics-exporter-http = { path = "../metrics-exporter-http", version = "^0.3", o
 metrics-observer-yaml = { path = "../metrics-observer-yaml", version = "^0.1", optional = true }
 metrics-observer-prometheus = { path = "../metrics-observer-prometheus", version = "^0.1", optional = true }
 metrics-observer-json = { path = "../metrics-observer-json", version = "^0.1", optional = true }
+atomic-shim = "0.1.0"
 
 [dev-dependencies]
 log = "^0.4"

--- a/metrics-runtime/examples/benchmark.rs
+++ b/metrics-runtime/examples/benchmark.rs
@@ -6,6 +6,7 @@ extern crate hdrhistogram;
 extern crate metrics_core;
 extern crate metrics_runtime;
 
+use atomic_shim::AtomicU64;
 use getopts::Options;
 use hdrhistogram::Histogram;
 use metrics_runtime::{Receiver, Sink};
@@ -13,7 +14,7 @@ use quanta::Clock;
 use std::{
     env,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
         Arc,
     },
     thread,

--- a/metrics-runtime/examples/facade.rs
+++ b/metrics-runtime/examples/facade.rs
@@ -10,6 +10,7 @@ extern crate tokio;
 #[macro_use]
 extern crate metrics;
 
+use atomic_shim::AtomicU64;
 use getopts::Options;
 use hdrhistogram::Histogram;
 use metrics_runtime::{exporters::HttpExporter, observers::JsonBuilder, Receiver};
@@ -17,7 +18,7 @@ use quanta::Clock;
 use std::{
     env,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
         Arc,
     },
     thread,

--- a/metrics-runtime/examples/stdbenchmark.rs
+++ b/metrics-runtime/examples/stdbenchmark.rs
@@ -4,13 +4,14 @@ extern crate env_logger;
 extern crate getopts;
 extern crate hdrhistogram;
 
+use atomic_shim::AtomicU64;
 use getopts::Options;
 use hdrhistogram::Histogram;
 use quanta::Clock;
 use std::{
     env,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
         Arc,
     },
     thread,

--- a/metrics-runtime/src/common.rs
+++ b/metrics-runtime/src/common.rs
@@ -1,15 +1,13 @@
 use crate::data::AtomicWindowedHistogram;
 use arc_swap::ArcSwapOption;
+use atomic_shim::{AtomicI64, AtomicU64};
 use metrics_core::Key;
 use metrics_util::StreamingIntegers;
 use quanta::Clock;
 use std::{
     fmt,
     ops::Deref,
-    sync::{
-        atomic::{AtomicI64, AtomicU64, Ordering},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
     time::{Duration, Instant},
 };
 

--- a/metrics-runtime/src/data/histogram.rs
+++ b/metrics-runtime/src/data/histogram.rs
@@ -1,10 +1,11 @@
 use crate::common::{Delta, ValueHandle};
 use crate::helper::duration_as_nanos;
+use atomic_shim::AtomicU64;
 use crossbeam_utils::Backoff;
 use metrics_util::{AtomicBucket, StreamingIntegers};
 use quanta::Clock;
 use std::cmp;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 /// A reference to a [`Histogram`].


### PR DESCRIPTION
`atomic-shim` does target detection, so it is using `std::atomic` where possible.
See https://github.com/metrics-rs/quanta/issues/22 and https://github.com/metrics-rs/quanta/pull/23
There are no static `AtomicI64/AtomicU64` used so no `ctor` dependency is needed