### PR TITLE
metrics-exporter-prometheus: split off tokio and hyper functionality to another (default) feature

### DIFF
--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -15,14 +15,20 @@ readme = "README.md"
 categories = ["development-tools::debugging"]
 keywords = ["metrics", "telemetry", "prometheus"]
 
+[features]
+default = ["tokio-exporter"]
+tokio-exporter = ["hyper", "tokio"]
+
 [dependencies]
-metrics = { version = "0.13.0-alpha.1", path = "../metrics" }
-metrics-util = { version = "0.4.0-alpha.1", path = "../metrics-util"}
+metrics = { version = "0.13.0-alpha.1", path="../metrics" }
+metrics-util = { version = "0.4.0-alpha.1", path="../metrics-util" }
 hdrhistogram = "7.1"
-hyper = { version = "0.13", default-features = false, features = ["tcp"] }
-tokio = { version = "0.2", features = ["rt-core", "tcp", "time", "macros"] }
 parking_lot = "0.11"
 thiserror = "1.0"
+
+# Optional
+hyper = { version = "0.13", default-features = false, features = ["tcp"], optional = true }
+tokio = { version = "0.2", features = ["rt-core", "tcp", "time", "macros"], optional = true }
 
 [dev-dependencies]
 quanta = "0.6"

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -20,8 +20,8 @@ default = ["tokio-exporter"]
 tokio-exporter = ["hyper", "tokio"]
 
 [dependencies]
-metrics = { version = "0.13.0-alpha.1", path="../metrics" }
-metrics-util = { version = "0.4.0-alpha.1", path="../metrics-util" }
+metrics = { version = "0.13.0-alpha.1", path = "../metrics" }
+metrics-util = { version = "0.4.0-alpha.1", path = "../metrics-util" }
 hdrhistogram = "7.1"
 parking_lot = "0.11"
 thiserror = "1.0"

--- a/metrics-exporter-prometheus/src/lib.rs
+++ b/metrics-exporter-prometheus/src/lib.rs
@@ -334,7 +334,7 @@ pub struct PrometheusRecorder {
 }
 
 impl PrometheusRecorder {
-    ///Returns a [`PrometheusHandle`] from the inner struct of this recorder.
+    /// Gets a [`PrometheusHandle`] to this recorder.
     pub fn handle(&self) -> PrometheusHandle {
         PrometheusHandle {
             inner: self.inner.clone(),
@@ -351,7 +351,9 @@ impl PrometheusRecorder {
     }
 }
 
-/// A wrapper around the Inner struct of the Prometheus recorder.
+/// Handle to [`PrometheusRecorder`].
+///
+/// Useful for exposing a scrape endpoint on an existing HTTP/HTTPS server.
 pub struct PrometheusHandle {
     inner: Arc<Inner>,
 }
@@ -465,7 +467,6 @@ impl PrometheusBuilder {
 
     /// Builds the recorder and returns it.
     /// This function is only enabled when default features are not set.
-    #[cfg(not(feature = "tokio-exporter"))]
     pub fn build(self) -> Result<PrometheusRecorder, Error> {
         let inner = Arc::new(Inner {
             registry: Registry::new(),
@@ -488,7 +489,7 @@ impl PrometheusBuilder {
     /// recorders, or needs to schedule the exporter to run in a particular way, this method
     /// provides the flexibility to do so.
     #[cfg(feature = "tokio-exporter")]
-    pub fn build(
+    pub fn build_with_exporter(
         self,
     ) -> Result<
         (

--- a/metrics-exporter-prometheus/src/lib.rs
+++ b/metrics-exporter-prometheus/src/lib.rs
@@ -439,7 +439,7 @@ impl PrometheusBuilder {
     /// installing the recorder as the global recorder.
     #[cfg(feature = "tokio-exporter")]
     pub fn install(self) -> Result<(), Error> {
-        let (recorder, exporter) = self.build()?;
+        let (recorder, exporter) = self.build_with_exporter()?;
         metrics::set_boxed_recorder(Box::new(recorder))?;
 
         let mut runtime = runtime::Builder::new()


### PR DESCRIPTION
I threw this up relatively quickly, I can dive into it more tonight and improve documentation + ci (adding different features to actions).

What this PR does it make the Tokio and hyper functionality apart of a feature. It is enabled by default, but allows for users to replace disable it if they wish. The only major change is introducing another `build` function on the PrometheusBuilder that only returns the Recorder rather than both the Recorder and Exporter. This function is only enabled when the `tokio-exporter` feature is disabled.