### PR TITLE
Update hdrhistogram dependency

### DIFF
--- a/metrics-benchmark/Cargo.toml
+++ b/metrics-benchmark/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 log = "0.4"
 env_logger = "0.8"
 getopts = "0.2"
-hdrhistogram = "7.0"
+hdrhistogram = "7.2"
 quanta = "0.6"
 atomic-shim = "0.1"
 metrics = { version = "0.13.0-alpha.8", path = "../metrics" }

--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -8,4 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 ### Added
-- Effective birth of the crate.
+- Update hdrhistogram dependency to 7.2

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -22,7 +22,7 @@ tokio-exporter = ["hyper", "tokio"]
 [dependencies]
 metrics = { version = "0.13.0-alpha.8", path = "../metrics" }
 metrics-util = { version = "0.4.0-alpha.6", path = "../metrics-util" }
-hdrhistogram = "7.1"
+hdrhistogram = "7.2"
 parking_lot = "0.11"
 thiserror = "1.0"
 quanta = "0.6"

--- a/metrics-observer/CHANGELOG.md
+++ b/metrics-observer/CHANGELOG.md
@@ -8,4 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 ### Added
-- Effective birth of the crate.
+- Update hdrhistogram dependency to 7.2

--- a/metrics-observer/Cargo.toml
+++ b/metrics-observer/Cargo.toml
@@ -15,7 +15,7 @@ prost = "0.6"
 prost-types = "0.6"
 tui = "0.12"
 termion = "1.5"
-hdrhistogram = "7.1"
+hdrhistogram = "7.2"
 evmap = "10.0"
 chrono = "0.4"
 metrics = { version = "0.13.0-alpha.8", path = "../metrics" }


### PR DESCRIPTION
[hdrhistogram 7.2.0](https://github.com/HdrHistogram/HdrHistogram_rust/blob/master/CHANGELOG.md#720---2020-11-29) was recently released. This bumps that dependency. I noticed because its leading to a duplicate dependency in one of @EmbarkStudios projects.