### PR TITLE
Composite registers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "metrics",
   "metrics-macros",
   "metrics-util",
+  "metrics-exporter-composite",
   "metrics-exporter-tcp",
   "metrics-exporter-prometheus",
   "metrics-tracing-context",

--- a/README.md
+++ b/README.md
@@ -49,24 +49,36 @@ Overall, this repository is home to the following crates:
 
 * [`metrics`][metrics]: A lightweight metrics facade, similar to [`log`][log].
 * [`metrics-macros`][metrics-macros]: Procedural macros that power `metrics`.
-* [`metrics-tracing-context`][metrics-tracing-context]: Allow capturing [`tracing`][tracing] span
-  fields as metric labels.
+* [`metrics-tracing-context`][metrics-tracing-context]: Allow capturing [`tracing`][tracing] span fields as metric
+  labels.
+* [`metrics-exporter-composite`][metrics-exporter-composite]: Enables the exporting of metrics to multiple destinations.
 * [`metrics-exporter-tcp`][metrics-exporter-tcp]: A `metrics`-compatible exporter for serving metrics over TCP.
-* [`metrics-exporter-prometheus`][metrics-exporter-prometheus]: A `metrics`-compatible exporter for
-  serving a Prometheus scrape endpoint.
+* [`metrics-exporter-prometheus`][metrics-exporter-prometheus]: A `metrics`-compatible exporter for serving a Prometheus
+  scrape endpoint.
 * [`metrics-util`][metrics-util]: Helper types/functions used by the `metrics` ecosystem.
 
 # contributing
 
-We're always looking for users who have thoughts on how to make `metrics` better, or users with interesting use cases.  Of course, we're also happy to accept code contributions for outstanding feature requests! 😀
+We're always looking for users who have thoughts on how to make `metrics` better, or users with interesting use cases.
+Of course, we're also happy to accept code contributions for outstanding feature requests! 😀
 
