### PR TITLE
[WIP] deps: update to tokio 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ members = [
   "metrics-tracing-context",
 ]
 exclude = ["metrics-observer"]
+
+[patch.crates-io]
+hyper = { git = "https://github.com/hyperium/hyper/", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
+

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -27,8 +27,8 @@ parking_lot = "0.11"
 thiserror = "1.0"
 
 # Optional
-hyper = { version = "0.13", default-features = false, features = ["tcp"], optional = true }
-tokio = { version = "0.2", features = ["rt-core", "tcp", "time", "macros"], optional = true }
+hyper = { version = "0.14.0-dev", default-features = false, features = ["tcp", "server", "http1", "http2"], optional = true }
+tokio = { version = "0.3", features = ["rt", "net", "time", "macros"], optional = true }
 
 [dev-dependencies]
 quanta = "0.6"

--- a/metrics-exporter-prometheus/src/lib.rs
+++ b/metrics-exporter-prometheus/src/lib.rs
@@ -443,12 +443,14 @@ impl PrometheusBuilder {
     /// installing the recorder as the global recorder.
     #[cfg(feature = "tokio-exporter")]
     pub fn install(self) -> Result<(), Error> {
-        let mut runtime = runtime::Builder::new()
-            .basic_scheduler()
+        let runtime = runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
 
-        let (recorder, exporter) = runtime.enter(|| self.build_with_exporter())?;
+        let (recorder, exporter) = {
+            let _guard = runtime.enter();
+            self.build_with_exporter()
+        }?;
         metrics::set_boxed_recorder(Box::new(recorder))?;
 
         thread::Builder::new()


### PR DESCRIPTION
I made these changes in service of removing old Tokio versions from our dep tree.  Until Hyper 0.14 is released I'm not sure whether you'd want to merge them and accept the git dependency on Hyper.