### PR TITLE
Fix macro documentation by removing proc-macro-hack.

### DIFF
--- a/metrics-exporter-tcp/Cargo.toml
+++ b/metrics-exporter-tcp/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["metrics", "telemetry", "tcp"]
 
 [dependencies]
 metrics = { version = "0.13.0-alpha.8", path = "../metrics", features = ["std"] }
-bytes = "0.6"
+bytes = "0.5"
 crossbeam-channel = "0.5"
 prost = "0.6"
 prost-types = "0.6"

--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -3,7 +3,6 @@ extern crate proc_macro;
 use self::proc_macro::TokenStream;
 
 use lazy_static::lazy_static;
-use proc_macro_hack::proc_macro_hack;
 use quote::{format_ident, quote, ToTokens};
 use regex::Regex;
 use syn::parse::discouraged::Speculative;
@@ -144,7 +143,7 @@ impl Parse for Registration {
     }
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn register_counter(input: TokenStream) -> TokenStream {
     let Registration {
         key,
@@ -156,7 +155,7 @@ pub fn register_counter(input: TokenStream) -> TokenStream {
     get_expanded_registration("counter", key, unit, description, labels).into()
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn register_gauge(input: TokenStream) -> TokenStream {
     let Registration {
         key,
@@ -168,7 +167,7 @@ pub fn register_gauge(input: TokenStream) -> TokenStream {
     get_expanded_registration("gauge", key, unit, description, labels).into()
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn register_histogram(input: TokenStream) -> TokenStream {
     let Registration {
         key,
@@ -180,7 +179,7 @@ pub fn register_histogram(input: TokenStream) -> TokenStream {
     get_expanded_registration("histogram", key, unit, description, labels).into()
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn increment(input: TokenStream) -> TokenStream {
     let WithoutExpression { key, labels } = parse_macro_input!(input as WithoutExpression);
 
@@ -189,7 +188,7 @@ pub fn increment(input: TokenStream) -> TokenStream {
     get_expanded_callsite("counter", "increment", key, labels, op_value).into()
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn counter(input: TokenStream) -> TokenStream {
     let WithExpression {
         key,
@@ -200,7 +199,7 @@ pub fn counter(input: TokenStream) -> TokenStream {
     get_expanded_callsite("counter", "increment", key, labels, op_value).into()
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn gauge(input: TokenStream) -> TokenStream {
     let WithExpression {
         key,
@@ -211,7 +210,7 @@ pub fn gauge(input: TokenStream) -> TokenStream {
     get_expanded_callsite("gauge", "update", key, labels, op_value).into()
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn histogram(input: TokenStream) -> TokenStream {
     let WithExpression {
         key,

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -218,8 +218,6 @@
 
 extern crate alloc;
 
-use proc_macro_hack::proc_macro_hack;
-
 mod common;
 pub use self::common::*;
 
@@ -275,7 +273,6 @@ pub use self::recorder::*;
 /// register_counter!("some_metric_name", &labels);
 /// # }
 /// ```
-#[proc_macro_hack]
 pub use metrics_macros::register_counter;
 
 /// Registers a gauge.
@@ -319,7 +316,6 @@ pub use metrics_macros::register_counter;
 /// register_gauge!("some_metric_name", &labels);
 /// # }
 /// ```
-#[proc_macro_hack]
 pub use metrics_macros::register_gauge;
 
 /// Records a histogram.
@@ -363,7 +359,6 @@ pub use metrics_macros::register_gauge;
 /// register_histogram!("some_metric_name", &labels);
 /// # }
 /// ```
-#[proc_macro_hack]
 pub use metrics_macros::register_histogram;
 
 /// Increments a counter by one.
@@ -387,7 +382,6 @@ pub use metrics_macros::register_histogram;
 /// increment!("some_metric_name", &labels);
 /// # }
 /// ```
-#[proc_macro_hack]
 pub use metrics_macros::increment;
 
 /// Increments a counter.
@@ -411,7 +405,6 @@ pub use metrics_macros::increment;
 /// counter!("some_metric_name", 12, &labels);
 /// # }
 /// ```
-#[proc_macro_hack]
 pub use metrics_macros::counter;
 
 /// Updates a gauge.
@@ -435,7 +428,6 @@ pub use metrics_macros::counter;
 /// gauge!("some_metric_name", 42.42, &labels);
 /// # }
 /// ```
-#[proc_macro_hack]
 pub use metrics_macros::gauge;
 
 /// Records a histogram.
@@ -472,5 +464,4 @@ pub use metrics_macros::gauge;
 /// histogram!("some_metric_name", 1337, &labels);
 /// # }
 /// ```
-#[proc_macro_hack]
 pub use metrics_macros::histogram;

--- a/metrics/tests/macros/02_metric_name.stderr
+++ b/metrics/tests/macros/02_metric_name.stderr
@@ -3,5 +3,3 @@ error: metric name must match ^[a-zA-Z][a-zA-Z0-9_:.]*$
   |
 8 |     counter!("abc$def");
   |              ^^^^^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Given that `#[proc_macro]` is now valid for expression position usage in 1.45 and above, and our MSRV is 1.46, we're getting rid of `proc-macro-hack` which in turn will fix #132 by allowing the same function docs to work for IDEs as well as docs.rs.