-We'd love to chat about any of the above, or anything else, really!  You can find us over on [Discord](https://discord.gg/eTwKyY9).
+We'd love to chat about any of the above, or anything else, really!  You can find us over
+on [Discord](https://discord.gg/eTwKyY9).
 
 [metrics]: https://github.com/metrics-rs/metrics/tree/main/metrics
+
 [metrics-macros]: https://github.com/metrics-rs/metrics/tree/main/metrics-macros
+
 [metrics-tracing-context]: https://github.com/metrics-rs/metrics/tree/main/metrics-tracing-context
+
+[metrics-exporter-composite]: https://github.com/metrics-rs/metrics/tree/main/metrics-exporter-composite
+
 [metrics-exporter-tcp]: https://github.com/metrics-rs/metrics/tree/main/metrics-exporter-tcp
+
 [metrics-exporter-prometheus]: https://github.com/metrics-rs/metrics/tree/main/metrics-exporter-prometheus
+
 [metrics-util]: https://github.com/metrics-rs/metrics/tree/main/metrics-util
+
 [log]: https://docs.rs/log
+
 [tracing]: https://tracing.rs

--- a/metrics-exporter-composite/Cargo.toml
+++ b/metrics-exporter-composite/Cargo.toml
@@ -22,6 +22,7 @@ metrics-util = { version = "^0.5", path = "../metrics-util" }
 
 
 [dev-dependencies]
+mockall = "0.9.0"
 quanta = "0.7"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/metrics-exporter-composite/Cargo.toml
+++ b/metrics-exporter-composite/Cargo.toml
@@ -23,7 +23,3 @@ metrics-util = { version = "^0.5", path = "../metrics-util" }
 
 [dev-dependencies]
 mockall = "0.9.0"
-quanta = "0.7"
-tracing = "0.1"
-tracing-subscriber = "0.2"
-rand = "0.8"

--- a/metrics-exporter-composite/Cargo.toml
+++ b/metrics-exporter-composite/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "metrics-exporter-composite"
+version = "0.0.1"
+authors = ["Ashton Kemerling <ashtonkemerling@protonmail.com>"]
+edition = "2018"
+
+license = "MIT"
+
+description = "Composite recorders to allow multiple metrics exporters to be used"
+homepage = "https://github.com/metrics-rs/metrics"
+repository = "https://github.com/metrics-rs/metrics"
+documentation = "https://docs.rs/metrics-exporter-prometheus"
+readme = "README.md"
+
+categories = ["development-tools::debugging"]
+keywords = ["metrics", "telemetry"]
+
+
+[dependencies]
+metrics = { version = "0.13", path = "../metrics" }
+metrics-util = { version = "^0.5", path = "../metrics-util" }
+
+
+[dev-dependencies]
+quanta = "0.7"
+tracing = "0.1"
+tracing-subscriber = "0.2"
+rand = "0.8"

--- a/metrics-exporter-composite/README.md
+++ b/metrics-exporter-composite/README.md
@@ -1,0 +1,26 @@
+# metrics-exporter-composite
+
+[![conduct-badge][]][conduct] [![downloads-badge][] ![release-badge][]][crate] [![docs-badge][]][docs] [![license-badge][]](#license)
+
+[conduct-badge]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
+
+[downloads-badge]: https://img.shields.io/crates/d/metrics-exporter-composite.svg
+
+[release-badge]: https://img.shields.io/crates/v/metrics-exporter-composite.svg
+
+[license-badge]: https://img.shields.io/crates/l/metrics-exporter-composite.svg
+
+[docs-badge]: https://docs.rs/metrics-exporter-composite/badge.svg
+
+[conduct]: https://github.com/metrics-rs/metrics/blob/master/CODE_OF_CONDUCT.md
+
+[crate]: https://crates.io/crates/metrics-exporter-composite
+
+[docs]: https://docs.rs/metrics-exporter-composite
+
+__metrics-exporter-prometheus__ contains several `metrics`-compatible exporters to allow you to export metrics to
+multiple destinations.
+
+## code of conduct
+
+**NOTE**: All conversations and contributions to this project shall adhere to the [Code of Conduct][conduct].

--- a/metrics-exporter-composite/src/composite_recorder.rs
+++ b/metrics-exporter-composite/src/composite_recorder.rs
@@ -68,3 +68,140 @@ impl Recorder for CompositeRecorder {
             .for_each(|recorder| recorder.record_histogram(key.clone(), value.clone()));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use mockall::mock;
+    use mockall::predicate::eq;
+
+    use metrics::KeyData;
+
+    use super::*;
+
+    mock! {
+        pub TestRecorder{}
+        impl Recorder for TestRecorder {
+            fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>);
+            fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>);
+            fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>);
+            fn increment_counter(&self, key: Key, value: u64);
+            fn update_gauge(&self, key: Key, value: GaugeValue);
+            fn record_histogram(&self, key: Key, value: f64);
+        }
+    }
+
+    #[test]
+    pub fn test_install() {
+        assert!(metrics::try_recorder().is_none());
+
+        let base_recorder = MockTestRecorder::new();
+        CompositeRecorderBuilder::new()
+            .add_recorder(base_recorder)
+            .install()
+            .expect("Should install");
+
+        assert!(metrics::try_recorder().is_some());
+    }
+
+    #[test]
+    fn test_register_counter() {
+        let key = Key::from(KeyData::from_name("counter"));
+        let mut base_recorder = MockTestRecorder::new();
+        base_recorder
+            .expect_register_counter()
+            .times(1)
+            .with(eq(key.clone()), eq(None), eq(None))
+            .return_const(());
+        let composite = CompositeRecorderBuilder::new()
+            .add_recorder(base_recorder)
+            .build();
+
+        composite.register_counter(key.clone(), None, None);
+    }
+
+    #[test]
+    fn test_increment_counter() {
+        let key = Key::from(KeyData::from_name("counter"));
+        let mut base_recorder = MockTestRecorder::new();
+        base_recorder.expect_register_counter().return_const(());
+        base_recorder
+            .expect_increment_counter()
+            .times(1)
+            .with(eq(key.clone()), eq(42))
+            .return_const(());
+        let composite = CompositeRecorderBuilder::new()
+            .add_recorder(base_recorder)
+            .build();
+
+        composite.register_counter(key.clone(), None, None);
+        composite.increment_counter(key.clone(), 42);
+    }
+
+    #[test]
+    fn test_register_gauge() {
+        let key = Key::from(KeyData::from_name("gauge"));
+        let mut base_recorder = MockTestRecorder::new();
+        base_recorder
+            .expect_register_gauge()
+            .times(1)
+            .with(eq(key.clone()), eq(None), eq(None))
+            .return_const(());
+        let composite = CompositeRecorderBuilder::new()
+            .add_recorder(base_recorder)
+            .build();
+
+        composite.register_gauge(key.clone(), None, None);
+    }
+
+    #[test]
+    fn test_update_gauge() {
+        let key = Key::from(KeyData::from_name("counter"));
+        let mut base_recorder = MockTestRecorder::new();
+        base_recorder.expect_register_gauge().return_const(());
+        base_recorder
+            .expect_update_gauge()
+            .times(1)
+            .with(eq(key.clone()), eq(GaugeValue::Absolute(42.0)))
+            .return_const(());
+        let composite = CompositeRecorderBuilder::new()
+            .add_recorder(base_recorder)
+            .build();
+
+        composite.register_gauge(key.clone(), None, None);
+        composite.update_gauge(key.clone(), GaugeValue::Absolute(42.0));
+    }
+
+    #[test]
+    fn test_register_histogram() {
+        let key = Key::from(KeyData::from_name("histogram"));
+        let mut base_recorder = MockTestRecorder::new();
+        base_recorder
+            .expect_register_histogram()
+            .times(1)
+            .with(eq(key.clone()), eq(None), eq(None))
+            .return_const(());
+        let composite = CompositeRecorderBuilder::new()
+            .add_recorder(base_recorder)
+            .build();
+
+        composite.register_histogram(key.clone(), None, None);
+    }
+
+    #[test]
+    fn test_record_histogram() {
+        let key = Key::from(KeyData::from_name("counter"));
+        let mut base_recorder = MockTestRecorder::new();
+        base_recorder.expect_register_histogram().return_const(());
+        base_recorder
+            .expect_record_histogram()
+            .times(1)
+            .with(eq(key.clone()), eq(2.0))
+            .return_const(());
+        let composite = CompositeRecorderBuilder::new()
+            .add_recorder(base_recorder)
+            .build();
+
+        composite.register_histogram(key.clone(), None, None);
+        composite.record_histogram(key.clone(), 2.0);
+    }
+}

