### PR TITLE
Relax atomic operations of `update_gauge` and `increment_counter`

### DIFF
--- a/metrics-util/src/handle.rs
+++ b/metrics-util/src/handle.rs
@@ -48,7 +48,7 @@ impl Handle {
     pub fn increment_counter(&self, value: u64) {
         match self {
             Handle::Counter(counter) => {
-                counter.fetch_add(value, Ordering::SeqCst);
+                counter.fetch_add(value, Ordering::Relaxed);
             }
             _ => panic!("tried to increment as counter"),
         }
@@ -60,7 +60,7 @@ impl Handle {
     pub fn update_gauge(&self, value: GaugeValue) {
         match self {
             Handle::Gauge(gauge) => {
-                let _ = gauge.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |curr| {
+                let _ = gauge.fetch_update(Ordering::AcqRel, Ordering::Relaxed, |curr| {
                     let input = f64::from_bits(curr);
                     let output = value.update_value(input);
                     Some(output.to_bits())


### PR DESCRIPTION
This commit relaxes the atomics of the aforementioned functions, removing the sync pressure on machines with large numbers of CPUs or ARM. As the reads of counters and gauges were formerly relaxed I believe this maintains the semantic intentions, though it is now possible for a writer to immediately read and "lose" the write temporarily if the read is done from a different CPU, in the case of the counter.

I noticed this while digging through https://github.com/timberio/vector/issues/6770. I haven't managed to test in our project because of https://github.com/timberio/vector/issues/6412.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>