### PR TITLE
Change listening address for tcp and prometheus

### DIFF
--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -38,7 +38,7 @@ impl PrometheusBuilder {
         let quantiles = parse_quantiles(&[0.0, 0.5, 0.9, 0.95, 0.99, 0.999, 1.0]);
 
         Self {
-            listen_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9000),
+            listen_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9000),
             quantiles,
             buckets: None,
             bucket_overrides: None,
@@ -51,7 +51,7 @@ impl PrometheusBuilder {
     ///
     /// The HTTP listener that is spawned will respond to GET requests on any request path.
     ///
-    /// Defaults to `127.0.0.1:9000`.
+    /// Defaults to `0.0.0.0:9000`.
     pub fn listen_address(mut self, addr: impl Into<SocketAddr>) -> Self {
         self.listen_address = addr.into();
         self

--- a/metrics-exporter-tcp/src/lib.rs
+++ b/metrics-exporter-tcp/src/lib.rs
@@ -166,7 +166,7 @@ impl TcpBuilder {
     /// Creates a new `TcpBuilder`.
     pub fn new() -> TcpBuilder {
         TcpBuilder {
-            listen_addr: ([127, 0, 0, 1], 5000).into(),
+            listen_addr: ([0, 0, 0, 0], 5000).into(),
             buffer_size: Some(1024),
         }
     }
@@ -176,7 +176,7 @@ impl TcpBuilder {
     /// The exporter will accept connections on this address and immediately begin forwarding
     /// metrics to the client.
     ///
-    /// Defaults to `127.0.0.1:5000`.
+    /// Defaults to `0.0.0.0:5000`.
     pub fn listen_address<A>(mut self, addr: A) -> TcpBuilder
     where
         A: Into<SocketAddr>,


### PR DESCRIPTION
By setting the default listening address to localhost the servers
sending out the metrics can only respond to other local connections.
This means that when you have another service consuming the metrics
endpoint most users will have to change the default address to one which
can accept extern connections.

This PR changes the listening address to 0.0.0.0:PORT that way when
deploying or running different things in different networks the metrics
consumer can still consume with the default address. This came from
wondering why things stopped working when I moved a local test to
docker-compose instead of just running directly on the host system.