--- a/metrics-exporter-composite/src/composite_recorder.rs
+++ b/metrics-exporter-composite/src/composite_recorder.rs
@@ -1,14 +1,20 @@
 use metrics::{GaugeValue, Key, Recorder, SetRecorderError, Unit};
 
+/// Builder for creating composite reporters.
 pub struct CompositeRecorderBuilder {
     inner: Vec<Box<dyn Recorder + 'static>>,
 }
 
+/// Composite Recorder. Accepts multiple recorders and will proxy all registrations and metric
+/// events to them.
+///
+/// Useful if you wish to emit metrics to two locations for a migration.
 pub struct CompositeRecorder {
     inner: Vec<Box<dyn Recorder + 'static>>,
 }
 
 impl CompositeRecorderBuilder {
+    /// Add a new recorder to the composite recorder.
     pub fn add_recorder<R>(mut self, recorder: R) -> Self
     where
         R: Recorder + 'static,
@@ -17,14 +23,17 @@ impl CompositeRecorderBuilder {
         self
     }
 
+    /// Create a new CompositeRecorderBuilder
     pub fn new() -> CompositeRecorderBuilder {
         CompositeRecorderBuilder { inner: Vec::new() }
     }
 
+    /// Constructs the CompositeBuilder. Useful if you wish to manually call metrics::install.
     pub fn build(self) -> CompositeRecorder {
         CompositeRecorder { inner: self.inner }
     }
 
+    /// Construct and install this recorder.
     pub fn install(self) -> Result<(), SetRecorderError> {
         let recorder = self.build();
         metrics::set_boxed_recorder(Box::new(recorder))

--- a/metrics-exporter-composite/src/composite_recorder.rs
+++ b/metrics-exporter-composite/src/composite_recorder.rs
@@ -1,0 +1,70 @@
+use metrics::{GaugeValue, Key, Recorder, SetRecorderError, Unit};
+
+pub struct CompositeRecorderBuilder {
+    inner: Vec<Box<dyn Recorder + 'static>>,
+}
+
+pub struct CompositeRecorder {
+    inner: Vec<Box<dyn Recorder + 'static>>,
+}
+
+impl CompositeRecorderBuilder {
+    pub fn add_recorder<R>(mut self, recorder: R) -> Self
+    where
+        R: Recorder + 'static,
+    {
+        self.inner.push(Box::new(recorder));
+        self
+    }
+
+    pub fn new() -> CompositeRecorderBuilder {
+        CompositeRecorderBuilder { inner: Vec::new() }
+    }
+
+    pub fn build(self) -> CompositeRecorder {
+        CompositeRecorder { inner: self.inner }
+    }
+
+    pub fn install(self) -> Result<(), SetRecorderError> {
+        let recorder = self.build();
+        metrics::set_boxed_recorder(Box::new(recorder))
+    }
+}
+
+impl Recorder for CompositeRecorder {
+    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+        self.inner.iter().for_each(|recorder| {
+            recorder.register_counter(key.clone(), unit.clone(), description.clone())
+        });
+    }
+
+    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+        self.inner.iter().for_each(|recorder| {
+            recorder.register_gauge(key.clone(), unit.clone(), description.clone())
+        });
+    }
+
+    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+        self.inner.iter().for_each(|recorder| {
+            recorder.register_histogram(key.clone(), unit.clone(), description.clone())
+        });
+    }
+
+    fn increment_counter(&self, key: Key, value: u64) {
+        self.inner
+            .iter()
+            .for_each(|recorder| recorder.increment_counter(key.clone(), value.clone()));
+    }
+
+    fn update_gauge(&self, key: Key, value: GaugeValue) {
+        self.inner
+            .iter()
+            .for_each(|recorder| recorder.update_gauge(key.clone(), value.clone()));
+    }
+
+    fn record_histogram(&self, key: Key, value: f64) {
+        self.inner
+            .iter()
+            .for_each(|recorder| recorder.record_histogram(key.clone(), value.clone()));
+    }
+}

--- a/metrics-exporter-composite/src/lib.rs
+++ b/metrics-exporter-composite/src/lib.rs
@@ -1,0 +1,1 @@
+mod composite_recorder;

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -11,7 +11,7 @@ use crate::cow::Cow;
 pub type SharedString = Cow<'static, str>;
 
 /// Value of a gauge operation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum GaugeValue {
     /// Sets the value of the gauge to this value.
     Absolute(f64),


### PR DESCRIPTION
Quick PR for "composite" recorders. 

In my day job we recently needed to support two separate metrics locations with Micrometer (InfluxDB & DataDog). This struck me as a reasonable thing that one might need to do either for cost reasons (DD is expensive, so only put key metrics there), or for transition reasons. I'm planning on adding some filtering recorders soon, to make it easy to greenlight specific metrics for specific recorders. 

Docs are really lightweight since I figure you'll want to tweak them to your liking.