### PR TITLE
Upgrade criterion invocations to the modern form

### DIFF
--- a/metrics-tracing-context/benches/layer.rs
+++ b/metrics-tracing-context/benches/layer.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use metrics::{Key, KeyData, Label, NoopRecorder, Recorder, SharedString};
 use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 use metrics_util::layers::Layer;
@@ -9,30 +9,18 @@ use tracing::{
 use tracing_subscriber::{layer::SubscriberExt, Registry};
 
 fn layer_benchmark(c: &mut Criterion) {
-    c.bench(
-        "layer",
-        Benchmark::new("all/enhance_key", |b| {
-            let subscriber = Registry::default().with(MetricsLayer::new());
-            let dispatcher = Dispatch::new(subscriber);
-            with_default(&dispatcher, || {
-                let user = "ferris";
-                let email = "ferris@rust-lang.org";
-                let span = span!(Level::TRACE, "login", user, user.email = email);
-                let _guard = span.enter();
+    let mut group = c.benchmark_group("layer");
+    group.bench_function("all/enhance_key", |b| {
+        let subscriber = Registry::default().with(MetricsLayer::new());
+        let dispatcher = Dispatch::new(subscriber);
+        with_default(&dispatcher, || {
+            let user = "ferris";
+            let email = "ferris@rust-lang.org";
+            let span = span!(Level::TRACE, "login", user, user.email = email);
+            let _guard = span.enter();
 
-                let tracing_layer = TracingContextLayer::all();
-                let recorder = tracing_layer.layer(NoopRecorder);
-                static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
-                static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-                static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
-
-                b.iter(|| {
-                    recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
-                })
-            })
-        })
-        .with_function("noop recorder overhead (increment_counter)", |b| {
-            let recorder = NoopRecorder;
+            let tracing_layer = TracingContextLayer::all();
+            let recorder = tracing_layer.layer(NoopRecorder);
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
@@ -40,8 +28,19 @@ fn layer_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
             })
-        }),
-    );
+        })
+    });
+    group.bench_function("noop recorder overhead (increment_counter)", |b| {
+        let recorder = NoopRecorder;
+        static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
+        static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
+        static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+
+        b.iter(|| {
+            recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+        })
+    });
+    group.finish();
 }
 
 criterion_group!(benches, layer_benchmark);

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BatchSize, Benchmark, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use metrics_tracing_context::Labels;
 use tracing::Metadata;
 use tracing_core::{
@@ -21,138 +21,137 @@ static CALLSITE_METADATA: Metadata = metadata! {
 };
 
 fn visit_benchmark(c: &mut Criterion) {
-    c.bench(
-        "visit",
-        Benchmark::new("record_str", |b| {
-            let field = CALLSITE
-                .metadata()
-                .fields()
-                .field("test")
-                .expect("test field missing");
-            b.iter_batched_ref(
-                || Labels(Vec::with_capacity(BATCH_SIZE)),
-                |labels| {
-                    labels.record_str(&field, "test test");
-                },
-                BatchSize::NumIterations(BATCH_SIZE as u64),
-            )
-        })
-        .with_function("record_bool[true]", |b| {
-            let field = CALLSITE
-                .metadata()
-                .fields()
-                .field("test")
-                .expect("test field missing");
-            b.iter_batched_ref(
-                || Labels(Vec::with_capacity(BATCH_SIZE)),
-                |labels| {
-                    labels.record_bool(&field, true);
-                },
-                BatchSize::NumIterations(BATCH_SIZE as u64),
-            )
-        })
-        .with_function("record_bool[false]", |b| {
-            let field = CALLSITE
-                .metadata()
-                .fields()
-                .field("test")
-                .expect("test field missing");
-            b.iter_batched_ref(
-                || Labels(Vec::with_capacity(BATCH_SIZE)),
-                |labels| {
-                    labels.record_bool(&field, false);
-                },
-                BatchSize::NumIterations(BATCH_SIZE as u64),
-            )
-        })
-        .with_function("record_i64", |b| {
-            let field = CALLSITE
-                .metadata()
-                .fields()
-                .field("test")
-                .expect("test field missing");
-            b.iter_batched_ref(
-                || Labels(Vec::with_capacity(BATCH_SIZE)),
-                |labels| {
-                    labels.record_i64(&field, -3423432);
-                },
-                BatchSize::NumIterations(BATCH_SIZE as u64),
-            )
-        })
-        .with_function("record_u64", |b| {
-            let field = CALLSITE
-                .metadata()
-                .fields()
-                .field("test")
-                .expect("test field missing");
-            b.iter_batched_ref(
-                || Labels(Vec::with_capacity(BATCH_SIZE)),
-                |labels| {
-                    labels.record_u64(&field, 3423432);
-                },
-                BatchSize::NumIterations(BATCH_SIZE as u64),
-            )
-        })
-        .with_function("record_debug", |b| {
-            let debug_struct = DebugStruct::new();
-            let field = CALLSITE
-                .metadata()
-                .fields()
-                .field("test")
-                .expect("test field missing");
-            b.iter_batched_ref(
-                || Labels(Vec::with_capacity(BATCH_SIZE)),
-                |labels| {
-                    labels.record_debug(&field, &debug_struct);
-                },
-                BatchSize::NumIterations(BATCH_SIZE as u64),
-            )
-        })
-        .with_function("record_debug[bool]", |b| {
-            let field = CALLSITE
-                .metadata()
-                .fields()
-                .field("test")
-                .expect("test field missing");
-            b.iter_batched_ref(
-                || Labels(Vec::with_capacity(BATCH_SIZE)),
-                |labels| {
-                    labels.record_debug(&field, &true);
-                },
-                BatchSize::NumIterations(BATCH_SIZE as u64),
-            )
-        })
-        .with_function("record_debug[i64]", |b| {
-            let value: i64 = -3423432;
-            let field = CALLSITE
-                .metadata()
-                .fields()
-                .field("test")
-                .expect("test field missing");
-            b.iter_batched_ref(
-                || Labels(Vec::with_capacity(BATCH_SIZE)),
-                |labels| {
-                    labels.record_debug(&field, &value);
-                },
-                BatchSize::NumIterations(BATCH_SIZE as u64),
-            )
-        })
-        .with_function("record_debug[u64]", |b| {
-            let value: u64 = 3423432;
-            let field = CALLSITE
-                .metadata()
-                .fields()
-                .field("test")
-                .expect("test field missing");
-            b.iter_batched_ref(
-                || Labels(Vec::with_capacity(BATCH_SIZE)),
-                |labels| {
-                    labels.record_debug(&field, &value);
-                },
-                BatchSize::NumIterations(BATCH_SIZE as u64),
-            )
-        }),
-    );
+    let mut group = c.benchmark_group("visit");
+    group.bench_function("record_str", |b| {
+        let field = CALLSITE
+            .metadata()
+            .fields()
+            .field("test")
+            .expect("test field missing");
+        b.iter_batched_ref(
+            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            |labels| {
+                labels.record_str(&field, "test test");
+            },
+            BatchSize::NumIterations(BATCH_SIZE as u64),
+        )
+    });
+    group.bench_function("record_bool[true]", |b| {
+        let field = CALLSITE
+            .metadata()
+            .fields()
+            .field("test")
+            .expect("test field missing");
+        b.iter_batched_ref(
+            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            |labels| {
+                labels.record_bool(&field, true);
+            },
+            BatchSize::NumIterations(BATCH_SIZE as u64),
+        )
+    });
+    group.bench_function("record_bool[false]", |b| {
+        let field = CALLSITE
+            .metadata()
+            .fields()
+            .field("test")
+            .expect("test field missing");
+        b.iter_batched_ref(
+            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            |labels| {
+                labels.record_bool(&field, false);
+            },
+            BatchSize::NumIterations(BATCH_SIZE as u64),
+        )
+    });
+    group.bench_function("record_i64", |b| {
+        let field = CALLSITE
+            .metadata()
+            .fields()
+            .field("test")
+            .expect("test field missing");
+        b.iter_batched_ref(
+            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            |labels| {
+                labels.record_i64(&field, -3423432);
+            },
+            BatchSize::NumIterations(BATCH_SIZE as u64),
+        )
+    });
+    group.bench_function("record_u64", |b| {
+        let field = CALLSITE
+            .metadata()
+            .fields()
+            .field("test")
+            .expect("test field missing");
+        b.iter_batched_ref(
+            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            |labels| {
+                labels.record_u64(&field, 3423432);
+            },
+            BatchSize::NumIterations(BATCH_SIZE as u64),
+        )
+    });
+    group.bench_function("record_debug", |b| {
+        let debug_struct = DebugStruct::new();
+        let field = CALLSITE
+            .metadata()
+            .fields()
+            .field("test")
+            .expect("test field missing");
+        b.iter_batched_ref(
+            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            |labels| {
+                labels.record_debug(&field, &debug_struct);
+            },
+            BatchSize::NumIterations(BATCH_SIZE as u64),
+        )
+    });
+    group.bench_function("record_debug[bool]", |b| {
+        let field = CALLSITE
+            .metadata()
+            .fields()
+            .field("test")
+            .expect("test field missing");
+        b.iter_batched_ref(
+            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            |labels| {
+                labels.record_debug(&field, &true);
+            },
+            BatchSize::NumIterations(BATCH_SIZE as u64),
+        )
+    });
+    group.bench_function("record_debug[i64]", |b| {
+        let value: i64 = -3423432;
+        let field = CALLSITE
+            .metadata()
+            .fields()
+            .field("test")
+            .expect("test field missing");
+        b.iter_batched_ref(
+            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            |labels| {
+                labels.record_debug(&field, &value);
+            },
+            BatchSize::NumIterations(BATCH_SIZE as u64),
+        )
+    });
+    group.bench_function("record_debug[u64]", |b| {
+        let value: u64 = 3423432;
+        let field = CALLSITE
+            .metadata()
+            .fields()
+            .field("test")
+            .expect("test field missing");
+        b.iter_batched_ref(
+            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            |labels| {
+                labels.record_debug(&field, &value);
+            },
+            BatchSize::NumIterations(BATCH_SIZE as u64),
+        )
+    });
+    group.finish();
 }
 
 #[derive(Debug)]

--- a/metrics-util/benches/bucket.rs
+++ b/metrics-util/benches/bucket.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Benchmark, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use lazy_static::lazy_static;
 use metrics_util::AtomicBucket;
 
@@ -36,19 +36,18 @@ lazy_static! {
 }
 
 fn bucket_benchmark(c: &mut Criterion) {
-    c.bench(
-        "bucket",
-        Benchmark::new("write", |b| {
-            let bucket = AtomicBucket::new();
+    let mut group = c.benchmark_group("bucket");
+    group.throughput(Throughput::Elements(RANDOM_INTS.len() as u64));
+    group.bench_function("write", |b| {
+        let bucket = AtomicBucket::new();
 
-            b.iter(|| {
-                for value in RANDOM_INTS.iter() {
-                    bucket.push(value);
-                }
-            })
+        b.iter(|| {
+            for value in RANDOM_INTS.iter() {
+                bucket.push(value);
+            }
         })
-        .throughput(Throughput::Elements(RANDOM_INTS.len() as u64)),
-    );
+    });
+    group.finish();
 }
 
 criterion_group!(benches, bucket_benchmark);

--- a/metrics/benches/key.rs
+++ b/metrics/benches/key.rs
@@ -1,27 +1,26 @@
-use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use metrics::{NameParts, SharedString};
 
 fn key_benchmark(c: &mut Criterion) {
-    c.bench(
-        "key",
-        Benchmark::new("name_parts/to_string", |b| {
-            static NAME_PARTS: [SharedString; 2] = [
-                SharedString::const_str("part1"),
-                SharedString::const_str("part2"),
-            ];
-            let name = NameParts::from_static_names(&NAME_PARTS);
-            b.iter(|| name.to_string())
-        })
-        .with_function("name_parts/Display::to_string", |b| {
-            static NAME_PARTS: [SharedString; 2] = [
-                SharedString::const_str("part1"),
-                SharedString::const_str("part2"),
-            ];
-            let name = NameParts::from_static_names(&NAME_PARTS);
-            b.iter(|| std::fmt::Display::to_string(&name))
-        }),
-    );
+    let mut group = c.benchmark_group("key");
+    group.bench_function("name_parts/to_string", |b| {
+        static NAME_PARTS: [SharedString; 2] = [
+            SharedString::const_str("part1"),
+            SharedString::const_str("part2"),
+        ];
+        let name = NameParts::from_static_names(&NAME_PARTS);
+        b.iter(|| name.to_string())
+    });
+    group.bench_function("name_parts/Display::to_string", |b| {
+        static NAME_PARTS: [SharedString; 2] = [
+            SharedString::const_str("part1"),
+            SharedString::const_str("part2"),
+        ];
+        let name = NameParts::from_static_names(&NAME_PARTS);
+        b.iter(|| std::fmt::Display::to_string(&name))
+    });
+    group.finish();
 }
 
 criterion_group!(benches, key_benchmark);

--- a/metrics/benches/macros.rs
+++ b/metrics/benches/macros.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate criterion;
 
-use criterion::{Benchmark, Criterion};
+use criterion::Criterion;
 
 use metrics::{counter, GaugeValue, Key, Recorder, Unit};
 use rand::{thread_rng, Rng};
@@ -30,44 +30,43 @@ fn reset_recorder() {
 }
 
 fn macro_benchmark(c: &mut Criterion) {
-    c.bench(
-        "macros",
-        Benchmark::new("uninitialized/no_labels", |b| {
-            metrics::clear_recorder();
-            b.iter(|| {
-                counter!("counter_bench", 42);
-            })
+    let mut group = c.benchmark_group("macros");
+    group.bench_function("uninitialized/no_labels", |b| {
+        metrics::clear_recorder();
+        b.iter(|| {
+            counter!("counter_bench", 42);
         })
-        .with_function("uninitialized/with_static_labels", |b| {
-            metrics::clear_recorder();
-            b.iter(|| {
-                counter!("counter_bench", 42, "request" => "http", "svc" => "admin");
-            })
+    });
+    group.bench_function("uninitialized/with_static_labels", |b| {
+        metrics::clear_recorder();
+        b.iter(|| {
+            counter!("counter_bench", 42, "request" => "http", "svc" => "admin");
         })
-        .with_function("initialized/no_labels", |b| {
-            reset_recorder();
-            b.iter(|| {
-                counter!("counter_bench", 42);
-            });
-            metrics::clear_recorder();
-        })
-        .with_function("initialized/with_static_labels", |b| {
-            reset_recorder();
-            b.iter(|| {
-                counter!("counter_bench", 42, "request" => "http", "svc" => "admin");
-            });
-            metrics::clear_recorder();
-        })
-        .with_function("initialized/with_dynamic_labels", |b| {
-            let label_val = thread_rng().gen::<u64>().to_string();
+    });
+    group.bench_function("initialized/no_labels", |b| {
+        reset_recorder();
+        b.iter(|| {
+            counter!("counter_bench", 42);
+        });
+        metrics::clear_recorder();
+    });
+    group.bench_function("initialized/with_static_labels", |b| {
+        reset_recorder();
+        b.iter(|| {
+            counter!("counter_bench", 42, "request" => "http", "svc" => "admin");
+        });
+        metrics::clear_recorder();
+    });
+    group.bench_function("initialized/with_dynamic_labels", |b| {
+        let label_val = thread_rng().gen::<u64>().to_string();
 
-            reset_recorder();
-            b.iter(move || {
-                counter!("counter_bench", 42, "request" => "http", "uid" => label_val.clone());
-            });
-            metrics::clear_recorder();
-        }),
-    );
+        reset_recorder();
+        b.iter(move || {
+            counter!("counter_bench", 42, "request" => "http", "uid" => label_val.clone());
+        });
+        metrics::clear_recorder();
+    });
+    group.finish();
 }
 
 criterion_group!(benches, macro_benchmark);


### PR DESCRIPTION
The old legacy form really confuses me, so I decided to do this first before adding more benchmarks (something that I'm really aiming to do).

No changes besides rewriting the invocation form.