### PR TITLE
metrics-exporter-tcp: drop metrics when no clients are connected.

### DIFF
--- a/metrics-exporter-tcp/examples/tcp_client.rs
+++ b/metrics-exporter-tcp/examples/tcp_client.rs
@@ -25,9 +25,9 @@ fn main() {
             Err(e) => eprintln!("read error: {:?}", e),
         };
 
-        match proto::Metric::decode_length_delimited(&mut buf) {
+        match proto::Event::decode_length_delimited(&mut buf) {
             Err(e) => eprintln!("decode error: {:?}", e),
-            Ok(msg) => println!("metric: {:?}", msg),
+            Ok(msg) => println!("event: {:?}", msg),
         }
     }
 }


### PR DESCRIPTION
This PR fixes the issue laid out in #99, which is that we go through with sending metrics to the internal event loop even no clients are connected, which slows down callers emitting metrics.

Granted, they'll end up paying the cost as soon as a single client connects, but we can at least reduce CPU usage where possible for optimal efficiency.