### PR TITLE
Switch to collecting metric names by part.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
           toolchain: 'stable'
           override: true
     - name: Run Benchmarks
-      run: cargo bench
+      run: cargo bench --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_version: ['1.43.0', 'stable', 'nightly']
+        rust_version: ['1.46.0', 'stable', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,102 +1,94 @@
 Short version for non-lawyers:
 
-metrics is MIT licensed.
+`metrics` is MIT licensed.
 
 Longer version:
 
-Copyrights in the metrics project are retained by their contributors. No
-copyright assignment is required to contribute to the metrics project.
+Copyrights in the `metrics` project are retained by their contributors. No copyright assignment is
+required to contribute to the `metrics` project.
 
-Some files include explicit copyright notices and/or license notices.
-For full authorship information, see the version control history.
+Some files include explicit copyright notices and/or license notices.  For full authorship
+information, see the version control history.
 
-Except as otherwise noted (below and/or in individual files), metrics
-is licensed under the MIT license <LICENSE> or
-<http://opensource.org/licenses/MIT>.
+Except as otherwise noted (below and/or in individual files), `metrics` is licensed under the MIT
+license <LICENSE> or <http://opensource.org/licenses/MIT>.
 
 
-metrics includes packages written by third parties.
-The following third party packages are included, and carry
-their own copyright notices and license terms:
+`metrics` includes packages written by third parties.  The following third party packages are
+included, and carry their own copyright notices and license terms:
 
-* Portions of the API design are derived from tic
-  <https://github.com/brayniac/tic>, which carries the following
-  license:
+* Portions of the API design are derived from the `tic` crate which carries the following license:
 
     Copyright (c) 2016 Brian Martin
 
-    Permission is hereby granted, free of charge, to any person
-    obtaining a copy of this software and associated documentation
-    files (the "Software"), to deal in the Software without restriction,
-    including without limitation the rights to use, copy, modify, merge,
-    publish, distribute, sublicense, and/or sell copies of the Software,
-    and to permit persons to whom the Software is furnished to do so,
-    subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in all copies or
+    substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-    BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-    ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-* metrics is a fork of rust-lang-nursery/log which carries the following
-  license:
+* metrics is a fork of `rust-lang-nursery/log` which carries the following license:
 
     Copyright (c) 2014 The Rust Project Developers
 
-    Permission is hereby granted, free of charge, to any
-    person obtaining a copy of this software and associated
-    documentation files (the "Software"), to deal in the
-    Software without restriction, including without
-    limitation the rights to use, copy, modify, merge,
-    publish, distribute, sublicense, and/or sell copies of
-    the Software, and to permit persons to whom the Software
-    is furnished to do so, subject to the following
-    conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice
-    shall be included in all copies or substantial portions
-    of the Software.
+    The above copyright notice and this permission notice shall be included in all copies or
+    substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-    PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-    SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-    IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-    DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-* metrics-observer reuses code from `std::time::Duration` which carries
-  the following license:
+* metrics-observer reuses code from `std::time::Duration` which carries the following license:
 
-    Permission is hereby granted, free of charge, to any
-    person obtaining a copy of this software and associated
-    documentation files (the "Software"), to deal in the
-    Software without restriction, including without
-    limitation the rights to use, copy, modify, merge,
-    publish, distribute, sublicense, and/or sell copies of
-    the Software, and to permit persons to whom the Software
-    is furnished to do so, subject to the following
-    conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice
-    shall be included in all copies or substantial portions
-    of the Software.
+    The above copyright notice and this permission notice shall be included in all copies or
+    substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-    PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-    SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-    IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-    DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+  * metrics includes code from the `beef` crate which carries the following license:
+
+    Copyright (c) 2020 Maciej Hirsz <hello@maciej.codes>
+
+    The MIT License (MIT)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -80,7 +80,7 @@ impl Generator {
 impl Drop for Generator {
     fn drop(&mut self) {
         info!(
-            "    sender latency: min: {:9} p50: {:9} p95: {:9} p99: {:9} p999: {:9} max: {:9}",
+            "    sender latency: min: {:8} p50: {:8} p95: {:8} p99: {:8} p999: {:8} max: {:8}",
             nanos_to_readable(self.hist.min()),
             nanos_to_readable(self.hist.value_at_percentile(50.0)),
             nanos_to_readable(self.hist.value_at_percentile(95.0)),
@@ -196,7 +196,7 @@ fn main() {
     info!("--------------------------------------------------------------------------------");
     info!(" ingested samples total: {}", total);
     info!(
-        "snapshot retrieval: min: {:9} p50: {:9} p95: {:9} p99: {:9} p999: {:9} max: {:9}",
+        "snapshot retrieval: min: {:8} p50: {:8} p95: {:8} p99: {:8} p999: {:8} max: {:8}",
         nanos_to_readable(snapshot_hist.min()),
         nanos_to_readable(snapshot_hist.value_at_percentile(50.0)),
         nanos_to_readable(snapshot_hist.value_at_percentile(95.0)),

--- a/metrics-exporter-prometheus/src/lib.rs
+++ b/metrics-exporter-prometheus/src/lib.rs
@@ -334,7 +334,7 @@ impl PrometheusRecorder {
     fn add_description_if_missing(&self, key: &Key, description: Option<&'static str>) {
         if let Some(description) = description {
             let mut descriptions = self.inner.descriptions.write();
-            if !descriptions.contains_key(key.name().as_ref()) {
+            if !descriptions.contains_key(key.name().to_string().as_str()) {
                 descriptions.insert(key.name().to_string(), description);
             }
         }
@@ -552,7 +552,11 @@ fn key_to_parts(key: Key) -> (String, Vec<String>) {
     let name = key.name();
     let labels = key.labels();
     let sanitize = |c| c == '.' || c == '=' || c == '{' || c == '}' || c == '+' || c == '-';
-    let name = name.replace(sanitize, "_");
+    let name = name
+        .parts()
+        .map(|s| s.replace(sanitize, "_"))
+        .collect::<Vec<_>>()
+        .join("_");
     let labels = labels
         .into_iter()
         .map(|label| {

--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -288,15 +288,17 @@ where
                 let labels_len = quote! { #labels_len };
 
                 quote! {
+                    static METRIC_NAME: metrics::NameParts = metrics::NameParts::from_static_name(#key);
                     static METRIC_LABELS: [metrics::Label; #labels_len] = [#(#labels),*];
                     static METRIC_KEY: metrics::KeyData =
-                        metrics::KeyData::from_static_parts(#key, &METRIC_LABELS);
+                        metrics::KeyData::from_static_parts(&METRIC_NAME, &METRIC_LABELS);
                 }
             }
             None => {
                 quote! {
+                    static METRIC_NAME: metrics::NameParts = metrics::NameParts::from_static_name(#key);
                     static METRIC_KEY: metrics::KeyData =
-                        metrics::KeyData::from_static_name(#key);
+                        metrics::KeyData::from_static_name(&METRIC_NAME);
                 }
             }
             _ => unreachable!("use_fast_path == true, but found expression-based labels"),

--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -367,10 +367,10 @@ fn key_to_quoted(labels: Option<Labels>) -> proc_macro2::TokenStream {
                     .into_iter()
                     .map(|(key, val)| quote! { metrics::Label::new(#key, #val) });
                 quote! {
-                    metrics::KeyData::from_hybrid_parts(&METRIC_NAME, vec![#(#labels),*])
+                    metrics::KeyData::from_parts(&METRIC_NAME[..], vec![#(#labels),*])
                 }
             }
-            Labels::Existing(e) => quote! { metrics::KeyData::from_hybrid_parts(&METRIC_NAME, #e) },
+            Labels::Existing(e) => quote! { metrics::KeyData::from_parts(&METRIC_NAME[..], #e) },
         },
     }
 }

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -167,7 +167,7 @@ fn test_get_expanded_callsite_fast_path_dynamic_labels() {
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
         "recorder . myop_mytype (metrics :: Key :: Owned (",
-        "metrics :: KeyData :: from_hybrid_parts (& METRIC_NAME , vec ! [metrics :: Label :: new (\"key1\" , & value1)])",
+        "metrics :: KeyData :: from_parts (& METRIC_NAME [..] , vec ! [metrics :: Label :: new (\"key1\" , & value1)])",
         ") , 1) ; ",
         "} ",
         "}",
@@ -192,7 +192,7 @@ fn test_get_expanded_callsite_regular_path() {
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
         "recorder . myop_mytype (",
-        "metrics :: Key :: Owned (metrics :: KeyData :: from_hybrid_parts (& METRIC_NAME , mylabels)) , ",
+        "metrics :: Key :: Owned (metrics :: KeyData :: from_parts (& METRIC_NAME [..] , mylabels)) , ",
         "1",
         ") ; ",
         "} }",
@@ -213,7 +213,7 @@ fn test_key_to_quoted_existing_labels() {
     let stream = key_to_quoted(Some(Labels::Existing(Expr::Path(
         parse_quote! { mylabels },
     ))));
-    let expected = "metrics :: KeyData :: from_hybrid_parts (& METRIC_NAME , mylabels)";
+    let expected = "metrics :: KeyData :: from_parts (& METRIC_NAME [..] , mylabels)";
     assert_eq!(stream.to_string(), expected);
 }
 
@@ -226,7 +226,7 @@ fn test_key_to_quoted_inline_labels() {
         (parse_quote! {"mylabel2"}, parse_quote! { "mylabel2" }),
     ])));
     let expected = concat!(
-        "metrics :: KeyData :: from_hybrid_parts (& METRIC_NAME , vec ! [",
+        "metrics :: KeyData :: from_parts (& METRIC_NAME [..] , vec ! [",
         "metrics :: Label :: new (\"mylabel1\" , mylabel1) , ",
         "metrics :: Label :: new (\"mylabel2\" , \"mylabel2\")",
         "])"
@@ -237,6 +237,6 @@ fn test_key_to_quoted_inline_labels() {
 #[test]
 fn test_key_to_quoted_inline_labels_empty() {
     let stream = key_to_quoted(Some(Labels::Inline(vec![])));
-    let expected = concat!("metrics :: KeyData :: from_hybrid_parts (& METRIC_NAME , vec ! [])");
+    let expected = concat!("metrics :: KeyData :: from_parts (& METRIC_NAME [..] , vec ! [])");
     assert_eq!(stream.to_string(), expected);
 }

--- a/metrics-tracing-context/benches/layer.rs
+++ b/metrics-tracing-context/benches/layer.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
-use metrics::{Key, KeyData, Label, NoopRecorder, Recorder};
+use metrics::{Key, KeyData, Label, NoopRecorder, Recorder, SharedString};
 use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 use metrics_util::layers::Layer;
 use tracing::{
@@ -22,8 +22,9 @@ fn layer_benchmark(c: &mut Criterion) {
 
                 let tracing_layer = TracingContextLayer::all();
                 let recorder = tracing_layer.layer(NoopRecorder);
-                static LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-                static KEY_DATA: KeyData = KeyData::from_static_parts("key", &LABELS);
+                static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
+                static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
+                static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
                 b.iter(|| {
                     recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
@@ -32,8 +33,9 @@ fn layer_benchmark(c: &mut Criterion) {
         })
         .with_function("noop recorder overhead (increment_counter)", |b| {
             let recorder = NoopRecorder;
-            static LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts("key", &LABELS);
+            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
+            static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
+            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
                 recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -101,7 +101,7 @@ where
     }
 }
 
-/// [`TracingContext`] is a [`metrics::Recorder`] that injects labels from [`tracing::Span`]s.
+/// [`TracingContext`] is a [`metrics::Recorder`] that injects labels from[`tracing::Span`]s.
 pub struct TracingContext<R, F> {
     inner: R,
     label_filter: F,
@@ -126,7 +126,7 @@ where
     fn enhance_key(&self, key: Key) -> Key {
         let (name, mut labels) = key.into_owned().into_parts();
         self.enhance_labels(&mut labels);
-        KeyData::from_parts(name, labels).into()
+        KeyData::from_owned_parts(name, labels).into()
     }
 }
 

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -126,7 +126,7 @@ where
     fn enhance_key(&self, key: Key) -> Key {
         let (name, mut labels) = key.into_owned().into_parts();
         self.enhance_labels(&mut labels);
-        KeyData::from_owned_parts(name, labels).into()
+        KeyData::from_parts(name, labels).into()
     }
 }
 

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -20,7 +20,7 @@ impl Visit for Labels {
     }
 
     fn record_bool(&mut self, field: &Field, value: bool) {
-        let label = Label::new(field.name(), if value { "true" } else { "false" });
+        let label = Label::from_static_parts(field.name(), if value { "true" } else { "false" });
         self.0.push(label);
     }
 

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -52,7 +52,7 @@ fn test_basic_functionality() {
         snapshot,
         vec![(
             MetricKind::Counter,
-            KeyData::from_owned_parts(
+            KeyData::from_parts(
                 "login_attempts",
                 vec![
                     Label::new("service", "login_service"),
@@ -95,7 +95,7 @@ fn test_macro_forms() {
         vec![
             (
                 MetricKind::Counter,
-                KeyData::from_owned_parts(
+                KeyData::from_parts(
                     "login_attempts_no_labels",
                     vec![
                         Label::new("user", "ferris"),
@@ -109,7 +109,7 @@ fn test_macro_forms() {
             ),
             (
                 MetricKind::Counter,
-                KeyData::from_owned_parts(
+                KeyData::from_parts(
                     "login_attempts_static_labels",
                     vec![
                         Label::new("service", "login_service"),
@@ -124,7 +124,7 @@ fn test_macro_forms() {
             ),
             (
                 MetricKind::Counter,
-                KeyData::from_owned_parts(
+                KeyData::from_parts(
                     "login_attempts_dynamic_labels",
                     vec![
                         Label::new("node_name", "localhost"),
@@ -139,7 +139,7 @@ fn test_macro_forms() {
             ),
             (
                 MetricKind::Counter,
-                KeyData::from_owned_parts(
+                KeyData::from_parts(
                     "login_attempts_static_and_dynamic_labels",
                     vec![
                         Label::new("service", "login_service"),
@@ -224,7 +224,7 @@ fn test_multiple_paths_to_the_same_callsite() {
         vec![
             (
                 MetricKind::Counter,
-                KeyData::from_owned_parts(
+                KeyData::from_parts(
                     "my_counter",
                     vec![
                         Label::new("shared_field", "path1"),
@@ -239,7 +239,7 @@ fn test_multiple_paths_to_the_same_callsite() {
             ),
             (
                 MetricKind::Counter,
-                KeyData::from_owned_parts(
+                KeyData::from_parts(
                     "my_counter",
                     vec![
                         Label::new("shared_field", "path2"),
@@ -295,7 +295,7 @@ fn test_nested_spans() {
         snapshot,
         vec![(
             MetricKind::Counter,
-            KeyData::from_owned_parts(
+            KeyData::from_parts(
                 "my_counter",
                 vec![
                     Label::new("shared_field", "inner"),
@@ -340,7 +340,7 @@ fn test_label_filtering() {
         snapshot,
         vec![(
             MetricKind::Counter,
-            KeyData::from_owned_parts(
+            KeyData::from_parts(
                 "login_attempts",
                 vec![
                     Label::new("service", "login_service"),

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -52,7 +52,7 @@ fn test_basic_functionality() {
         snapshot,
         vec![(
             MetricKind::Counter,
-            KeyData::from_parts(
+            KeyData::from_owned_parts(
                 "login_attempts",
                 vec![
                     Label::new("service", "login_service"),
@@ -95,7 +95,7 @@ fn test_macro_forms() {
         vec![
             (
                 MetricKind::Counter,
-                KeyData::from_parts(
+                KeyData::from_owned_parts(
                     "login_attempts_no_labels",
                     vec![
                         Label::new("user", "ferris"),
@@ -109,7 +109,7 @@ fn test_macro_forms() {
             ),
             (
                 MetricKind::Counter,
-                KeyData::from_parts(
+                KeyData::from_owned_parts(
                     "login_attempts_static_labels",
                     vec![
                         Label::new("service", "login_service"),
@@ -124,7 +124,7 @@ fn test_macro_forms() {
             ),
             (
                 MetricKind::Counter,
-                KeyData::from_parts(
+                KeyData::from_owned_parts(
                     "login_attempts_dynamic_labels",
                     vec![
                         Label::new("node_name", "localhost"),
@@ -139,7 +139,7 @@ fn test_macro_forms() {
             ),
             (
                 MetricKind::Counter,
-                KeyData::from_parts(
+                KeyData::from_owned_parts(
                     "login_attempts_static_and_dynamic_labels",
                     vec![
                         Label::new("service", "login_service"),
@@ -224,7 +224,7 @@ fn test_multiple_paths_to_the_same_callsite() {
         vec![
             (
                 MetricKind::Counter,
-                KeyData::from_parts(
+                KeyData::from_owned_parts(
                     "my_counter",
                     vec![
                         Label::new("shared_field", "path1"),
@@ -239,7 +239,7 @@ fn test_multiple_paths_to_the_same_callsite() {
             ),
             (
                 MetricKind::Counter,
-                KeyData::from_parts(
+                KeyData::from_owned_parts(
                     "my_counter",
                     vec![
                         Label::new("shared_field", "path2"),
@@ -295,7 +295,7 @@ fn test_nested_spans() {
         snapshot,
         vec![(
             MetricKind::Counter,
-            KeyData::from_parts(
+            KeyData::from_owned_parts(
                 "my_counter",
                 vec![
                     Label::new("shared_field", "inner"),
@@ -340,7 +340,7 @@ fn test_label_filtering() {
         snapshot,
         vec![(
             MetricKind::Counter,
-            KeyData::from_parts(
+            KeyData::from_owned_parts(
                 "login_attempts",
                 vec![
                     Label::new("service", "login_service"),

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -26,6 +26,10 @@ harness = false
 name = "registry"
 harness = false
 
+[[bench]]
+name = "prefix"
+harness = false
+
 [dependencies]
 metrics = { version = "0.13.0-alpha.1", path = "../metrics", features = ["std"] }
 crossbeam-epoch = { version = "0.9", optional = true }

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -30,6 +30,10 @@ harness = false
 name = "prefix"
 harness = false
 
+[[bench]]
+name = "filter"
+harness = false
+
 [dependencies]
 metrics = { version = "0.13.0-alpha.1", path = "../metrics", features = ["std"] }
 crossbeam-epoch = { version = "0.9", optional = true }

--- a/metrics-util/benches/prefix.rs
+++ b/metrics-util/benches/prefix.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
-use metrics::{Key, KeyData, Label, NameParts, NoopRecorder, Recorder};
+use metrics::{Key, KeyData, Label, NoopRecorder, Recorder, SharedString};
 use metrics_util::layers::{Layer, PrefixLayer};
 
 fn layer_benchmark(c: &mut Criterion) {
@@ -8,9 +8,9 @@ fn layer_benchmark(c: &mut Criterion) {
         Benchmark::new("basic", |b| {
             let prefix_layer = PrefixLayer::new("prefix");
             let recorder = prefix_layer.layer(NoopRecorder);
-            static NAME: NameParts = NameParts::from_static_name("key");
-            static LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&NAME, &LABELS);
+            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
+            static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
+            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
                 recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
@@ -18,9 +18,9 @@ fn layer_benchmark(c: &mut Criterion) {
         })
         .with_function("noop recorder overhead (increment_counter)", |b| {
             let recorder = NoopRecorder;
-            static NAME: NameParts = NameParts::from_static_name("key");
-            static LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&NAME, &LABELS);
+            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
+            static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
+            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
                 recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);

--- a/metrics-util/benches/prefix.rs
+++ b/metrics-util/benches/prefix.rs
@@ -1,0 +1,33 @@
+use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
+use metrics::{Key, KeyData, Label, NameParts, NoopRecorder, Recorder};
+use metrics_util::layers::{Layer, PrefixLayer};
+
+fn layer_benchmark(c: &mut Criterion) {
+    c.bench(
+        "prefix",
+        Benchmark::new("basic", |b| {
+            let prefix_layer = PrefixLayer::new("prefix");
+            let recorder = prefix_layer.layer(NoopRecorder);
+            static NAME: NameParts = NameParts::from_static_name("key");
+            static LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
+            static KEY_DATA: KeyData = KeyData::from_static_parts(&NAME, &LABELS);
+
+            b.iter(|| {
+                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+            })
+        })
+        .with_function("noop recorder overhead (increment_counter)", |b| {
+            let recorder = NoopRecorder;
+            static NAME: NameParts = NameParts::from_static_name("key");
+            static LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
+            static KEY_DATA: KeyData = KeyData::from_static_parts(&NAME, &LABELS);
+
+            b.iter(|| {
+                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+            })
+        }),
+    );
+}
+
+criterion_group!(benches, layer_benchmark);
+criterion_main!(benches);

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -64,7 +64,7 @@ fn registry_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 let key = "simple_key";
                 let labels = vec![Label::new("type", "http")];
-                KeyData::from_owned_parts(key, labels)
+                KeyData::from_parts(key, labels)
             })
         })
         .with_function("const key data overhead (basic)", |b| {
@@ -90,7 +90,7 @@ fn registry_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 let key = "simple_key";
                 let labels = vec![Label::new("type", "http")];
-                Key::Owned(KeyData::from_owned_parts(key, labels))
+                Key::Owned(KeyData::from_parts(key, labels))
             })
         })
         .with_function("cached key overhead (basic)", |b| {

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Benchmark, Criterion};
-use metrics::{Key, KeyData, Label};
+use metrics::{Key, KeyData, Label, NameParts};
 use metrics_util::Registry;
 
 fn registry_benchmark(c: &mut Criterion) {
@@ -7,7 +7,8 @@ fn registry_benchmark(c: &mut Criterion) {
         "registry",
         Benchmark::new("cached op (basic)", |b| {
             let registry: Registry<Key, ()> = Registry::new();
-            static KEY_DATA: KeyData = KeyData::from_static_name("simple_key");
+            static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
+            static KEY_DATA: KeyData = KeyData::from_static_name(&KEY_NAME);
 
             b.iter(|| {
                 let key = Key::Borrowed(&KEY_DATA);
@@ -16,8 +17,9 @@ fn registry_benchmark(c: &mut Criterion) {
         })
         .with_function("cached op (labels)", |b| {
             let registry: Registry<Key, ()> = Registry::new();
+            static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts("simple_key", &KEY_LABELS);
+            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
                 let key = Key::Borrowed(&KEY_DATA);
@@ -67,15 +69,15 @@ fn registry_benchmark(c: &mut Criterion) {
         })
         .with_function("const key data overhead (basic)", |b| {
             b.iter(|| {
-                let key = "simple_key";
-                KeyData::from_static_name(key)
+                static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
+                KeyData::from_static_name(&KEY_NAME)
             })
         })
         .with_function("const key data overhead (labels)", |b| {
             b.iter(|| {
-                let key = "simple_key";
+                static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
                 static LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
-                KeyData::from_static_parts(key, &LABELS)
+                KeyData::from_static_parts(&KEY_NAME, &LABELS)
             })
         })
         .with_function("owned key overhead (basic)", |b| {
@@ -92,12 +94,14 @@ fn registry_benchmark(c: &mut Criterion) {
             })
         })
         .with_function("cached key overhead (basic)", |b| {
-            static KEY_DATA: KeyData = KeyData::from_static_name("simple_key");
+            static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
+            static KEY_DATA: KeyData = KeyData::from_static_name(&KEY_NAME);
             b.iter(|| Key::Borrowed(&KEY_DATA))
         })
         .with_function("cached key overhead (labels)", |b| {
+            static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts("simple_key", &KEY_LABELS);
+            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
             b.iter(|| Key::Borrowed(&KEY_DATA))
         }),
     );

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Benchmark, Criterion};
-use metrics::{Key, KeyData, Label, NameParts};
+use metrics::{Key, KeyData, Label, SharedString};
 use metrics_util::Registry;
 
 fn registry_benchmark(c: &mut Criterion) {
@@ -7,7 +7,7 @@ fn registry_benchmark(c: &mut Criterion) {
         "registry",
         Benchmark::new("cached op (basic)", |b| {
             let registry: Registry<Key, ()> = Registry::new();
-            static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
+            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
             static KEY_DATA: KeyData = KeyData::from_static_name(&KEY_NAME);
 
             b.iter(|| {
@@ -17,7 +17,7 @@ fn registry_benchmark(c: &mut Criterion) {
         })
         .with_function("cached op (labels)", |b| {
             let registry: Registry<Key, ()> = Registry::new();
-            static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
+            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
             static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
@@ -64,18 +64,18 @@ fn registry_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 let key = "simple_key";
                 let labels = vec![Label::new("type", "http")];
-                KeyData::from_parts(key, labels)
+                KeyData::from_owned_parts(key, labels)
             })
         })
         .with_function("const key data overhead (basic)", |b| {
             b.iter(|| {
-                static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
+                static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
                 KeyData::from_static_name(&KEY_NAME)
             })
         })
         .with_function("const key data overhead (labels)", |b| {
             b.iter(|| {
-                static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
+                static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
                 static LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
                 KeyData::from_static_parts(&KEY_NAME, &LABELS)
             })
@@ -90,16 +90,16 @@ fn registry_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 let key = "simple_key";
                 let labels = vec![Label::new("type", "http")];
-                Key::Owned(KeyData::from_parts(key, labels))
+                Key::Owned(KeyData::from_owned_parts(key, labels))
             })
         })
         .with_function("cached key overhead (basic)", |b| {
-            static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
+            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
             static KEY_DATA: KeyData = KeyData::from_static_name(&KEY_NAME);
             b.iter(|| Key::Borrowed(&KEY_DATA))
         })
         .with_function("cached key overhead (labels)", |b| {
-            static KEY_NAME: NameParts = NameParts::from_static_name("simple_key");
+            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
             static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
             b.iter(|| Key::Borrowed(&KEY_DATA))

--- a/metrics-util/src/layers/mod.rs
+++ b/metrics-util/src/layers/mod.rs
@@ -17,7 +17,12 @@
 //!
 //! impl<R> StairwayDeny<R> {
 //!     fn is_invalid_key(&self, key: &Key) -> bool {
-//!         key.name().contains("stairway") || key.name().contains("heaven")
+//!         for part in key.name().parts() {
+//!             if part.contains("stairway") || part.contains("heaven") {
+//!                 return true
+//!             }
+//!         }
+//!         false
 //!     }
 //! }
 //!

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -5,15 +5,15 @@ use metrics::{Key, Recorder, Unit};
 ///
 /// Keys will be prefixed in the format of `<prefix>.<remaining>`.
 pub struct Prefix<R> {
-    prefix: String,
+    prefix: &'static str,
     inner: R,
 }
 
 impl<R> Prefix<R> {
     fn prefix_key(&self, key: Key) -> Key {
-        key.into_owned()
-            .map_name(|old| format!("{}.{}", self.prefix, old))
-            .into()
+        let mut owned = key.into_owned();
+        owned.prepend_name(self.prefix);
+        owned.into()
     }
 }
 
@@ -52,12 +52,12 @@ impl<R: Recorder> Recorder for Prefix<R> {
 /// A layer for applying a prefix to every metric key.
 ///
 /// More information on the behavior of the layer can be found in [`Prefix`].
-pub struct PrefixLayer(String);
+pub struct PrefixLayer(&'static str);
 
 impl PrefixLayer {
     /// Creates a new `PrefixLayer` based on the given prefix.
     pub fn new<S: Into<String>>(prefix: S) -> PrefixLayer {
-        PrefixLayer(prefix.into())
+        PrefixLayer(Box::leak(prefix.into().into_boxed_str()))
     }
 }
 
@@ -66,7 +66,7 @@ impl<R> Layer<R> for PrefixLayer {
 
     fn layer(&self, inner: R) -> Self::Output {
         Prefix {
-            prefix: self.0.clone(),
+            prefix: self.0,
             inner,
         }
     }
@@ -115,7 +115,7 @@ mod tests {
         assert_eq!(after.len(), 3);
 
         for (i, (_kind, key, unit, desc, _value)) in after.iter().enumerate() {
-            assert!(key.name().starts_with("testing"));
+            assert!(key.name().to_string().starts_with("testing"));
             assert_eq!(&Some(ud[i].0.clone()), unit);
             assert_eq!(&Some(ud[i].1), desc);
         }

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -1,19 +1,17 @@
 use crate::layers::Layer;
-use metrics::{Key, Recorder, Unit};
+use metrics::{Key, Recorder, SharedString, Unit};
 
 /// Applies a prefix to every metric key.
 ///
 /// Keys will be prefixed in the format of `<prefix>.<remaining>`.
 pub struct Prefix<R> {
-    prefix: &'static str,
+    prefix: SharedString,
     inner: R,
 }
 
 impl<R> Prefix<R> {
     fn prefix_key(&self, key: Key) -> Key {
-        let mut owned = key.into_owned();
-        owned.prepend_name(self.prefix);
-        owned.into()
+        key.into_owned().prepend_name(self.prefix.clone()).into()
     }
 }
 
@@ -66,7 +64,7 @@ impl<R> Layer<R> for PrefixLayer {
 
     fn layer(&self, inner: R) -> Self::Output {
         Prefix {
-            prefix: self.0,
+            prefix: self.0.into(),
             inner,
         }
     }

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -31,6 +31,7 @@ harness = false
 beef = "0.4"
 metrics-macros = { version = "0.1.0-alpha.1", path = "../metrics-macros" }
 proc-macro-hack = "0.5"
+sharded-slab = "0.1"
 
 [dev-dependencies]
 log = "0.4"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -27,6 +27,10 @@ bench = false
 name = "macros"
 harness = false
 
+[[bench]]
+name = "key"
+harness = false
+
 [dependencies]
 beef = "0.4"
 metrics-macros = { version = "0.1.0-alpha.1", path = "../metrics-macros" }

--- a/metrics/benches/key.rs
+++ b/metrics/benches/key.rs
@@ -1,0 +1,28 @@
+use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
+
+use metrics::{NameParts, SharedString};
+
+fn key_benchmark(c: &mut Criterion) {
+    c.bench(
+        "key",
+        Benchmark::new("name_parts/to_string", |b| {
+            static NAME_PARTS: [SharedString; 2] = [
+                SharedString::const_str("part1"),
+                SharedString::const_str("part2"),
+            ];
+            let name = NameParts::from_static_names(&NAME_PARTS);
+            b.iter(|| name.to_string())
+        })
+        .with_function("name_parts/Display::to_string", |b| {
+            static NAME_PARTS: [SharedString; 2] = [
+                SharedString::const_str("part1"),
+                SharedString::const_str("part2"),
+            ];
+            let name = NameParts::from_static_names(&NAME_PARTS);
+            b.iter(|| std::fmt::Display::to_string(&name))
+        }),
+    );
+}
+
+criterion_group!(benches, key_benchmark);
+criterion_main!(benches);

--- a/metrics/examples/sizes.rs
+++ b/metrics/examples/sizes.rs
@@ -1,0 +1,13 @@
+//! This example is purely for development.
+use std::borrow::Cow;
+use metrics::{Key, KeyData, NameParts, Label, SharedString};
+
+fn main() {
+    println!("KeyData: {} bytes", std::mem::size_of::<KeyData>());
+    println!("Key: {} bytes", std::mem::size_of::<Key>());
+    println!("NameParts: {} bytes", std::mem::size_of::<NameParts>());
+    println!("Label: {} bytes", std::mem::size_of::<Label>());
+    println!("Cow<'static, [Label]>: {} bytes", std::mem::size_of::<Cow<'static, [Label]>>());
+    println!("Vec<SharedString>: {} bytes", std::mem::size_of::<Vec<SharedString>>());
+    println!("[Option<SharedString>; 2]: {} bytes", std::mem::size_of::<[Option<SharedString>; 2]>());
+}

--- a/metrics/examples/sizes.rs
+++ b/metrics/examples/sizes.rs
@@ -1,13 +1,22 @@
 //! This example is purely for development.
+use metrics::{Key, KeyData, Label, NameParts, SharedString};
 use std::borrow::Cow;
-use metrics::{Key, KeyData, NameParts, Label, SharedString};
 
 fn main() {
     println!("KeyData: {} bytes", std::mem::size_of::<KeyData>());
     println!("Key: {} bytes", std::mem::size_of::<Key>());
     println!("NameParts: {} bytes", std::mem::size_of::<NameParts>());
     println!("Label: {} bytes", std::mem::size_of::<Label>());
-    println!("Cow<'static, [Label]>: {} bytes", std::mem::size_of::<Cow<'static, [Label]>>());
-    println!("Vec<SharedString>: {} bytes", std::mem::size_of::<Vec<SharedString>>());
-    println!("[Option<SharedString>; 2]: {} bytes", std::mem::size_of::<[Option<SharedString>; 2]>());
+    println!(
+        "Cow<'static, [Label]>: {} bytes",
+        std::mem::size_of::<Cow<'static, [Label]>>()
+    );
+    println!(
+        "Vec<SharedString>: {} bytes",
+        std::mem::size_of::<Vec<SharedString>>()
+    );
+    println!(
+        "[Option<SharedString>; 2]: {} bytes",
+        std::mem::size_of::<[Option<SharedString>; 2]>()
+    );
 }

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -1,7 +1,4 @@
-#[cfg(target_pointer_width = "64")]
-use beef::lean::Cow;
-#[cfg(not(target_pointer_width = "64"))]
-use beef::Cow;
+use crate::cow::Cow;
 
 /// An allocation-optimized string.
 ///

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -5,6 +5,9 @@ use crate::cow::Cow;
 /// We specify `SharedString` to attempt to get the best of both worlds: flexibility to provide a
 /// static or dynamic (owned) string, while retaining the performance benefits of being able to
 /// take ownership of owned strings and borrows of completely static strings.
+///
+/// `SharedString` can be converted to from either `&'static str` or `String`, with a method,
+/// `const_str`, from constructing `SharedString` from `&'static str` in a `const` fashion.
 pub type SharedString = Cow<'static, str>;
 
 /// Units for a given metric.

--- a/metrics/src/cow.rs
+++ b/metrics/src/cow.rs
@@ -1,0 +1,515 @@
+use crate::label::Label;
+use alloc::borrow::Borrow;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::ptr::{slice_from_raw_parts, NonNull};
+
+/// A clone-on-write smart pointer with an optimized memory layout.
+pub struct Cow<'a, T: Cowable + ?Sized + 'a> {
+    /// Pointer to data.
+    ptr: NonNull<T::Pointer>,
+
+    /// Pointer metadata: length and capacity.
+    meta: Metadata,
+
+    /// Lifetime marker.
+    marker: PhantomData<&'a T>,
+}
+
+impl<T> Cow<'_, T>
+where
+    T: Cowable + ?Sized,
+{
+    #[inline]
+    pub fn owned(val: T::Owned) -> Self {
+        let (ptr, meta) = T::owned_into_parts(val);
+
+        Cow {
+            ptr,
+            meta,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Cow<'a, T>
+where
+    T: Cowable + ?Sized,
+{
+    #[inline]
+    pub fn borrowed(val: &'a T) -> Self {
+        let (ptr, meta) = T::ref_into_parts(val);
+
+        Cow {
+            ptr,
+            meta,
+            marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn into_owned(self) -> T::Owned {
+        let cow = ManuallyDrop::new(self);
+
+        if cow.is_borrowed() {
+            unsafe { T::clone_from_parts(cow.ptr, &cow.meta) }
+        } else {
+            unsafe { T::owned_from_parts(cow.ptr, &cow.meta) }
+        }
+    }
+
+    #[inline]
+    pub fn is_borrowed(&self) -> bool {
+        self.meta.capacity() == 0
+    }
+
+    #[inline]
+    pub fn is_owned(&self) -> bool {
+        self.meta.capacity() != 0
+    }
+
+    #[inline]
+    fn borrow(&self) -> &T {
+        unsafe { &*T::ref_from_parts(self.ptr, &self.meta) }
+    }
+}
+
+// Implementations of constant functions for creating `Cow` via static strings, static string
+// slices, and static label slices.
+impl<'a> Cow<'a, str> {
+    pub const fn const_str(val: &'a str) -> Self {
+        Cow {
+            // We are casting *const T to *mut T, however for all borrowed values
+            // this raw pointer is only ever dereferenced back to &T.
+            ptr: unsafe { NonNull::new_unchecked(val.as_ptr() as *mut u8) },
+            meta: Metadata::from_ref(val.len()),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'a> Cow<'a, [Cow<'static, str>]> {
+    pub const fn const_slice(val: &'a [Cow<'static, str>]) -> Self {
+        Cow {
+            ptr: unsafe { NonNull::new_unchecked(val.as_ptr() as *mut Cow<'static, str>) },
+            meta: Metadata::from_ref(val.len()),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'a> Cow<'a, [Label]> {
+    pub const fn const_slice(val: &'a [Label]) -> Self {
+        Cow {
+            ptr: unsafe { NonNull::new_unchecked(val.as_ptr() as *mut Label) },
+            meta: Metadata::from_ref(val.len()),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Hash for Cow<'_, T>
+where
+    T: Hash + Cowable + ?Sized,
+{
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.borrow().hash(state)
+    }
+}
+
+impl<'a, T> Default for Cow<'a, T>
+where
+    T: Cowable + ?Sized,
+    &'a T: Default,
+{
+    #[inline]
+    fn default() -> Self {
+        Cow::borrowed(Default::default())
+    }
+}
+
+impl<T> Eq for Cow<'_, T> where T: Eq + Cowable + ?Sized {}
+
+impl<A, B> PartialOrd<Cow<'_, B>> for Cow<'_, A>
+where
+    A: Cowable + ?Sized + PartialOrd<B>,
+    B: Cowable + ?Sized,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &Cow<'_, B>) -> Option<Ordering> {
+        PartialOrd::partial_cmp(self.borrow(), other.borrow())
+    }
+}
+
+impl<T> Ord for Cow<'_, T>
+where
+    T: Ord + Cowable + ?Sized,
+{
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        Ord::cmp(self.borrow(), other.borrow())
+    }
+}
+
+impl<'a, T> From<&'a T> for Cow<'a, T>
+where
+    T: Cowable + ?Sized,
+{
+    #[inline]
+    fn from(val: &'a T) -> Self {
+        Cow::borrowed(val)
+    }
+}
+
+impl From<String> for Cow<'_, str> {
+    #[inline]
+    fn from(s: String) -> Self {
+        Cow::owned(s)
+    }
+}
+
+impl From<Vec<Label>> for Cow<'_, [Label]> {
+    #[inline]
+    fn from(v: Vec<Label>) -> Self {
+        Cow::owned(v)
+    }
+}
+
+impl From<Vec<Cow<'static, str>>> for Cow<'_, [Cow<'static, str>]> {
+    #[inline]
+    fn from(v: Vec<Cow<'static, str>>) -> Self {
+        Cow::owned(v)
+    }
+}
+
+impl<T> Drop for Cow<'_, T>
+where
+    T: Cowable + ?Sized,
+{
+    #[inline]
+    fn drop(&mut self) {
+        if self.is_owned() {
+            unsafe { T::owned_from_parts(self.ptr, &self.meta) };
+        }
+    }
+}
+
+impl<'a, T> Clone for Cow<'a, T>
+where
+    T: Cowable + ?Sized,
+{
+    #[inline]
+    fn clone(&self) -> Self {
+        if self.is_owned() {
+            // Gotta clone the actual inner value.
+            Cow::owned(unsafe { T::clone_from_parts(self.ptr, &self.meta) })
+        } else {
+            Cow { ..*self }
+        }
+    }
+}
+
+impl<T> core::ops::Deref for Cow<'_, T>
+where
+    T: Cowable + ?Sized,
+{
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        self.borrow()
+    }
+}
+
+impl<T> AsRef<T> for Cow<'_, T>
+where
+    T: Cowable + ?Sized,
+{
+    #[inline]
+    fn as_ref(&self) -> &T {
+        self.borrow()
+    }
+}
+
+impl<T> Borrow<T> for Cow<'_, T>
+where
+    T: Cowable + ?Sized,
+{
+    #[inline]
+    fn borrow(&self) -> &T {
+        self.borrow()
+    }
+}
+
+impl<A, B> PartialEq<Cow<'_, B>> for Cow<'_, A>
+where
+    A: Cowable + ?Sized,
+    B: Cowable + ?Sized,
+    A: PartialEq<B>,
+{
+    fn eq(&self, other: &Cow<B>) -> bool {
+        self.borrow() == other.borrow()
+    }
+}
+
+impl<T> fmt::Debug for Cow<'_, T>
+where
+    T: Cowable + fmt::Debug + ?Sized,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.borrow().fmt(f)
+    }
+}
+
+impl<T> fmt::Display for Cow<'_, T>
+where
+    T: Cowable + fmt::Display + ?Sized,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.borrow().fmt(f)
+    }
+}
+
+unsafe impl<T: Cowable + Sync + ?Sized> Sync for Cow<'_, T> {}
+unsafe impl<T: Cowable + Send + ?Sized> Send for Cow<'_, T> {}
+
+/// Helper trait required by `Cow<T>` to extract capacity of owned
+/// variant of `T`, and manage conversions.
+///
+/// This can be only implemented on types that match requirements:
+///
+/// + `T::Owned` has a `capacity`, which is an extra word that is absent in `T`.
+/// + `T::Owned` with `capacity` of `0` does not allocate memory.
+/// + `T::Owned` can be reconstructed from `*mut T` borrowed out of it, plus capacity.
+pub unsafe trait Cowable {
+    type Pointer;
+    type Owned;
+
+    fn ref_into_parts(&self) -> (NonNull<Self::Pointer>, Metadata);
+    fn owned_into_parts(owned: Self::Owned) -> (NonNull<Self::Pointer>, Metadata);
+
+    unsafe fn ref_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) -> *const Self;
+    unsafe fn owned_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) -> Self::Owned;
+    unsafe fn clone_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) -> Self::Owned;
+}
+
+unsafe impl Cowable for str {
+    type Pointer = u8;
+    type Owned = String;
+
+    #[inline]
+    fn ref_into_parts(&self) -> (NonNull<u8>, Metadata) {
+        // A note on soundness:
+        //
+        // We are casting *const T to *mut T, however for all borrowed values
+        // this raw pointer is only ever dereferenced back to &T.
+        let ptr = unsafe { NonNull::new_unchecked(self.as_ptr() as *mut _) };
+        let metadata = Metadata::from_ref(self.len());
+        (ptr, metadata)
+    }
+
+    #[inline]
+    unsafe fn ref_from_parts(ptr: NonNull<u8>, metadata: &Metadata) -> *const str {
+        slice_from_raw_parts(ptr.as_ptr(), metadata.length()) as *const _
+    }
+
+    #[inline]
+    fn owned_into_parts(owned: String) -> (NonNull<u8>, Metadata) {
+        let mut owned = ManuallyDrop::new(owned);
+        let ptr = unsafe { NonNull::new_unchecked(owned.as_mut_ptr()) };
+        let metadata = Metadata::from_owned(owned.len(), owned.capacity());
+        (ptr, metadata)
+    }
+
+    #[inline]
+    unsafe fn owned_from_parts(ptr: NonNull<u8>, metadata: &Metadata) -> String {
+        String::from_utf8_unchecked(Vec::from_raw_parts(
+            ptr.as_ptr(),
+            metadata.length(),
+            metadata.capacity(),
+        ))
+    }
+
+    #[inline]
+    unsafe fn clone_from_parts(ptr: NonNull<u8>, metadata: &Metadata) -> Self::Owned {
+        let str = Self::ref_from_parts(ptr, metadata);
+        str.as_ref().unwrap().to_string()
+    }
+}
+
+unsafe impl<'a> Cowable for [Cow<'a, str>] {
+    type Pointer = Cow<'a, str>;
+    type Owned = Vec<Cow<'a, str>>;
+
+    #[inline]
+    fn ref_into_parts(&self) -> (NonNull<Cow<'a, str>>, Metadata) {
+        // A note on soundness:
+        //
+        // We are casting *const T to *mut T, however for all borrowed values
+        // this raw pointer is only ever dereferenced back to &T.
+        let ptr = unsafe { NonNull::new_unchecked(self.as_ptr() as *mut _) };
+        let metadata = Metadata::from_ref(self.len());
+        (ptr, metadata)
+    }
+
+    #[inline]
+    unsafe fn ref_from_parts(
+        ptr: NonNull<Cow<'a, str>>,
+        metadata: &Metadata,
+    ) -> *const [Cow<'a, str>] {
+        slice_from_raw_parts(ptr.as_ptr(), metadata.length())
+    }
+
+    #[inline]
+    fn owned_into_parts(owned: Vec<Cow<'a, str>>) -> (NonNull<Cow<'a, str>>, Metadata) {
+        let mut owned = ManuallyDrop::new(owned);
+        let ptr = unsafe { NonNull::new_unchecked(owned.as_mut_ptr()) };
+        let metadata = Metadata::from_owned(owned.len(), owned.capacity());
+        (ptr, metadata)
+    }
+
+    #[inline]
+    unsafe fn owned_from_parts(
+        ptr: NonNull<Cow<'a, str>>,
+        metadata: &Metadata,
+    ) -> Vec<Cow<'a, str>> {
+        Vec::from_raw_parts(ptr.as_ptr(), metadata.length(), metadata.capacity())
+    }
+
+    #[inline]
+    unsafe fn clone_from_parts(ptr: NonNull<Cow<'a, str>>, metadata: &Metadata) -> Self::Owned {
+        let ptr = Self::ref_from_parts(ptr, metadata);
+        let xs = ptr.as_ref().unwrap();
+        let mut owned = Vec::with_capacity(xs.len() + 1);
+        owned.extend_from_slice(xs);
+        owned
+    }
+}
+
+unsafe impl Cowable for [Label] {
+    type Pointer = Label;
+    type Owned = Vec<Label>;
+
+    #[inline]
+    fn ref_into_parts(&self) -> (NonNull<Label>, Metadata) {
+        // A note on soundness:
+        //
+        // We are casting *const T to *mut T, however for all borrowed values
+        // this raw pointer is only ever dereferenced back to &T.
+        let ptr = unsafe { NonNull::new_unchecked(self.as_ptr() as *mut _) };
+        let metadata = Metadata::from_ref(self.len());
+        (ptr, metadata)
+    }
+
+    #[inline]
+    unsafe fn ref_from_parts(ptr: NonNull<Label>, metadata: &Metadata) -> *const [Label] {
+        slice_from_raw_parts(ptr.as_ptr(), metadata.length())
+    }
+
+    #[inline]
+    fn owned_into_parts(owned: Vec<Label>) -> (NonNull<Label>, Metadata) {
+        let mut owned = ManuallyDrop::new(owned);
+        let ptr = unsafe { NonNull::new_unchecked(owned.as_mut_ptr()) };
+        let metadata = Metadata::from_owned(owned.len(), owned.capacity());
+        (ptr, metadata)
+    }
+
+    #[inline]
+    unsafe fn owned_from_parts(ptr: NonNull<Label>, metadata: &Metadata) -> Vec<Label> {
+        Vec::from_raw_parts(ptr.as_ptr(), metadata.length(), metadata.capacity())
+    }
+
+    #[inline]
+    unsafe fn clone_from_parts(ptr: NonNull<Label>, metadata: &Metadata) -> Self::Owned {
+        let xs = Self::ref_from_parts(ptr, metadata);
+        xs.as_ref().unwrap().to_vec()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Metadata(usize, usize);
+
+impl Metadata {
+    #[inline]
+    fn length(&self) -> usize {
+        self.0
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.1
+    }
+
+    pub const fn from_ref(len: usize) -> Metadata {
+        Metadata(len, 0)
+    }
+
+    pub const fn from_owned(len: usize, capacity: usize) -> Metadata {
+        Metadata(len, capacity)
+    }
+
+    pub const fn borrowed() -> Metadata {
+        Metadata(0, 0)
+    }
+
+    pub const fn owned() -> Metadata {
+        Metadata(0, 1)
+    }
+}
+
+/*
+
+This can be enabled again when we have a way to do panics/asserts in stable Rust,
+since const panicking is behind a feature flag at the moment.
+
+const MASK_LO: usize = u32::MAX as usize;
+const MASK_HI: usize = !MASK_LO;
+
+#[cfg(target_pointer_width = "64")]
+impl Metadata {
+    #[inline]
+    fn length(&self) -> usize {
+        self.0 & MASK_LO
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.0 & MASK_HI
+    }
+
+    pub const fn from_ref(len: usize) -> Metadata {
+        if len & MASK_HI != 0 {
+            panic!("Cow: length out of bounds for referenced value");
+        }
+
+        Metadata(len)
+    }
+
+    pub const fn from_owned(len: usize, capacity: usize) -> Metadata {
+        if len & MASK_HI != 0 {
+            panic!("Cow: length out of bounds for owned value");
+        }
+
+        if capacity & MASK_HI != 0 {
+            panic!("Cow: capacity out of bounds for owned value");
+        }
+
+        Metadata((capacity & MASK_LO) << 32 | len & MASK_LO)
+    }
+
+    pub const fn borrowed() -> Metadata {
+        Metadata(0)
+    }
+
+    pub const fn owned() -> Metadata {
+        Metadata(1 << 32)
+    }
+}*/

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -157,6 +157,7 @@ impl fmt::Display for NameParts {
 /// [`KeyData`] is responsible for the actual storage of the name and label data.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub struct KeyData {
+    // TODO: once const slicing is possible on stable, we could likely use `beef` for both of these
     name_parts: Cow<'static, NameParts>,
     labels: Cow<'static, [Label]>,
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -223,6 +223,8 @@ use proc_macro_hack::proc_macro_hack;
 mod common;
 pub use self::common::*;
 
+mod cow;
+
 mod key;
 pub use self::key::*;
 


### PR DESCRIPTION
In most cases, a metric has a single string identifier for its name.  Depending on whether you're using a layer that appends or prepends another string, or want to do something like scoping a metric name by where the callsite lives, you inevitably have to modify that string identifier to do so.  This comes at a cost, as even if the metric name can be referred to statically for the life of the program, it now must be copied, which involves allocation and ultimately slows down the codepath from `counter!(...)` to reaching the installed recorder.  Further, the optimizations that `metrics`make to push down as much work to compile-time as possible are then squandered as soon as a small change is made.

This PR introduces a new approach to building the name of a metric: `NameParts`.

`NameParts` contains a custom copy-on-write smart pointer (more on that later) which holds a reference to a slice or vector of actual string parts, which themselves are COW pointers to a `&'static str`/`String`.  What this lets us achieve is being able to provide multiple pieces for a metric name upfront _without_ allocating or mutating the strings, which means it can be done in a `const` fashion and allows `metrics` to take advantage of all of the existing optimizations it does.

When anything in the layer stack, or elsewhere, wants to modify a key in an additive way, it can simply prepend or append a new COW pointer to the given data to `NameParts`, incurring a small allocation for the COW pointer (and potentially the string being used) but without reallocating the existing parts.

On top of that, we have a custom COW pointer, which is a stripped down version of `beef`, which itself is a stripped down version of `std::borrow::Cow`.  This bears some explanation.

`beef` itself is an optimization to make the `Cow` struct smaller.  Normally, `std::borrow::Cow` would be 4 words -- discriminant, capacity, length, data pointer -- where `beef::Cow` is 3 words, as it bakes the discriminant into the capacity field.  It has an even more optimized mode where it splits the capacity/length within a single word, allowing you to have a 2-word COW pointer when you know the length/capacity of the value will be less than 2^32.  This is perfect for `metrics`.

We've forked `beef` here in order to make some changes, though:
- generics and `const` aren't yet stable, so we couldn't use `Cow::const_slice` on stable
- when allocating a new vector during a clone, we increase the capacity knowing that a new value will be written into it
- make the 2-vs-3 word optimization baked in rather than having to futz with `cfg` attributes ourselves

Right now, the 2-word optimization is commented out as we have no way to panic in `const` fns on stable, and while it's very unlikely that a user passes in a 4GB metric name or 4 million values, we'd rather not rely on that assumption.

All of this boils down to us now using this enhanced COW pointer not only for strings themselves, but the string slices for `NameParts` _and_ using it labels, allowing us to now use static slices for labels instead of always having to allocate a vector!

We've introduced a lot of permutations of constructor methods and so this could probably stand to do with some clean-up/consolidation but the premise is there.