### PR TITLE
Fix compile errors and warnings when compiling prometheus exporter without default features

### DIFF
--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -6,7 +6,9 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::thread;
 use std::time::Duration;
 
-use crate::common::{InstallError, Matcher};
+#[cfg(feature = "tokio-exporter")]
+use crate::common::InstallError;
+use crate::common::Matcher;
 use crate::distribution::DistributionBuilder;
 use crate::recorder::{Inner, PrometheusRecorder};
 

--- a/metrics-exporter-prometheus/src/common.rs
+++ b/metrics-exporter-prometheus/src/common.rs
@@ -3,7 +3,6 @@ use std::io;
 
 use crate::distribution::Distribution;
 
-use hyper::Error as HyperError;
 use metrics::SetRecorderError;
 use thiserror::Error as ThisError;
 
@@ -42,7 +41,7 @@ pub enum InstallError {
     /// Binding/listening to the given address did not succeed.
     #[cfg(feature = "tokio-exporter")]
     #[error("failed to bind to given listen address: {0}")]
-    Hyper(#[from] HyperError),
+    Hyper(#[from] hyper::Error),
 
     /// Installing the recorder did not succeed.
     #[error("failed to install exporter as global recorder: {0}")]


### PR DESCRIPTION
I was trying to use `metrics-exporter-prometheus` with `default-features = false` in my project and got these compile errors/warnings:

```
error[E0432]: unresolved import `hyper`
 --> metrics-exporter-prometheus\src\common.rs:6:5
  |
6 | use hyper::Error as HyperError;
  |     ^^^^^ use of undeclared crate or module `hyper`

warning: unused import: `InstallError`
 --> metrics-exporter-prometheus\src\builder.rs:9:21
  |
9 | use crate::common::{InstallError, Matcher};
  |                     ^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error: aborting due to previous error; 1 warning emitted
```

This PR fixes those errors, the project compiles fine with no default flags now.