### PR TITLE
Observer: Use `BTreeMap` as metrics storage to sort by key

### DIFF
--- a/metrics-observer/src/main.rs
+++ b/metrics-observer/src/main.rs
@@ -34,7 +34,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut terminal = Terminal::new(backend)?;
 
     let mut events = InputEvents::new();
-    let address = std::env::args().nth(1).unwrap_or_else(|| "127.0.0.1:5000".to_owned());
+    let address = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:5000".to_owned());
     let client = metrics_inner::Client::new(address);
     let mut selector = Selector::new();
 

--- a/metrics-observer/src/metrics.rs
+++ b/metrics-observer/src/metrics.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::Read;
 use std::net::TcpStream;
 use std::net::ToSocketAddrs;
@@ -37,14 +37,14 @@ pub enum MetricData {
 
 pub struct Client {
     state: Arc<Mutex<ClientState>>,
-    metrics: Arc<RwLock<HashMap<CompositeKey, MetricData>>>,
+    metrics: Arc<RwLock<BTreeMap<CompositeKey, MetricData>>>,
     metadata: Arc<RwLock<HashMap<(MetricKind, String), (Option<Unit>, Option<String>)>>>,
 }
 
 impl Client {
     pub fn new(addr: String) -> Client {
         let state = Arc::new(Mutex::new(ClientState::Disconnected(None)));
-        let metrics = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(RwLock::new(BTreeMap::new()));
         let metadata = Arc::new(RwLock::new(HashMap::new()));
         {
             let state = state.clone();
@@ -96,7 +96,7 @@ struct Runner {
     state: RunnerState,
     addr: String,
     client_state: Arc<Mutex<ClientState>>,
-    metrics: Arc<RwLock<HashMap<CompositeKey, MetricData>>>,
+    metrics: Arc<RwLock<BTreeMap<CompositeKey, MetricData>>>,
     metadata: Arc<RwLock<HashMap<(MetricKind, String), (Option<Unit>, Option<String>)>>>,
 }
 
@@ -104,7 +104,7 @@ impl Runner {
     pub fn new(
         addr: String,
         state: Arc<Mutex<ClientState>>,
-        metrics: Arc<RwLock<HashMap<CompositeKey, MetricData>>>,
+        metrics: Arc<RwLock<BTreeMap<CompositeKey, MetricData>>>,
         metadata: Arc<RwLock<HashMap<(MetricKind, String), (Option<Unit>, Option<String>)>>>,
     ) -> Runner {
         Runner {

--- a/metrics-util/src/key.rs
+++ b/metrics-util/src/key.rs
@@ -35,3 +35,15 @@ impl CompositeKey {
         (self.0, self.1)
     }
 }
+
+impl PartialOrd for CompositeKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.1.partial_cmp(&other.1)
+    }
+}
+
+impl Ord for CompositeKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.1.cmp(&other.1)
+    }
+}


### PR DESCRIPTION
This change allows preserving alphabetical order in the observer interface.