### PR TITLE
metrics-util: fix soundness issue with AtomicBucket<T>

### DIFF
--- a/metrics-util/src/bucket.rs
+++ b/metrics-util/src/bucket.rs
@@ -96,8 +96,8 @@ impl<T> Block<T> {
     }
 }
 
-unsafe impl<T> Send for Block<T> {}
-unsafe impl<T> Sync for Block<T> {}
+unsafe impl<T: Send> Send for Block<T> {}
+unsafe impl<T: Sync> Sync for Block<T> {}
 
 impl<T> std::fmt::Debug for Block<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
As evidenced by #190, the current `Block<T>` unconditionally implements `Sync`/`Send`, which allows invariants of `T` to potentially be invalidated.

This PR properly constrains the `Sync`/`Send` implementations to `T: Sync` and `T: Send` respectively.