### PR TITLE
Doc typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,23 @@ jobs:
           override: true
     - name: Run Tests
       run: cargo test
+  docs:
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust Nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          override: true
+          components: rust-docs
+    - name: Check docs
+      uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --workspace --no-deps
   bench:
     name: Bench ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -9,7 +9,7 @@ use core::{
 
 /// Inner representation of [`Key`].
 ///
-/// While [`Key`] is the type that users will interact with via [`Recorder`][crate::Recorder`,
+/// While [`Key`] is the type that users will interact with via [`Recorder`][crate::Recorder],
 /// [`KeyData`] is responsible for the actual storage of the name and label data.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub struct KeyData {


### PR DESCRIPTION
This fixes a trivial docs typo.  Though also adds a docs build to the CI which will fail if there are warnings while building docs, which happen for e.g. broken links.