### PR TITLE
tracing-context: optimize Visit impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_version: ['1.36.0', 'stable', 'nightly']
+        rust_version: ['1.37.0', 'stable', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_version: ['1.37.0', 'stable', 'nightly']
+        rust_version: ['1.39.0', 'stable', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_version: ['1.39.0', 'stable', 'nightly']
+        rust_version: ['1.40.0', 'stable', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_version: ['1.40.0', 'stable', 'nightly']
+        rust_version: ['1.42.0', 'stable', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1

--- a/metrics-tracing-context/.gitignore
+++ b/metrics-tracing-context/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -15,12 +15,21 @@ readme = "README.md"
 categories = ["development-tools::debugging"]
 keywords = ["metrics", "tracing"]
 
+[lib]
+bench = false
+
+[[bench]]
+name = "visit"
+harness = false
+
 [dependencies]
 metrics = { version = "0.13.0-alpha.1", path = "../metrics", features = ["std"] }
 metrics-util = { version = "0.4.0-alpha.1", path = "../metrics-util" }
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.2"
+itoa = "0.4"
 
 [dev-dependencies]
+criterion = "0.3"
 parking_lot = "0.11"

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -108,6 +108,20 @@ fn visit_benchmark(c: &mut Criterion) {
                 BatchSize::NumIterations(BATCH_SIZE as u64),
             )
         })
+        .with_function("record_debug[bool]", |b| {
+            let field = CALLSITE
+                .metadata()
+                .fields()
+                .field("test")
+                .expect("test field missing");
+            b.iter_batched_ref(
+                || Labels(Vec::with_capacity(BATCH_SIZE)),
+                |labels| {
+                    labels.record_debug(&field, &true);
+                },
+                BatchSize::NumIterations(BATCH_SIZE as u64),
+            )
+        })
         .with_function("record_debug[i64]", |b| {
             let value: i64 = -3423432;
             let field = CALLSITE

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -1,0 +1,169 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Benchmark, Criterion};
+use metrics_tracing_context::Labels;
+use tracing::Metadata;
+use tracing_core::{
+    field::Visit,
+    metadata,
+    metadata::{Kind, Level},
+    Callsite, Interest,
+};
+
+const BATCH_SIZE: usize = 1000;
+
+static CALLSITE: TestCallsite = TestCallsite;
+static CALLSITE_METADATA: Metadata = metadata! {
+    name: "test",
+    target: module_path!(),
+    level: Level::DEBUG,
+    fields: &["test"],
+    callsite: &CALLSITE,
+    kind: Kind::SPAN,
+};
+
+fn visit_benchmark(c: &mut Criterion) {
+    c.bench(
+        "visit",
+        Benchmark::new("record_str", |b| {
+            let field = CALLSITE
+                .metadata()
+                .fields()
+                .field("test")
+                .expect("test field missing");
+            b.iter_batched_ref(
+                || Labels(Vec::with_capacity(BATCH_SIZE)),
+                |labels| {
+                    labels.record_str(&field, "test test");
+                },
+                BatchSize::NumIterations(BATCH_SIZE as u64),
+            )
+        })
+        .with_function("record_bool[true]", |b| {
+            let field = CALLSITE
+                .metadata()
+                .fields()
+                .field("test")
+                .expect("test field missing");
+            b.iter_batched_ref(
+                || Labels(Vec::with_capacity(BATCH_SIZE)),
+                |labels| {
+                    labels.record_bool(&field, true);
+                },
+                BatchSize::NumIterations(BATCH_SIZE as u64),
+            )
+        })
+        .with_function("record_bool[false]", |b| {
+            let field = CALLSITE
+                .metadata()
+                .fields()
+                .field("test")
+                .expect("test field missing");
+            b.iter_batched_ref(
+                || Labels(Vec::with_capacity(BATCH_SIZE)),
+                |labels| {
+                    labels.record_bool(&field, false);
+                },
+                BatchSize::NumIterations(BATCH_SIZE as u64),
+            )
+        })
+        .with_function("record_i64", |b| {
+            let field = CALLSITE
+                .metadata()
+                .fields()
+                .field("test")
+                .expect("test field missing");
+            b.iter_batched_ref(
+                || Labels(Vec::with_capacity(BATCH_SIZE)),
+                |labels| {
+                    labels.record_i64(&field, -3423432);
+                },
+                BatchSize::NumIterations(BATCH_SIZE as u64),
+            )
+        })
+        .with_function("record_u64", |b| {
+            let field = CALLSITE
+                .metadata()
+                .fields()
+                .field("test")
+                .expect("test field missing");
+            b.iter_batched_ref(
+                || Labels(Vec::with_capacity(BATCH_SIZE)),
+                |labels| {
+                    labels.record_u64(&field, 3423432);
+                },
+                BatchSize::NumIterations(BATCH_SIZE as u64),
+            )
+        })
+        .with_function("record_debug", |b| {
+            let debug_struct = DebugStruct::new();
+            let field = CALLSITE
+                .metadata()
+                .fields()
+                .field("test")
+                .expect("test field missing");
+            b.iter_batched_ref(
+                || Labels(Vec::with_capacity(BATCH_SIZE)),
+                |labels| {
+                    labels.record_debug(&field, &debug_struct);
+                },
+                BatchSize::NumIterations(BATCH_SIZE as u64),
+            )
+        })
+        .with_function("record_debug[i64]", |b| {
+            let value: i64 = -3423432;
+            let field = CALLSITE
+                .metadata()
+                .fields()
+                .field("test")
+                .expect("test field missing");
+            b.iter_batched_ref(
+                || Labels(Vec::with_capacity(BATCH_SIZE)),
+                |labels| {
+                    labels.record_debug(&field, &value);
+                },
+                BatchSize::NumIterations(BATCH_SIZE as u64),
+            )
+        })
+        .with_function("record_debug[u64]", |b| {
+            let value: u64 = 3423432;
+            let field = CALLSITE
+                .metadata()
+                .fields()
+                .field("test")
+                .expect("test field missing");
+            b.iter_batched_ref(
+                || Labels(Vec::with_capacity(BATCH_SIZE)),
+                |labels| {
+                    labels.record_debug(&field, &value);
+                },
+                BatchSize::NumIterations(BATCH_SIZE as u64),
+            )
+        }),
+    );
+}
+
+#[derive(Debug)]
+struct DebugStruct {
+    field1: String,
+    field2: u64,
+}
+
+impl DebugStruct {
+    pub fn new() -> DebugStruct {
+        DebugStruct {
+            field1: format!("yeehaw!"),
+            field2: 324242343243,
+        }
+    }
+}
+
+struct TestCallsite;
+
+impl Callsite for TestCallsite {
+    fn set_interest(&self, _interest: Interest) {}
+    fn metadata(&self) -> &Metadata<'_> {
+        &CALLSITE_METADATA
+    }
+}
+
+criterion_group!(benches, visit_benchmark);
+criterion_main!(benches);

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -63,7 +63,7 @@ pub mod label_filter;
 mod tracing_integration;
 
 pub use label_filter::LabelFilter;
-pub use tracing_integration::{MetricsLayer, SpanExt};
+pub use tracing_integration::{Labels, MetricsLayer, SpanExt};
 
 /// [`TracingContextLayer`] provides an implementation of a [`metrics::Layer`]
 /// for [`TracingContext`].

--- a/metrics-util/benches/bucket.rs
+++ b/metrics-util/benches/bucket.rs
@@ -1,10 +1,5 @@
-#[macro_use]
-extern crate criterion;
-
-#[macro_use]
-extern crate lazy_static;
-
-use criterion::{Benchmark, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Benchmark, Criterion, Throughput};
+use lazy_static::lazy_static;
 use metrics_util::AtomicBucket;
 
 lazy_static! {

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate criterion;
-
-use criterion::{BatchSize, Benchmark, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Benchmark, Criterion};
 use metrics::{Key, KeyData, Label, OnceKeyData};
 use metrics_util::Registry;
 

--- a/metrics-util/benches/streaming_integers.rs
+++ b/metrics-util/benches/streaming_integers.rs
@@ -1,10 +1,5 @@
-#[macro_use]
-extern crate criterion;
-
-#[macro_use]
-extern crate lazy_static;
-
-use criterion::{Benchmark, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Benchmark, Criterion, Throughput};
+use lazy_static::lazy_static;
 use metrics_util::StreamingIntegers;
 use rand::{distributions::Distribution, rngs::SmallRng, SeedableRng};
 use rand_distr::Gamma;


### PR DESCRIPTION
When it was originally written, `metrics-tracing-context` used only a `record_str` and `record_debug` override for the `tracing::field::Visit` implementation, which allowed full functionality but wasn't entirely optimized.  This PR simply fills in the other `record_*` functions (except for `record_error`) with optimized implementations.

Performance increases:
- boolean fields: ~75% faster (54ns -> 15ns)
- integer fields: ~40% faster (70ns -> 40ns)