### PR TITLE
impl Ord/PartialOrd for key types

### DIFF
--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Added
+- Implemented `Ord`/`PartialOrd` for various key-related types.
 
 ## [0.14.1] - 2021-02-02
 ### Added

--- a/metrics/src/label.rs
+++ b/metrics/src/label.rs
@@ -11,7 +11,7 @@ use alloc::vec::Vec;
 /// the request currently being processed, or the request path being processed.  Another example may
 /// be that if you were running a piece o code that was turned on or off by a feature toggle, you may
 /// wish to include a label in metrics to indicate whether or not they were using the feature toggle.
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord)]
 pub struct Label(pub(crate) SharedString, pub(crate) SharedString);
 
 impl Label {


### PR DESCRIPTION
Allows for interoperability with structures like [`LruCache`](https://docs.rs/lru_time_cache/0.11.7/lru_time_cache/struct.LruCache.html).