### PR TITLE
Experiment: switch to `&Key` for `Recorder`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 /.vscode
 perf.data*
 flamegraph.svg
+massif.*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/*.rs.bk
 Cargo.lock
 /.vscode
+perf.data*
+flamegraph.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
   "metrics-observer",
   "metrics-benchmark",
 ]
+
+[profile.release]
+debug = true

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -255,7 +255,7 @@ mod tests {
 
     use quanta::Clock;
 
-    use metrics::{GaugeValue, Key, KeyData, Label, Recorder};
+    use metrics::{GaugeValue, Key, Label, Recorder};
     use metrics_util::MetricKindMask;
 
     use super::{Matcher, PrometheusBuilder};
@@ -264,8 +264,8 @@ mod tests {
     fn test_render() {
         let recorder = PrometheusBuilder::new().build();
 
-        let key = Key::from(KeyData::from_name("basic_counter"));
-        recorder.increment_counter(key, 42);
+        let key = Key::from_name("basic_counter");
+        recorder.increment_counter(&key, 42);
 
         let handle = recorder.handle();
         let rendered = handle.render();
@@ -274,8 +274,8 @@ mod tests {
         assert_eq!(rendered, expected_counter);
 
         let labels = vec![Label::new("wutang", "forever")];
-        let key = Key::from(KeyData::from_parts("basic_gauge", labels));
-        recorder.update_gauge(key, GaugeValue::Absolute(-3.14));
+        let key = Key::from_parts("basic_gauge", labels);
+        recorder.update_gauge(&key, GaugeValue::Absolute(-3.14));
         let rendered = handle.render();
         let expected_gauge = format!(
             "{}# TYPE basic_gauge gauge\nbasic_gauge{{wutang=\"forever\"}} -3.14\n\n",
@@ -284,8 +284,8 @@ mod tests {
 
         assert_eq!(rendered, expected_gauge);
 
-        let key = Key::from(KeyData::from_name("basic_histogram"));
-        recorder.record_histogram(key, 12.0);
+        let key = Key::from_name("basic_histogram");
+        recorder.record_histogram(&key, 12.0);
         let rendered = handle.render();
 
         let histogram_data = concat!(
@@ -326,17 +326,17 @@ mod tests {
             .set_buckets(&DEFAULT_VALUES[..])
             .build();
 
-        let full_key = Key::from(KeyData::from_name("metrics_testing_foo"));
-        recorder.record_histogram(full_key, FULL_VALUES[0]);
+        let full_key = Key::from_name("metrics_testing_foo");
+        recorder.record_histogram(&full_key, FULL_VALUES[0]);
 
-        let prefix_key = Key::from(KeyData::from_name("metrics_testing_bar"));
-        recorder.record_histogram(prefix_key, PREFIX_VALUES[1]);
+        let prefix_key = Key::from_name("metrics_testing_bar");
+        recorder.record_histogram(&prefix_key, PREFIX_VALUES[1]);
 
-        let suffix_key = Key::from(KeyData::from_name("metrics_testin_foo"));
-        recorder.record_histogram(suffix_key, SUFFIX_VALUES[2]);
+        let suffix_key = Key::from_name("metrics_testin_foo");
+        recorder.record_histogram(&suffix_key, SUFFIX_VALUES[2]);
 
-        let default_key = Key::from(KeyData::from_name("metrics_wee"));
-        recorder.record_histogram(default_key, DEFAULT_VALUES[2] + 1.0);
+        let default_key = Key::from_name("metrics_wee");
+        recorder.record_histogram(&default_key, DEFAULT_VALUES[2] + 1.0);
 
         let full_data = concat!(
             "# TYPE metrics_testing_foo histogram\n",
@@ -395,11 +395,11 @@ mod tests {
             .idle_timeout(MetricKindMask::COUNTER, Some(Duration::from_secs(10)))
             .build_with_clock(clock);
 
-        let key = Key::from(KeyData::from_name("basic_counter"));
-        recorder.increment_counter(key, 42);
+        let key = Key::from_name("basic_counter");
+        recorder.increment_counter(&key, 42);
 
-        let key = Key::from(KeyData::from_name("basic_gauge"));
-        recorder.update_gauge(key, GaugeValue::Absolute(-3.14));
+        let key = Key::from_name("basic_gauge");
+        recorder.update_gauge(&key, GaugeValue::Absolute(-3.14));
 
         let handle = recorder.handle();
         let rendered = handle.render();
@@ -429,8 +429,8 @@ mod tests {
             .add_global_label("foo", "foo")
             .add_global_label("foo", "bar")
             .build();
-        let key = Key::from(KeyData::from_name("basic_counter"));
-        recorder.increment_counter(key, 42);
+        let key = Key::from_name("basic_counter");
+        recorder.increment_counter(&key, 42);
 
         let handle = recorder.handle();
         let rendered = handle.render();
@@ -445,11 +445,9 @@ mod tests {
             .add_global_label("foo", "foo")
             .build();
 
-        let key = Key::from(
-            KeyData::from_name("overridden")
-                .with_extra_labels(vec![Label::new("foo", "overridden")]),
-        );
-        recorder.increment_counter(key, 1);
+        let key = Key::from_name("overridden")
+            .with_extra_labels(vec![Label::new("foo", "overridden")]);
+        recorder.increment_counter(&key, 1);
 
         let handle = recorder.handle();
         let rendered = handle.render();

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -445,8 +445,8 @@ mod tests {
             .add_global_label("foo", "foo")
             .build();
 
-        let key = Key::from_name("overridden")
-            .with_extra_labels(vec![Label::new("foo", "overridden")]);
+        let key =
+            Key::from_name("overridden").with_extra_labels(vec![Label::new("foo", "overridden")]);
         recorder.increment_counter(&key, 1);
 
         let handle = recorder.handle();

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -226,32 +226,28 @@ impl From<Inner> for PrometheusRecorder {
 impl Recorder for PrometheusRecorder {
     fn register_counter(&self, key: &Key, _unit: Option<Unit>, description: Option<&'static str>) {
         self.add_description_if_missing(&key, description);
-        self.inner.registry().op(
-            MetricKind::Counter,
-            key,
-            |_| {},
-            Handle::counter,
-        );
+        self.inner
+            .registry()
+            .op(MetricKind::Counter, key, |_| {}, Handle::counter);
     }
 
     fn register_gauge(&self, key: &Key, _unit: Option<Unit>, description: Option<&'static str>) {
         self.add_description_if_missing(&key, description);
-        self.inner.registry().op(
-            MetricKind::Gauge,
-            key,
-            |_| {},
-            Handle::gauge,
-        );
+        self.inner
+            .registry()
+            .op(MetricKind::Gauge, key, |_| {}, Handle::gauge);
     }
 
-    fn register_histogram(&self, key: &Key, _unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_histogram(
+        &self,
+        key: &Key,
+        _unit: Option<Unit>,
+        description: Option<&'static str>,
+    ) {
         self.add_description_if_missing(&key, description);
-        self.inner.registry().op(
-            MetricKind::Histogram,
-            key,
-            |_| {},
-            Handle::histogram,
-        );
+        self.inner
+            .registry()
+            .op(MetricKind::Histogram, key, |_| {}, Handle::histogram);
     }
 
     fn increment_counter(&self, key: &Key, value: u64) {

--- a/metrics-exporter-tcp/src/lib.rs
+++ b/metrics-exporter-tcp/src/lib.rs
@@ -252,47 +252,47 @@ impl Default for TcpBuilder {
 impl TcpRecorder {
     fn register_metric(
         &self,
-        key: Key,
+        key: &Key,
         metric_type: MetricType,
         unit: Option<Unit>,
         description: Option<&'static str>,
     ) {
         let _ = self
             .tx
-            .try_send(Event::Metadata(key, metric_type, unit, description));
+            .try_send(Event::Metadata(key.clone(), metric_type, unit, description));
         self.state.wake();
     }
 
-    fn push_metric(&self, key: Key, value: MetricValue) {
+    fn push_metric(&self, key: &Key, value: MetricValue) {
         if self.state.should_send() {
-            let _ = self.tx.try_send(Event::Metric(key, value));
+            let _ = self.tx.try_send(Event::Metric(key.clone(), value));
             self.state.wake();
         }
     }
 }
 
 impl Recorder for TcpRecorder {
-    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         self.register_metric(key, MetricType::Counter, unit, description);
     }
 
-    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         self.register_metric(key, MetricType::Gauge, unit, description);
     }
 
-    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         self.register_metric(key, MetricType::Histogram, unit, description);
     }
 
-    fn increment_counter(&self, key: Key, value: u64) {
+    fn increment_counter(&self, key: &Key, value: u64) {
         self.push_metric(key, MetricValue::Counter(value));
     }
 
-    fn update_gauge(&self, key: Key, value: GaugeValue) {
+    fn update_gauge(&self, key: &Key, value: GaugeValue) {
         self.push_metric(key, MetricValue::Gauge(value));
     }
 
-    fn record_histogram(&self, key: Key, value: f64) {
+    fn record_histogram(&self, key: &Key, value: f64) {
         self.push_metric(key, MetricValue::Histogram(value));
     }
 }

--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -413,7 +413,7 @@ fn generate_metric_key(name: &Expr, labels: &Option<Labels>) -> (TokenStream2, T
         let labels = labels.as_ref().unwrap();
         let quoted_labels = labels_to_quoted(labels);
         quote! {
-            let key = metrics::Key::from_hybrid(&METRIC_NAME, #quoted_labels);
+            let key = metrics::Key::from_parts(&METRIC_NAME[..], #quoted_labels);
         }
     } else if !use_name_static && !use_labels_static {
         // The name is not static, and neither are the labels. Since `use_labels_static`
@@ -421,7 +421,7 @@ fn generate_metric_key(name: &Expr, labels: &Option<Labels>) -> (TokenStream2, T
         let labels = labels.as_ref().unwrap();
         let quoted_labels = labels_to_quoted(labels);
         quote! {
-            metrics::Key::from_parts(#name, #quoted_labels)
+            let key = metrics::Key::from_parts(#name, #quoted_labels);
         }
     } else {
         // The name is not static, but the labels are.  This could technically mean that there
@@ -429,11 +429,11 @@ fn generate_metric_key(name: &Expr, labels: &Option<Labels>) -> (TokenStream2, T
         // to figure out the correct key.
         if has_labels {
             quote! {
-                metrics::Key::from_static_labels(#name, &METRICS_LABELS)
+                let key = metrics::Key::from_static_labels(#name, &METRICS_LABELS)
             }
         } else {
             quote! {
-                metrics::Key::from_name(#name)
+                let key = metrics::Key::from_name(#name);
             }
         }
     };

--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -429,7 +429,7 @@ fn generate_metric_key(name: &Expr, labels: &Option<Labels>) -> (TokenStream2, T
         // to figure out the correct key.
         if has_labels {
             quote! {
-                let key = metrics::Key::from_static_labels(#name, &METRICS_LABELS)
+                let key = metrics::Key::from_static_labels(#name, &METRIC_LABELS);
             }
         } else {
             quote! {

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -228,7 +228,7 @@ fn test_get_expanded_callsite_owned_name_static_inline_labels() {
         "{ ",
         "static METRIC_LABELS : [metrics :: Label ; 1usize] = [metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "let key = metrics :: Key :: from_static_labels (String :: from (\"owned\") , & METRICS_LABELS) ; ",
+        "let key = metrics :: Key :: from_static_labels (String :: from (\"owned\") , & METRIC_LABELS) ; ",
         "recorder . myop_mytype (& key , 1) ; ",
         "} ",
         "}",

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -12,9 +12,9 @@ fn test_get_expanded_registration() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
-        "static METRIC_KEY : metrics :: KeyData = metrics :: KeyData :: from_static_name (& METRIC_NAME) ; ",
+        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_name (& METRIC_NAME) ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . register_mytype (metrics :: Key :: Borrowed (& METRIC_KEY) , None , None) ; ",
+        "recorder . register_mytype (& METRIC_KEY , None , None) ; ",
         "} ",
         "}",
     );
@@ -37,9 +37,9 @@ fn test_get_expanded_registration_with_unit() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
-        "static METRIC_KEY : metrics :: KeyData = metrics :: KeyData :: from_static_name (& METRIC_NAME) ; ",
+        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_name (& METRIC_NAME) ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . register_mytype (metrics :: Key :: Borrowed (& METRIC_KEY) , Some (metrics :: Unit :: Nanoseconds) , None) ; ",
+        "recorder . register_mytype (& METRIC_KEY , Some (metrics :: Unit :: Nanoseconds) , None) ; ",
         "} ",
         "}",
     );
@@ -61,9 +61,9 @@ fn test_get_expanded_registration_with_description() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
-        "static METRIC_KEY : metrics :: KeyData = metrics :: KeyData :: from_static_name (& METRIC_NAME) ; ",
+        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_name (& METRIC_NAME) ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . register_mytype (metrics :: Key :: Borrowed (& METRIC_KEY) , None , Some (\"flerkin\")) ; ",
+        "recorder . register_mytype (& METRIC_KEY , None , Some (\"flerkin\")) ; ",
         "} ",
         "}",
     );
@@ -86,9 +86,9 @@ fn test_get_expanded_registration_with_unit_and_description() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
-        "static METRIC_KEY : metrics :: KeyData = metrics :: KeyData :: from_static_name (& METRIC_NAME) ; ",
+        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_name (& METRIC_NAME) ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . register_mytype (metrics :: Key :: Borrowed (& METRIC_KEY) , Some (metrics :: Unit :: Nanoseconds) , Some (\"flerkin\")) ; ",
+        "recorder . register_mytype (& METRIC_KEY , Some (metrics :: Unit :: Nanoseconds) , Some (\"flerkin\")) ; ",
         "} ",
         "}",
     );
@@ -109,9 +109,9 @@ fn test_get_expanded_callsite_static_name_no_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
-        "static METRIC_KEY : metrics :: KeyData = metrics :: KeyData :: from_static_name (& METRIC_NAME) ; ",
+        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_name (& METRIC_NAME) ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Borrowed (& METRIC_KEY) , 1) ; ",
+        "recorder . myop_mytype (& METRIC_KEY , 1) ; ",
         "} }",
     );
 
@@ -133,9 +133,9 @@ fn test_get_expanded_callsite_static_name_static_inline_labels() {
         "{ ",
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
         "static METRIC_LABELS : [metrics :: Label ; 1usize] = [metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
-        "static METRIC_KEY : metrics :: KeyData = metrics :: KeyData :: from_static_parts (& METRIC_NAME , & METRIC_LABELS) ; ",
+        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_parts (& METRIC_NAME , & METRIC_LABELS) ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Borrowed (& METRIC_KEY) , 1) ; ",
+        "recorder . myop_mytype (& METRIC_KEY , 1) ; ",
         "} ",
         "}",
     );
@@ -158,9 +158,8 @@ fn test_get_expanded_callsite_static_name_dynamic_inline_labels() {
         "{ ",
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Owned (",
-        "metrics :: KeyData :: from_hybrid (& METRIC_NAME , vec ! [metrics :: Label :: new (\"key1\" , & value1)])",
-        ") , 1) ; ",
+        "let key = metrics :: Key :: from_parts (& METRIC_NAME [..] , vec ! [metrics :: Label :: new (\"key1\" , & value1)]) ; ",
+        "recorder . myop_mytype (& key , 1) ; ",
         "} ",
         "}",
     );
@@ -183,7 +182,8 @@ fn test_get_expanded_callsite_static_name_existing_labels() {
         "{ ",
         "static METRIC_NAME : [metrics :: SharedString ; 1] = [metrics :: SharedString :: const_str (\"mykeyname\")] ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Owned (metrics :: KeyData :: from_hybrid (& METRIC_NAME , mylabels)) , 1) ; ",
+        "let key = metrics :: Key :: from_parts (& METRIC_NAME [..] , mylabels) ; ",
+        "recorder . myop_mytype (& key , 1) ; ",
         "} ",
         "}",
     );
@@ -204,7 +204,8 @@ fn test_get_expanded_callsite_owned_name_no_labels() {
     let expected = concat!(
         "{ ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Owned (metrics :: KeyData :: from_name (String :: from (\"owned\"))) , 1) ; ",
+        "let key = metrics :: Key :: from_name (String :: from (\"owned\")) ; ",
+        "recorder . myop_mytype (& key , 1) ; ",
         "} ",
         "}",
     );
@@ -227,7 +228,8 @@ fn test_get_expanded_callsite_owned_name_static_inline_labels() {
         "{ ",
         "static METRIC_LABELS : [metrics :: Label ; 1usize] = [metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Owned (metrics :: KeyData :: from_static_labels (String :: from (\"owned\") , & METRIC_LABELS)) , 1) ; ",
+        "let key = metrics :: Key :: from_static_labels (String :: from (\"owned\") , & METRICS_LABELS) ; ",
+        "recorder . myop_mytype (& key , 1) ; ",
         "} ",
         "}",
     );
@@ -249,9 +251,8 @@ fn test_get_expanded_callsite_owned_name_dynamic_inline_labels() {
     let expected = concat!(
         "{ ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Owned (",
-        "metrics :: KeyData :: from_parts (String :: from (\"owned\") , vec ! [metrics :: Label :: new (\"key1\" , & value1)])",
-        ") , 1) ; ",
+        "let key = metrics :: Key :: from_parts (String :: from (\"owned\") , vec ! [metrics :: Label :: new (\"key1\" , & value1)]) ; ",
+        "recorder . myop_mytype (& key , 1) ; ",
         "} ",
         "}",
     );
@@ -273,7 +274,8 @@ fn test_get_expanded_callsite_owned_name_existing_labels() {
     let expected = concat!(
         "{ ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Owned (metrics :: KeyData :: from_parts (String :: from (\"owned\") , mylabels)) , 1) ; ",
+        "let key = metrics :: Key :: from_parts (String :: from (\"owned\") , mylabels) ; ",
+        "recorder . myop_mytype (& key , 1) ; ",
         "} ",
         "}",
     );

--- a/metrics-observer/src/metrics.rs
+++ b/metrics-observer/src/metrics.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use bytes::{BufMut, BytesMut};
 use prost::Message;
 
-use metrics::{KeyData, Label, Unit};
+use metrics::{Key, Label, Unit};
 use metrics_util::{CompositeKey, MetricKind, Summary};
 
 mod proto {
@@ -225,7 +225,7 @@ impl Runner {
                                         .into_iter()
                                         .map(|(k, v)| Label::new(k, v))
                                         .collect::<Vec<_>>();
-                                    let key_data: KeyData = (metric.name, labels).into();
+                                    let key_data: Key = (metric.name, labels).into();
 
                                     match metric.value.expect("no metric value") {
                                         proto::metric::Value::Counter(value) => {

--- a/metrics-tracing-context/benches/layer.rs
+++ b/metrics-tracing-context/benches/layer.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use metrics::{Key, KeyData, Label, NoopRecorder, Recorder, SharedString};
+use metrics::{Key, Label, NoopRecorder, Recorder, SharedString};
 use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 use metrics_util::layers::Layer;
 use tracing::{
@@ -14,10 +14,10 @@ fn layer_benchmark(c: &mut Criterion) {
         let recorder = NoopRecorder;
         static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
         static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-        static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+        static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
         b.iter(|| {
-            recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+            recorder.increment_counter(&KEY_DATA, 1);
         })
     });
     group.bench_function("no integration", |b| {
@@ -32,10 +32,10 @@ fn layer_benchmark(c: &mut Criterion) {
             let recorder = NoopRecorder;
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         })
     });
@@ -51,10 +51,10 @@ fn layer_benchmark(c: &mut Criterion) {
             let recorder = NoopRecorder;
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         })
     });
@@ -71,10 +71,10 @@ fn layer_benchmark(c: &mut Criterion) {
             let recorder = tracing_layer.layer(NoopRecorder);
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         })
     });
@@ -91,10 +91,10 @@ fn layer_benchmark(c: &mut Criterion) {
             let recorder = tracing_layer.layer(NoopRecorder);
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         })
     });

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -55,7 +55,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
 
-use metrics::{GaugeValue, Key, KeyData, Label, Recorder, Unit};
+use metrics::{GaugeValue, Key, Label, Recorder, Unit};
 use metrics_util::layers::Layer;
 use tracing::Span;
 
@@ -123,10 +123,10 @@ where
         });
     }
 
-    fn enhance_key(&self, key: Key) -> Key {
-        let (name, mut labels) = key.into_owned().into_parts();
+    fn enhance_key(&self, key: &Key) -> Key {
+        let (name, mut labels) = key.clone().into_parts();
         self.enhance_labels(&mut labels);
-        KeyData::from_parts(name, labels).into()
+        Key::from_parts(name, labels)
     }
 }
 
@@ -135,30 +135,30 @@ where
     R: Recorder,
     F: LabelFilter,
 {
-    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         self.inner.register_counter(key, unit, description)
     }
 
-    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         self.inner.register_gauge(key, unit, description)
     }
 
-    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         self.inner.register_histogram(key, unit, description)
     }
 
-    fn increment_counter(&self, key: Key, value: u64) {
+    fn increment_counter(&self, key: &Key, value: u64) {
         let key = self.enhance_key(key);
-        self.inner.increment_counter(key, value);
+        self.inner.increment_counter(&key, value);
     }
 
-    fn update_gauge(&self, key: Key, value: GaugeValue) {
+    fn update_gauge(&self, key: &Key, value: GaugeValue) {
         let key = self.enhance_key(key);
-        self.inner.update_gauge(key, value);
+        self.inner.update_gauge(&key, value);
     }
 
-    fn record_histogram(&self, key: Key, value: f64) {
+    fn record_histogram(&self, key: &Key, value: f64) {
         let key = self.enhance_key(key);
-        self.inner.record_histogram(key, value);
+        self.inner.record_histogram(&key, value);
     }
 }

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -154,10 +154,7 @@ fn test_macro_forms() {
             (
                 CompositeKey::new(
                     MetricKind::Counter,
-                    Key::from_static_parts(
-                        LOGIN_ATTEMPTS_STATIC,
-                        SVC_USER_EMAIL
-                    ),
+                    Key::from_static_parts(LOGIN_ATTEMPTS_STATIC, SVC_USER_EMAIL),
                 ),
                 None,
                 None,
@@ -166,10 +163,7 @@ fn test_macro_forms() {
             (
                 CompositeKey::new(
                     MetricKind::Counter,
-                    Key::from_static_parts(
-                        LOGIN_ATTEMPTS_DYNAMIC,
-                        NODE_USER_EMAIL
-                    ),
+                    Key::from_static_parts(LOGIN_ATTEMPTS_DYNAMIC, NODE_USER_EMAIL),
                 ),
                 None,
                 None,
@@ -178,10 +172,7 @@ fn test_macro_forms() {
             (
                 CompositeKey::new(
                     MetricKind::Counter,
-                    Key::from_static_parts(
-                        LOGIN_ATTEMPTS_BOTH,
-                        SVC_NODE_USER_EMAIL
-                    ),
+                    Key::from_static_parts(LOGIN_ATTEMPTS_BOTH, SVC_NODE_USER_EMAIL),
                 ),
                 None,
                 None,
@@ -205,10 +196,7 @@ fn test_no_labels() {
     assert_eq!(
         snapshot,
         vec![(
-            CompositeKey::new(
-                MetricKind::Counter,
-                Key::from_static_name(LOGIN_ATTEMPTS),
-            ),
+            CompositeKey::new(MetricKind::Counter, Key::from_static_name(LOGIN_ATTEMPTS),),
             None,
             None,
             DebugValue::Counter(1),

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -1,4 +1,4 @@
-use metrics::{counter, Key, KeyData, Label, SharedString};
+use metrics::{counter, Key, Label, SharedString};
 use metrics_tracing_context::{LabelFilter, MetricsLayer, TracingContextLayer};
 use metrics_util::{
     layers::Layer, CompositeKey, DebugValue, DebuggingRecorder, MetricKind, Snapshotter,
@@ -108,7 +108,7 @@ fn test_basic_functionality() {
         vec![(
             CompositeKey::new(
                 MetricKind::Counter,
-                Key::Owned(KeyData::from_static_parts(LOGIN_ATTEMPTS, SVC_USER_EMAIL))
+                Key::from_static_parts(LOGIN_ATTEMPTS, SVC_USER_EMAIL)
             ),
             None,
             None,
@@ -145,7 +145,7 @@ fn test_macro_forms() {
             (
                 CompositeKey::new(
                     MetricKind::Counter,
-                    Key::Owned(KeyData::from_static_parts(LOGIN_ATTEMPTS_NONE, USER_EMAIL))
+                    Key::from_static_parts(LOGIN_ATTEMPTS_NONE, USER_EMAIL)
                 ),
                 None,
                 None,
@@ -154,10 +154,10 @@ fn test_macro_forms() {
             (
                 CompositeKey::new(
                     MetricKind::Counter,
-                    Key::Owned(KeyData::from_static_parts(
+                    Key::from_static_parts(
                         LOGIN_ATTEMPTS_STATIC,
                         SVC_USER_EMAIL
-                    )),
+                    ),
                 ),
                 None,
                 None,
@@ -166,10 +166,10 @@ fn test_macro_forms() {
             (
                 CompositeKey::new(
                     MetricKind::Counter,
-                    Key::Owned(KeyData::from_static_parts(
+                    Key::from_static_parts(
                         LOGIN_ATTEMPTS_DYNAMIC,
                         NODE_USER_EMAIL
-                    )),
+                    ),
                 ),
                 None,
                 None,
@@ -178,10 +178,10 @@ fn test_macro_forms() {
             (
                 CompositeKey::new(
                     MetricKind::Counter,
-                    Key::Owned(KeyData::from_static_parts(
+                    Key::from_static_parts(
                         LOGIN_ATTEMPTS_BOTH,
                         SVC_NODE_USER_EMAIL
-                    )),
+                    ),
                 ),
                 None,
                 None,
@@ -207,7 +207,7 @@ fn test_no_labels() {
         vec![(
             CompositeKey::new(
                 MetricKind::Counter,
-                Key::Owned(KeyData::from_static_name(LOGIN_ATTEMPTS)),
+                Key::from_static_name(LOGIN_ATTEMPTS),
             ),
             None,
             None,
@@ -261,7 +261,7 @@ fn test_multiple_paths_to_the_same_callsite() {
             (
                 CompositeKey::new(
                     MetricKind::Counter,
-                    Key::Owned(KeyData::from_static_parts(MY_COUNTER, SAME_CALLSITE_PATH_1)),
+                    Key::from_static_parts(MY_COUNTER, SAME_CALLSITE_PATH_1),
                 ),
                 None,
                 None,
@@ -270,7 +270,7 @@ fn test_multiple_paths_to_the_same_callsite() {
             (
                 CompositeKey::new(
                     MetricKind::Counter,
-                    Key::Owned(KeyData::from_static_parts(MY_COUNTER, SAME_CALLSITE_PATH_2)),
+                    Key::from_static_parts(MY_COUNTER, SAME_CALLSITE_PATH_2),
                 ),
                 None,
                 None,
@@ -320,7 +320,7 @@ fn test_nested_spans() {
         vec![(
             CompositeKey::new(
                 MetricKind::Counter,
-                Key::Owned(KeyData::from_static_parts(MY_COUNTER, COMBINED_LABELS))
+                Key::from_static_parts(MY_COUNTER, COMBINED_LABELS)
             ),
             None,
             None,
@@ -356,7 +356,7 @@ fn test_label_filtering() {
         vec![(
             CompositeKey::new(
                 MetricKind::Counter,
-                Key::Owned(KeyData::from_static_parts(LOGIN_ATTEMPTS, EMAIL_USER))
+                Key::from_static_parts(LOGIN_ATTEMPTS, EMAIL_USER)
             ),
             None,
             None,

--- a/metrics-util/CHANGELOG.md
+++ b/metrics-util/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+- Switched `Registry` over to supporting `&Key`.
+- Switched from `dashmap` to `hashbrown`/`parking_lot` for `Registry`.
+- Updated all layers to support the change from `Key` to `&Key` in `metrics::Recorder`.`
+### Added
+- Support for using the pre-hashed value of `Key` to speed up `Registry` operations.
+
 ## [0.6.2] - 2021-03-08
 ### Changed
 - Fixed issue with ordering on `CompositeKey`. (#182)

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -50,6 +50,9 @@ parking_lot = { version = "0.11", optional = true }
 quanta = { version = "0.7", optional = true }
 sketches-ddsketch = { version = "0.1", optional = true }
 ordered-float = "2.0"
+num_cpus = "1"
+t1ha = "0.1"
+hashbrown = "0.11"
 
 [dev-dependencies]
 approx = "0.4"

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -56,7 +56,7 @@ hashbrown = "0.11"
 
 [dev-dependencies]
 approx = "0.4"
-criterion = "0.3"
+criterion = { version = "0.3", default-features = false, features = ["html_reports", "cargo_bench_support"] }
 lazy_static = "1.3"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"

--- a/metrics-util/benches/absolute.rs
+++ b/metrics-util/benches/absolute.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 #[cfg(feature = "layer-absolute")]
-use metrics::{Key, KeyData, Label, NoopRecorder, Recorder, SharedString};
+use metrics::{Key, Label, NoopRecorder, Recorder, SharedString};
 
 #[cfg(feature = "layer-absolute")]
 use metrics_util::layers::{AbsoluteLayer, Layer};
@@ -16,10 +16,10 @@ fn layer_benchmark(c: &mut Criterion) {
             let absolute_layer = AbsoluteLayer::from_patterns(patterns);
             let recorder = absolute_layer.layer(NoopRecorder);
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("counter")];
-            static KEY_DATA: KeyData = KeyData::from_static_name(&KEY_NAME);
+            static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         });
         group.bench_function("match (same value)", |b| {
@@ -27,10 +27,10 @@ fn layer_benchmark(c: &mut Criterion) {
             let absolute_layer = AbsoluteLayer::from_patterns(patterns);
             let recorder = absolute_layer.layer(NoopRecorder);
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("rdkafka.bytes")];
-            static KEY_DATA: KeyData = KeyData::from_static_name(&KEY_NAME);
+            static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         });
         group.bench_function("match (updating value)", |b| {
@@ -38,12 +38,12 @@ fn layer_benchmark(c: &mut Criterion) {
             let absolute_layer = AbsoluteLayer::from_patterns(patterns);
             let recorder = absolute_layer.layer(NoopRecorder);
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("rdkafka.bytes")];
-            static KEY_DATA: KeyData = KeyData::from_static_name(&KEY_NAME);
+            static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
 
             let mut counter = 1;
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), counter);
+                recorder.increment_counter(&KEY_DATA, counter);
                 counter += 1;
             })
         });
@@ -51,10 +51,10 @@ fn layer_benchmark(c: &mut Criterion) {
             let recorder = NoopRecorder;
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("counter")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         });
     }

--- a/metrics-util/benches/absolute.rs
+++ b/metrics-util/benches/absolute.rs
@@ -10,7 +10,7 @@ use metrics_util::layers::{AbsoluteLayer, Layer};
 fn layer_benchmark(c: &mut Criterion) {
     #[cfg(feature = "layer-absolute")]
     {
-        let mut group = c.benchmark_group("Absolute");
+        let mut group = c.benchmark_group("absolute");
         group.bench_function("no match", |b| {
             let patterns = vec!["rdkafka"];
             let absolute_layer = AbsoluteLayer::from_patterns(patterns);

--- a/metrics-util/benches/filter.rs
+++ b/metrics-util/benches/filter.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 #[cfg(feature = "layer-filter")]
-use metrics::{Key, KeyData, Label, NoopRecorder, Recorder, SharedString};
+use metrics::{Key, Label, NoopRecorder, Recorder, SharedString};
 
 #[cfg(feature = "layer-filter")]
 use metrics_util::layers::{FilterLayer, Layer};
@@ -17,10 +17,10 @@ fn layer_benchmark(c: &mut Criterion) {
             let recorder = filter_layer.layer(NoopRecorder);
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("tokio.foo")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         });
         group.bench_function("no match", |b| {
@@ -29,10 +29,10 @@ fn layer_benchmark(c: &mut Criterion) {
             let recorder = filter_layer.layer(NoopRecorder);
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("hyper.foo")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         });
         group.bench_function("deep match", |b| {
@@ -44,20 +44,20 @@ fn layer_benchmark(c: &mut Criterion) {
                 SharedString::const_str("tokio.foo"),
             ];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         });
         group.bench_function("noop recorder overhead (increment_counter)", |b| {
             let recorder = NoopRecorder;
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("tokio.foo")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         });
     }

--- a/metrics-util/benches/prefix.rs
+++ b/metrics-util/benches/prefix.rs
@@ -1,32 +1,31 @@
-use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use metrics::{Key, Label, NoopRecorder, Recorder, SharedString};
 use metrics_util::layers::{Layer, PrefixLayer};
 
 fn layer_benchmark(c: &mut Criterion) {
-    c.bench(
-        "prefix",
-        Benchmark::new("basic", |b| {
-            let prefix_layer = PrefixLayer::new("prefix");
-            let recorder = prefix_layer.layer(NoopRecorder);
-            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-            static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+    let mut group = c.benchmark_group("prefix");
+    group.bench_function("basic", |b| {
+        let prefix_layer = PrefixLayer::new("prefix");
+        let recorder = prefix_layer.layer(NoopRecorder);
+        static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
+        static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
+        static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
-            b.iter(|| {
-                recorder.increment_counter(&KEY_DATA, 1);
-            })
+        b.iter(|| {
+            recorder.increment_counter(&KEY_DATA, 1);
         })
-        .with_function("noop recorder overhead (increment_counter)", |b| {
-            let recorder = NoopRecorder;
-            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-            static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+    });
+    group.bench_function("noop recorder overhead (increment_counter)", |b| {
+        let recorder = NoopRecorder;
+        static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
+        static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
+        static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
-            b.iter(|| {
-                recorder.increment_counter(&KEY_DATA, 1);
-            })
-        }),
-    );
+        b.iter(|| {
+            recorder.increment_counter(&KEY_DATA, 1);
+        })
+    });
+    group.finish();
 }
 
 criterion_group!(benches, layer_benchmark);

--- a/metrics-util/benches/prefix.rs
+++ b/metrics-util/benches/prefix.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
-use metrics::{Key, KeyData, Label, NoopRecorder, Recorder, SharedString};
+use metrics::{Key, Label, NoopRecorder, Recorder, SharedString};
 use metrics_util::layers::{Layer, PrefixLayer};
 
 fn layer_benchmark(c: &mut Criterion) {
@@ -10,20 +10,20 @@ fn layer_benchmark(c: &mut Criterion) {
             let recorder = prefix_layer.layer(NoopRecorder);
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         })
         .with_function("noop recorder overhead (increment_counter)", |b| {
             let recorder = NoopRecorder;
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                recorder.increment_counter(Key::Borrowed(&KEY_DATA), 1);
+                recorder.increment_counter(&KEY_DATA, 1);
             })
         }),
     );

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -1,83 +1,76 @@
-use criterion::{criterion_group, criterion_main, BatchSize, Benchmark, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use metrics::{Key, Label, SharedString};
 use metrics_util::{MetricKind, Registry};
 
 fn registry_benchmark(c: &mut Criterion) {
-    c.bench(
-        "registry",
-        Benchmark::new("cached op (basic)", |b| {
-            let registry: Registry<Key, ()> = Registry::new();
-            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-            static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
+    let mut group = c.benchmark_group("registry");
+    group.bench_function("cached op (basic)", |b| {
+        let registry: Registry<Key, ()> = Registry::new();
+        static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
+        static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
 
-            b.iter(|| {
-                registry.op(MetricKind::Counter, &KEY_DATA, |_| (), || ())
-            })
-        })
-        .with_function("cached op (labels)", |b| {
-            let registry: Registry<Key, ()> = Registry::new();
-            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-            static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
-            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+        b.iter(|| registry.op(MetricKind::Counter, &KEY_DATA, |_| (), || ()))
+    });
+    group.bench_function("cached op (labels)", |b| {
+        let registry: Registry<Key, ()> = Registry::new();
+        static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
+        static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
+        static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
-            b.iter(|| {
-                registry.op(MetricKind::Counter, &KEY_DATA, |_| (), || ())
-            })
-        })
-        .with_function("uncached op (basic)", |b| {
-            b.iter_batched_ref(
-                || Registry::<Key, ()>::new(),
-                |registry| {
-                    let key = "simple_key".into();
-                    registry.op(MetricKind::Counter, &key, |_| (), || ())
-                },
-                BatchSize::SmallInput,
-            )
-        })
-        .with_function("uncached op (labels)", |b| {
-            b.iter_batched_ref(
-                || Registry::<Key, ()>::new(),
-                |registry| {
-                    let labels = vec![Label::new("type", "http")];
-                    let key = ("simple_key", labels).into();
-                    registry.op(MetricKind::Counter, &key, |_| (), || ())
-                },
-                BatchSize::SmallInput,
-            )
-        })
-        .with_function("registry overhead", |b| {
-            b.iter_batched(
-                || (),
-                |_| Registry::<(), ()>::new(),
-                BatchSize::NumIterations(1),
-            )
-        })
-        .with_function("const key overhead (basic)", |b| {
-            b.iter(|| {
-                static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-                Key::from_static_name(&KEY_NAME)
-            })
-        })
-        .with_function("const key data overhead (labels)", |b| {
-            b.iter(|| {
-                static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-                static LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
-                Key::from_static_parts(&KEY_NAME, &LABELS)
-            })
-        })
-        .with_function("owned key overhead (basic)", |b| {
-            b.iter(|| {
-                Key::from_name("simple_key")
-            })
-        })
-        .with_function("owned key overhead (labels)", |b| {
-            b.iter(|| {
-                let key = "simple_key";
+        b.iter(|| registry.op(MetricKind::Counter, &KEY_DATA, |_| (), || ()))
+    });
+    group.bench_function("uncached op (basic)", |b| {
+        b.iter_batched_ref(
+            || Registry::<Key, ()>::new(),
+            |registry| {
+                let key = "simple_key".into();
+                registry.op(MetricKind::Counter, &key, |_| (), || ())
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("uncached op (labels)", |b| {
+        b.iter_batched_ref(
+            || Registry::<Key, ()>::new(),
+            |registry| {
                 let labels = vec![Label::new("type", "http")];
-                Key::from_parts(key, labels)
-            })
-        }),
-    );
+                let key = ("simple_key", labels).into();
+                registry.op(MetricKind::Counter, &key, |_| (), || ())
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("registry overhead", |b| {
+        b.iter_batched(
+            || (),
+            |_| Registry::<u64, ()>::new(),
+            BatchSize::NumIterations(1),
+        )
+    });
+    group.bench_function("const key overhead (basic)", |b| {
+        b.iter(|| {
+            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
+            Key::from_static_name(&KEY_NAME)
+        })
+    });
+    group.bench_function("const key data overhead (labels)", |b| {
+        b.iter(|| {
+            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
+            static LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
+            Key::from_static_parts(&KEY_NAME, &LABELS)
+        })
+    });
+    group.bench_function("owned key overhead (basic)", |b| {
+        b.iter(|| Key::from_name("simple_key"))
+    });
+    group.bench_function("owned key overhead (labels)", |b| {
+        b.iter(|| {
+            let key = "simple_key";
+            let labels = vec![Label::new("type", "http")];
+            Key::from_parts(key, labels)
+        })
+    });
+    group.finish();
 }
 
 criterion_group!(benches, registry_benchmark);

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Benchmark, Criterion};
-use metrics::{Key, KeyData, Label, SharedString};
-use metrics_util::Registry;
+use metrics::{Key, Label, SharedString};
+use metrics_util::{MetricKind, Registry};
 
 fn registry_benchmark(c: &mut Criterion) {
     c.bench(
@@ -8,30 +8,28 @@ fn registry_benchmark(c: &mut Criterion) {
         Benchmark::new("cached op (basic)", |b| {
             let registry: Registry<Key, ()> = Registry::new();
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-            static KEY_DATA: KeyData = KeyData::from_static_name(&KEY_NAME);
+            static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
 
             b.iter(|| {
-                let key = Key::Borrowed(&KEY_DATA);
-                registry.op(key, |_| (), || ())
+                registry.op(MetricKind::Counter, &KEY_DATA, |_| (), || ())
             })
         })
         .with_function("cached op (labels)", |b| {
             let registry: Registry<Key, ()> = Registry::new();
             static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
 
             b.iter(|| {
-                let key = Key::Borrowed(&KEY_DATA);
-                registry.op(key, |_| (), || ())
+                registry.op(MetricKind::Counter, &KEY_DATA, |_| (), || ())
             })
         })
         .with_function("uncached op (basic)", |b| {
             b.iter_batched_ref(
                 || Registry::<Key, ()>::new(),
                 |registry| {
-                    let key = Key::Owned("simple_key".into());
-                    registry.op(key, |_| (), || ())
+                    let key = "simple_key".into();
+                    registry.op(MetricKind::Counter, &key, |_| (), || ())
                 },
                 BatchSize::SmallInput,
             )
@@ -41,8 +39,8 @@ fn registry_benchmark(c: &mut Criterion) {
                 || Registry::<Key, ()>::new(),
                 |registry| {
                     let labels = vec![Label::new("type", "http")];
-                    let key = Key::Owned(("simple_key", labels).into());
-                    registry.op(key, |_| (), || ())
+                    let key = ("simple_key", labels).into();
+                    registry.op(MetricKind::Counter, &key, |_| (), || ())
                 },
                 BatchSize::SmallInput,
             )
@@ -54,55 +52,43 @@ fn registry_benchmark(c: &mut Criterion) {
                 BatchSize::NumIterations(1),
             )
         })
-        .with_function("key data overhead (basic)", |b| {
+        .with_function("key overhead (basic)", |b| {
             b.iter(|| {
                 let key = "simple_key";
-                KeyData::from_name(key)
+                Key::from_name(key)
             })
         })
-        .with_function("key data overhead (labels)", |b| {
+        .with_function("key overhead (labels)", |b| {
             b.iter(|| {
                 let key = "simple_key";
                 let labels = vec![Label::new("type", "http")];
-                KeyData::from_parts(key, labels)
+                Key::from_parts(key, labels)
             })
         })
-        .with_function("const key data overhead (basic)", |b| {
+        .with_function("const key overhead (basic)", |b| {
             b.iter(|| {
                 static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-                KeyData::from_static_name(&KEY_NAME)
+                Key::from_static_name(&KEY_NAME)
             })
         })
         .with_function("const key data overhead (labels)", |b| {
             b.iter(|| {
                 static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
                 static LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
-                KeyData::from_static_parts(&KEY_NAME, &LABELS)
+                Key::from_static_parts(&KEY_NAME, &LABELS)
             })
         })
         .with_function("owned key overhead (basic)", |b| {
             b.iter(|| {
-                let key = "simple_key";
-                Key::Owned(KeyData::from_name(key))
+                Key::from_name("simple_key")
             })
         })
         .with_function("owned key overhead (labels)", |b| {
             b.iter(|| {
                 let key = "simple_key";
                 let labels = vec![Label::new("type", "http")];
-                Key::Owned(KeyData::from_parts(key, labels))
+                Key::from_parts(key, labels)
             })
-        })
-        .with_function("cached key overhead (basic)", |b| {
-            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-            static KEY_DATA: KeyData = KeyData::from_static_name(&KEY_NAME);
-            b.iter(|| Key::Borrowed(&KEY_DATA))
-        })
-        .with_function("cached key overhead (labels)", |b| {
-            static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];
-            static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
-            static KEY_DATA: KeyData = KeyData::from_static_parts(&KEY_NAME, &KEY_LABELS);
-            b.iter(|| Key::Borrowed(&KEY_DATA))
         }),
     );
 }

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -52,19 +52,6 @@ fn registry_benchmark(c: &mut Criterion) {
                 BatchSize::NumIterations(1),
             )
         })
-        .with_function("key overhead (basic)", |b| {
-            b.iter(|| {
-                let key = "simple_key";
-                Key::from_name(key)
-            })
-        })
-        .with_function("key overhead (labels)", |b| {
-            b.iter(|| {
-                let key = "simple_key";
-                let labels = vec![Label::new("type", "http")];
-                Key::from_parts(key, labels)
-            })
-        })
         .with_function("const key overhead (basic)", |b| {
             b.iter(|| {
                 static KEY_NAME: [SharedString; 1] = [SharedString::const_str("simple_key")];

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -43,7 +43,7 @@ fn registry_benchmark(c: &mut Criterion) {
     group.bench_function("registry overhead", |b| {
         b.iter_batched(
             || (),
-            |_| Registry::<u64, ()>::new(),
+            |_| Registry::<Key, ()>::new(),
             BatchSize::NumIterations(1),
         )
     });

--- a/metrics-util/src/common.rs
+++ b/metrics-util/src/common.rs
@@ -1,6 +1,7 @@
-use std::hash::Hash;
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
 
-use metrics::Key;
+use metrics::{Key, KeyHasher};
 
 /// A type that can hash itself.
 ///
@@ -8,6 +9,10 @@ use metrics::Key;
 /// is anticipated that an object will be hashed multiple times. Rather than the standard library
 /// `Hash` trait, `Hashable` exposes an interface that forces objects to hash themselves entirely,
 /// providing only the resulting 8-byte hash.
+///
+/// For all implementations of `Hashable`, you _must_ utilize `metrics::KeyHasher`.  Usage of
+/// another hasher will lead to inconsistency in places where `Hashable` is used, specifically
+/// `Registry`.  You can wrap items in `DefaultHashable` to ensure they utilize the correct hasher.
 pub trait Hashable: Hash {
     /// Generate the hash of this object.
     fn hashable(&self) -> u64;
@@ -19,8 +24,13 @@ impl Hashable for Key {
     }
 }
 
-impl Hashable for u64 {
+#[derive(Debug, Hash, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct DefaultHashable<H: Hash>(pub H);
+
+impl<H: Hash> Hashable for DefaultHashable<H> {
     fn hashable(&self) -> u64 {
-        *self
+        let mut hasher = KeyHasher::default();
+        self.hash(&mut hasher);
+        hasher.finish()
     }
 }

--- a/metrics-util/src/common.rs
+++ b/metrics-util/src/common.rs
@@ -1,0 +1,26 @@
+use std::hash::Hash;
+
+use metrics::Key;
+
+/// A type that can hash itself.
+///
+/// In high-performance use cases, an object can pre-hash itself, or memoize its hash value, when it
+/// is anticipated that an object will be hashed multiple times. Rather than the standard library
+/// `Hash` trait, `Hashable` exposes an interface that forces objects to hash themselves entirely,
+/// providing only the resulting 8-byte hash.
+pub trait Hashable: Hash {
+    /// Generate the hash of this object.
+    fn hashable(&self) -> u64;
+}
+
+impl Hashable for Key {
+    fn hashable(&self) -> u64 {
+        self.get_hash()
+    }
+}
+
+impl Hashable for u64 {
+    fn hashable(&self) -> u64 {
+        *self
+    }
+}

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -177,21 +177,24 @@ impl Recorder for DebuggingRecorder {
         let rkey = CompositeKey::new(MetricKind::Counter, key.clone());
         self.register_metric(rkey.clone());
         self.insert_unit_description(rkey.clone(), unit, description);
-        self.registry.op(MetricKind::Counter, key, |_| {}, Handle::counter)
+        self.registry
+            .op(MetricKind::Counter, key, |_| {}, Handle::counter)
     }
 
     fn register_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         let rkey = CompositeKey::new(MetricKind::Gauge, key.clone());
         self.register_metric(rkey.clone());
         self.insert_unit_description(rkey.clone(), unit, description);
-        self.registry.op(MetricKind::Gauge, key, |_| {}, Handle::gauge)
+        self.registry
+            .op(MetricKind::Gauge, key, |_| {}, Handle::gauge)
     }
 
     fn register_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         let rkey = CompositeKey::new(MetricKind::Histogram, key.clone());
         self.register_metric(rkey.clone());
         self.insert_unit_description(rkey.clone(), unit, description);
-        self.registry.op(MetricKind::Histogram, key, |_| {}, Handle::histogram)
+        self.registry
+            .op(MetricKind::Histogram, key, |_| {}, Handle::histogram)
     }
 
     fn increment_counter(&self, key: &Key, value: u64) {
@@ -212,7 +215,7 @@ impl Recorder for DebuggingRecorder {
             MetricKind::Gauge,
             key,
             |handle| handle.update_gauge(value),
-            Handle::gauge
+            Handle::gauge,
         )
     }
 

--- a/metrics-util/src/key.rs
+++ b/metrics-util/src/key.rs
@@ -40,15 +40,15 @@ impl CompositeKey {
 mod tests {
     use std::cmp::Ordering;
 
-    use metrics::KeyData;
+    use metrics::Key;
 
     use super::*;
 
     #[test]
     fn test_same_keys_different_kinds_not_equal() {
-        let key = KeyData::from_name("test");
-        let key1 = CompositeKey::new(MetricKind::Counter, key.clone().into());
-        let key2 = CompositeKey::new(MetricKind::Gauge, key.into());
+        let key = Key::from_name("test");
+        let key1 = CompositeKey::new(MetricKind::Counter, key.clone());
+        let key2 = CompositeKey::new(MetricKind::Gauge, key);
 
         assert_ne!(key1.cmp(&key2), Ordering::Equal);
     }

--- a/metrics-util/src/layers/absolute.rs
+++ b/metrics-util/src/layers/absolute.rs
@@ -174,7 +174,7 @@ mod tests {
     use super::AbsoluteLayer;
     use crate::layers::Layer;
     use crate::{debugging::DebuggingRecorder, DebugValue};
-    use metrics::{GaugeValue, Key, Recorder};
+    use metrics::{GaugeValue, Recorder};
     use ordered_float::OrderedFloat;
 
     #[test]

--- a/metrics-util/src/layers/fanout.rs
+++ b/metrics-util/src/layers/fanout.rs
@@ -96,21 +96,10 @@ mod tests {
 
         let ud = &[(Unit::Count, "counter desc"), (Unit::Bytes, "gauge desc")];
 
-        fanout.register_counter(
-            &tlkey,
-            Some(ud[0].0.clone()),
-            Some(ud[0].1),
-        );
-        fanout.register_gauge(
-            &hsbkey,
-            Some(ud[1].0.clone()),
-            Some(ud[1].1),
-        );
+        fanout.register_counter(&tlkey, Some(ud[0].0.clone()), Some(ud[0].1));
+        fanout.register_gauge(&hsbkey, Some(ud[1].0.clone()), Some(ud[1].1));
         fanout.increment_counter(&tlkey, 47);
-        fanout.update_gauge(
-            &hsbkey,
-            GaugeValue::Absolute(12.0),
-        );
+        fanout.update_gauge(&hsbkey, GaugeValue::Absolute(12.0));
 
         let after1 = snapshotter1.snapshot();
         let after2 = snapshotter2.snapshot();

--- a/metrics-util/src/layers/fanout.rs
+++ b/metrics-util/src/layers/fanout.rs
@@ -6,39 +6,39 @@ pub struct Fanout {
 }
 
 impl Recorder for Fanout {
-    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         for recorder in &self.recorders {
-            recorder.register_counter(key.clone(), unit.clone(), description);
+            recorder.register_counter(key, unit.clone(), description);
         }
     }
 
-    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         for recorder in &self.recorders {
-            recorder.register_gauge(key.clone(), unit.clone(), description);
+            recorder.register_gauge(key, unit.clone(), description);
         }
     }
 
-    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         for recorder in &self.recorders {
-            recorder.register_histogram(key.clone(), unit.clone(), description);
+            recorder.register_histogram(key, unit.clone(), description);
         }
     }
 
-    fn increment_counter(&self, key: Key, value: u64) {
+    fn increment_counter(&self, key: &Key, value: u64) {
         for recorder in &self.recorders {
-            recorder.increment_counter(key.clone(), value);
+            recorder.increment_counter(key, value);
         }
     }
 
-    fn update_gauge(&self, key: Key, value: GaugeValue) {
+    fn update_gauge(&self, key: &Key, value: GaugeValue) {
         for recorder in &self.recorders {
-            recorder.update_gauge(key.clone(), value.clone());
+            recorder.update_gauge(key, value.clone());
         }
     }
 
-    fn record_histogram(&self, key: Key, value: f64) {
+    fn record_histogram(&self, key: &Key, value: f64) {
         for recorder in &self.recorders {
-            recorder.record_histogram(key.clone(), value);
+            recorder.record_histogram(key, value);
         }
     }
 }
@@ -73,7 +73,7 @@ impl FanoutBuilder {
 mod tests {
     use super::FanoutBuilder;
     use crate::debugging::DebuggingRecorder;
-    use metrics::{GaugeValue, Key, Recorder, Unit};
+    use metrics::{GaugeValue, Recorder, Unit};
 
     #[test]
     fn test_basic_functionality() {
@@ -86,6 +86,9 @@ mod tests {
             .add_recorder(recorder2)
             .build();
 
+        let tlkey = "tokio.loops".into();
+        let hsbkey = "hyper.sent.bytes".into();
+
         let before1 = snapshotter1.snapshot();
         let before2 = snapshotter2.snapshot();
         assert_eq!(before1.len(), 0);
@@ -94,18 +97,18 @@ mod tests {
         let ud = &[(Unit::Count, "counter desc"), (Unit::Bytes, "gauge desc")];
 
         fanout.register_counter(
-            Key::Owned("tokio.loops".into()),
+            &tlkey,
             Some(ud[0].0.clone()),
             Some(ud[0].1),
         );
         fanout.register_gauge(
-            Key::Owned("hyper.sent_bytes".into()),
+            &hsbkey,
             Some(ud[1].0.clone()),
             Some(ud[1].1),
         );
-        fanout.increment_counter(Key::Owned("tokio.loops".into()), 47);
+        fanout.increment_counter(&tlkey, 47);
         fanout.update_gauge(
-            Key::Owned("hyper.sent_bytes".into()),
+            &hsbkey,
             GaugeValue::Absolute(12.0),
         );
 

--- a/metrics-util/src/layers/filter.rs
+++ b/metrics-util/src/layers/filter.rs
@@ -184,31 +184,11 @@ mod tests {
             (Unit::Bytes, "gauge desc"),
         ];
 
-        layered.register_counter(
-            &tlkey,
-            Some(ud[0].0.clone()),
-            Some(ud[0].1),
-        );
-        layered.register_gauge(
-            &hsbkey,
-            Some(ud[1].0.clone()),
-            Some(ud[1].1),
-        );
-        layered.register_histogram(
-            &htsbkey,
-            Some(ud[2].0.clone()),
-            Some(ud[2].1),
-        );
-        layered.register_counter(
-            &bckey,
-            Some(ud[3].0.clone()),
-            Some(ud[3].1),
-        );
-        layered.register_gauge(
-            &hrbkey,
-            Some(ud[4].0.clone()),
-            Some(ud[4].1),
-        );
+        layered.register_counter(&tlkey, Some(ud[0].0.clone()), Some(ud[0].1));
+        layered.register_gauge(&hsbkey, Some(ud[1].0.clone()), Some(ud[1].1));
+        layered.register_histogram(&htsbkey, Some(ud[2].0.clone()), Some(ud[2].1));
+        layered.register_counter(&bckey, Some(ud[3].0.clone()), Some(ud[3].1));
+        layered.register_gauge(&hrbkey, Some(ud[4].0.clone()), Some(ud[4].1));
 
         let after = snapshotter.snapshot();
         assert_eq!(after.len(), 2);

--- a/metrics-util/src/layers/mod.rs
+++ b/metrics-util/src/layers/mod.rs
@@ -165,27 +165,27 @@ impl<R: Recorder + 'static> Stack<R> {
 }
 
 impl<R: Recorder> Recorder for Stack<R> {
-    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         self.inner.register_counter(key, unit, description);
     }
 
-    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         self.inner.register_gauge(key, unit, description);
     }
 
-    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         self.inner.register_histogram(key, unit, description);
     }
 
-    fn increment_counter(&self, key: Key, value: u64) {
+    fn increment_counter(&self, key: &Key, value: u64) {
         self.inner.increment_counter(key, value);
     }
 
-    fn update_gauge(&self, key: Key, value: GaugeValue) {
+    fn update_gauge(&self, key: &Key, value: GaugeValue) {
         self.inner.update_gauge(key, value);
     }
 
-    fn record_histogram(&self, key: Key, value: f64) {
+    fn record_histogram(&self, key: &Key, value: f64) {
         self.inner.record_histogram(key, value);
     }
 }

--- a/metrics-util/src/layers/mod.rs
+++ b/metrics-util/src/layers/mod.rs
@@ -27,42 +27,42 @@
 //! }
 //!
 //! impl<R: Recorder> Recorder for StairwayDeny<R> {
-//!    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+//!    fn register_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
 //!        if self.is_invalid_key(&key) {
 //!            return;
 //!        }
 //!        self.0.register_counter(key, unit, description)
 //!    }
 //!
-//!    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+//!    fn register_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
 //!        if self.is_invalid_key(&key) {
 //!            return;
 //!        }
 //!        self.0.register_gauge(key, unit, description)
 //!    }
 //!
-//!    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+//!    fn register_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
 //!        if self.is_invalid_key(&key) {
 //!            return;
 //!        }
 //!        self.0.register_histogram(key, unit, description)
 //!    }
 //!
-//!    fn increment_counter(&self, key: Key, value: u64) {
+//!    fn increment_counter(&self, key: &Key, value: u64) {
 //!        if self.is_invalid_key(&key) {
 //!            return;
 //!        }
 //!        self.0.increment_counter(key, value);
 //!    }
 //!
-//!    fn update_gauge(&self, key: Key, value: GaugeValue) {
+//!    fn update_gauge(&self, key: &Key, value: GaugeValue) {
 //!        if self.is_invalid_key(&key) {
 //!            return;
 //!        }
 //!        self.0.update_gauge(key, value);
 //!    }
 //!
-//!    fn record_histogram(&self, key: Key, value: f64) {
+//!    fn record_histogram(&self, key: &Key, value: f64) {
 //!        if self.is_invalid_key(&key) {
 //!            return;
 //!        }

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -97,21 +97,9 @@ mod tests {
             (Unit::Milliseconds, "histogram desc"),
         ];
 
-        layered.register_counter(
-            &ckey,
-            Some(ud[0].0.clone()),
-            Some(ud[0].1),
-        );
-        layered.register_gauge(
-            &gkey,
-            Some(ud[1].0.clone()),
-            Some(ud[1].1),
-        );
-        layered.register_histogram(
-            &hkey,
-            Some(ud[2].0.clone()),
-            Some(ud[2].1),
-        );
+        layered.register_counter(&ckey, Some(ud[0].0.clone()), Some(ud[0].1));
+        layered.register_gauge(&gkey, Some(ud[1].0.clone()), Some(ud[1].1));
+        layered.register_histogram(&hkey, Some(ud[2].0.clone()), Some(ud[2].1));
 
         let after = snapshotter.snapshot();
         assert_eq!(after.len(), 3);

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -75,7 +75,7 @@ mod tests {
     use super::PrefixLayer;
     use crate::debugging::DebuggingRecorder;
     use crate::layers::Layer;
-    use metrics::{Key, Recorder, Unit};
+    use metrics::{Recorder, Unit};
 
     #[test]
     fn test_basic_functionality() {

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -10,40 +10,40 @@ pub struct Prefix<R> {
 }
 
 impl<R> Prefix<R> {
-    fn prefix_key(&self, key: Key) -> Key {
-        key.into_owned().prepend_name(self.prefix.clone()).into()
+    fn prefix_key(&self, key: &Key) -> Key {
+        key.clone().prepend_name(self.prefix.clone()).into()
     }
 }
 
 impl<R: Recorder> Recorder for Prefix<R> {
-    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         let new_key = self.prefix_key(key);
-        self.inner.register_counter(new_key, unit, description)
+        self.inner.register_counter(&new_key, unit, description)
     }
 
-    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         let new_key = self.prefix_key(key);
-        self.inner.register_gauge(new_key, unit, description)
+        self.inner.register_gauge(&new_key, unit, description)
     }
 
-    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         let new_key = self.prefix_key(key);
-        self.inner.register_histogram(new_key, unit, description)
+        self.inner.register_histogram(&new_key, unit, description)
     }
 
-    fn increment_counter(&self, key: Key, value: u64) {
+    fn increment_counter(&self, key: &Key, value: u64) {
         let new_key = self.prefix_key(key);
-        self.inner.increment_counter(new_key, value);
+        self.inner.increment_counter(&new_key, value);
     }
 
-    fn update_gauge(&self, key: Key, value: GaugeValue) {
+    fn update_gauge(&self, key: &Key, value: GaugeValue) {
         let new_key = self.prefix_key(key);
-        self.inner.update_gauge(new_key, value);
+        self.inner.update_gauge(&new_key, value);
     }
 
-    fn record_histogram(&self, key: Key, value: f64) {
+    fn record_histogram(&self, key: &Key, value: f64) {
         let new_key = self.prefix_key(key);
-        self.inner.record_histogram(new_key, value);
+        self.inner.record_histogram(&new_key, value);
     }
 }
 
@@ -75,7 +75,7 @@ mod tests {
     use super::PrefixLayer;
     use crate::debugging::DebuggingRecorder;
     use crate::layers::Layer;
-    use metrics::{KeyData, Recorder, Unit};
+    use metrics::{Key, Recorder, Unit};
 
     #[test]
     fn test_basic_functionality() {
@@ -83,6 +83,10 @@ mod tests {
         let snapshotter = recorder.snapshotter();
         let prefix = PrefixLayer::new("testing");
         let layered = prefix.layer(recorder);
+
+        let ckey = "counter_metric".into();
+        let gkey = "gauge_metric".into();
+        let hkey = "histogram_metric".into();
 
         let before = snapshotter.snapshot();
         assert_eq!(before.len(), 0);
@@ -94,17 +98,17 @@ mod tests {
         ];
 
         layered.register_counter(
-            KeyData::from_name("counter_metric").into(),
+            &ckey,
             Some(ud[0].0.clone()),
             Some(ud[0].1),
         );
         layered.register_gauge(
-            KeyData::from_name("gauge_metric").into(),
+            &gkey,
             Some(ud[1].0.clone()),
             Some(ud[1].1),
         );
         layered.register_histogram(
-            KeyData::from_name("histogram_metric").into(),
+            &hkey,
             Some(ud[2].0.clone()),
             Some(ud[2].1),
         );

--- a/metrics-util/src/lib.rs
+++ b/metrics-util/src/lib.rs
@@ -27,7 +27,7 @@ mod registry;
 pub use registry::{Generation, Registry};
 
 mod common;
-pub use common::Hashable;
+pub use common::*;
 
 mod key;
 pub use key::CompositeKey;

--- a/metrics-util/src/lib.rs
+++ b/metrics-util/src/lib.rs
@@ -26,6 +26,9 @@ mod registry;
 #[cfg(feature = "std")]
 pub use registry::{Generation, Registry};
 
+mod common;
+pub use common::Hashable;
+
 mod key;
 pub use key::CompositeKey;
 

--- a/metrics-util/src/recency.rs
+++ b/metrics-util/src/recency.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
-use std::{collections::HashMap, hash::Hash, ops::DerefMut};
+use std::{collections::HashMap, ops::DerefMut};
 
-use crate::{kind::MetricKindMask, Generation, MetricKind, Registry};
+use crate::{kind::MetricKindMask, Generation, Hashable, MetricKind, Registry};
 
 use parking_lot::Mutex;
 use quanta::{Clock, Instant};
@@ -71,7 +71,7 @@ impl<K> Recency<K> {
         registry: &Registry<K, H>,
     ) -> bool
     where
-        K: Eq + Hash + Clone + 'static,
+        K: Eq + Hashable + Clone + 'static,
         H: Clone + 'static,
     {
         if let Some(idle_timeout) = self.idle_timeout {

--- a/metrics-util/src/recency.rs
+++ b/metrics-util/src/recency.rs
@@ -88,7 +88,7 @@ impl<K> Recency<K> {
                             // If the delete returns false, that means that our generation counter is
                             // out-of-date, and that the metric has been updated since, so we don't
                             // actually want to delete it yet.
-                            if registry.delete(&key, gen) {
+                            if registry.delete(kind, &key, gen) {
                                 return false;
                             }
                         }

--- a/metrics-util/src/recency.rs
+++ b/metrics-util/src/recency.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::time::Duration;
 use std::{collections::HashMap, ops::DerefMut};
 
@@ -71,8 +72,8 @@ impl<K> Recency<K> {
         registry: &Registry<K, H>,
     ) -> bool
     where
-        K: Eq + Hashable + Clone + 'static,
-        H: Clone + 'static,
+        K: Debug + Eq + Hashable + Clone + 'static,
+        H: Debug + Clone + 'static,
     {
         if let Some(idle_timeout) = self.idle_timeout {
             if self.mask.matches(kind) {

--- a/metrics-util/src/registry.rs
+++ b/metrics-util/src/registry.rs
@@ -2,8 +2,16 @@ use core::{
     hash::Hash,
     sync::atomic::{AtomicUsize, Ordering},
 };
-use dashmap::DashMap;
-use std::collections::HashMap;
+use std::{hash::{BuildHasherDefault, Hasher}, iter::repeat};
+
+use hashbrown::{HashMap, hash_map::RawEntryMut};
+use parking_lot::RwLock;
+use t1ha::T1haHasher;
+
+use crate::MetricKind;
+
+type RegistryHasher = T1haHasher;
+type RegistryHashMap<K, V> = HashMap<K, Generational<V>, BuildHasherDefault<RegistryHasher>>;
 
 /// Generation counter.
 ///
@@ -58,7 +66,8 @@ where
     K: Eq + Hash + Clone + 'static,
     H: 'static,
 {
-    map: DashMap<K, Generational<H>>,
+    shards: Vec<Vec<RwLock<RegistryHashMap<K, H>>>>,
+    mask: usize,
 }
 
 impl<K, H> Registry<K, H>
@@ -68,9 +77,44 @@ where
 {
     /// Creates a new `Registry`.
     pub fn new() -> Self {
+        let shard_count = std::cmp::max(1, num_cpus::get()).next_power_of_two();
+        let mask = shard_count - 1;
+        let counters = repeat(())
+            .take(shard_count)
+            .map(|_| RwLock::new(RegistryHashMap::default()))
+            .collect();
+        let gauges = repeat(())
+            .take(shard_count)
+            .map(|_| RwLock::new(RegistryHashMap::default()))
+            .collect();
+        let histograms = repeat(())
+            .take(shard_count)
+            .map(|_| RwLock::new(RegistryHashMap::default()))
+            .collect();
+
+        let shards = vec![counters, gauges, histograms];
+
         Self {
-            map: DashMap::new(),
+            shards,
+            mask,
         }
+    }
+
+    #[inline]
+    fn get_hash_and_shard(&self, kind: MetricKind, key: &K) -> (u64, &RwLock<RegistryHashMap<K, H>>) {
+        let mut hasher = RegistryHasher::default();
+        let hash = hash_key(&mut hasher, key);
+
+        // SAFETY: We map each MetricKind variant -- three at present -- to a usize value
+        // representing an index in a vector, so we statically know that we're always extracting our
+        // sub-shards correctly.  Secondly, we initialize vector of subshards with a power-of-two
+        // value, and `self.mask` is `self.shards.len() - 1`, thus we can never have a result from
+        // the masking operation that results in a value which is not in bounds of our subshards
+        // vector.
+        let shards = unsafe { self.shards.get_unchecked(kind_to_idx(kind)) };
+        let shard = unsafe { shards.get_unchecked(hash as usize & self.mask) };
+
+        (hash, shard)
     }
 
     /// Perform an operation on a given key.
@@ -79,19 +123,37 @@ where
     ///
     /// If the `key` is not already mapped, the `init` function will be
     /// called, and the resulting handle will be stored in the registry.
-    pub fn op<I, O, V>(&self, key: K, op: O, init: I) -> V
+    pub fn op<I, O, V>(&self, kind: MetricKind, key: &K, op: O, init: I) -> V
     where
         I: FnOnce() -> H,
         O: FnOnce(&H) -> V,
     {
-        let valref = self.map.entry(key).or_insert_with(|| {
-            let value = init();
-            Generational::new(value)
-        });
-        let value = valref.value();
-        let result = op(value.get_inner());
-        value.increment_generation();
-        result
+        let (hash, shard) = self.get_hash_and_shard(kind, key);
+
+        // Try and get the handle if it exists, running our operation if we succeed.
+        let shard_read = shard.read();
+        if let Some((_, v)) = shard_read.raw_entry().from_key_hashed_nocheck(hash, key) {
+            let result = op(v.get_inner());
+            v.increment_generation();
+            result
+        } else {
+            // Switch to write guard and insert the handle first.
+            drop(shard_read);
+            let mut shard_write = shard.write();
+            let v = if let Some((_, v)) = shard_write.raw_entry().from_key_hashed_nocheck(hash, key) {
+                v
+            } else {
+                shard_write.entry(key.clone())
+                    .or_insert_with(|| {
+                        let value = init();
+                        Generational::new(value)
+                    })
+            };
+
+            let result = op(v.get_inner());
+            v.increment_generation();
+            result
+        }
     }
 
     /// Deletes a handle from the registry.
@@ -99,52 +161,39 @@ where
     /// The generation of a given key is passed along when querying the registry via
     /// [`get_handles`](Registry::get_handles).  If the generation given here does not match the
     /// current generation, then the handle will not be removed.
-    pub fn delete(&self, key: &K, generation: Generation) -> bool {
-        self.map
-            .remove_if(key, |_, g| g.get_generation() == generation)
-            .is_some()
+    pub fn delete(&self, kind: MetricKind, key: &K, generation: Generation) -> bool {
+        let (hash, shard) = self.get_hash_and_shard(kind, key);
+        let mut shard_write = shard.write();
+        let entry = shard_write.raw_entry_mut().from_key_hashed_nocheck(hash, key);
+        if let RawEntryMut::Occupied(entry) = entry {
+            if entry.get().get_generation() == generation {
+                let _ = entry.remove_entry();
+                return true
+            }
+        }
+
+        false
     }
 
     /// Gets a map of all present handles, mapped by key.
     ///
     /// Handles must implement `Clone`.  This map is a point-in-time snapshot of the registry.
-    pub fn get_handles(&self) -> HashMap<K, (Generation, H)>
+    pub fn get_handles(&self) -> HashMap<(MetricKind, K), (Generation, H)>
     where
         H: Clone,
     {
-        self.collect()
-    }
+        self.shards.iter()
+            .enumerate()
+            .fold(HashMap::default(), |mut acc, (idx, subshards)| {
+                let kind = idx_to_kind(idx);
 
-    /// Collects all present key and associated generation/handle pairs
-    /// into the provided type `T`.
-    ///
-    /// Handles must implement `Clone`.
-    /// This collected result is a point-in-time snapshot of the registry.
-    pub fn collect<T>(&self) -> T
-    where
-        H: Clone,
-        T: std::iter::FromIterator<(K, (Generation, H))>,
-    {
-        self.map_collect(|key, generation, handle| (key.clone(), (generation, handle.clone())))
-    }
-
-    /// Maps and then collects all present key and associated generation/handle
-    /// pairs into the provided type `T`.
-    ///
-    /// This map is appied over the values from a point-in-time snapshot of
-    /// the registry.
-    pub fn map_collect<F, R, T>(&self, mut f: F) -> T
-    where
-        F: for<'a> FnMut(&'a K, Generation, &'a H) -> R,
-        T: std::iter::FromIterator<R>,
-    {
-        self.map
-            .iter()
-            .map(|item| {
-                let value = item.value();
-                f(item.key(), value.get_generation(), value.get_inner())
+                for subshard in subshards {
+                    let shard_read = subshard.read();
+                    let items = shard_read.iter().map(|(k, v)|  ((kind, k.clone()), (v.get_generation(), v.get_inner().clone())));
+                    acc.extend(items);
+                }
+                acc
             })
-            .collect()
     }
 }
 
@@ -158,9 +207,32 @@ where
     }
 }
 
+fn hash_key<H: Hasher, I: Hash>(hasher: &mut H, item: I) -> u64 {
+    item.hash(hasher);
+    hasher.finish()
+}
+
+const fn kind_to_idx(kind: MetricKind) -> usize {
+    match kind {
+        MetricKind::Counter => 0,
+        MetricKind::Gauge => 1,
+        MetricKind::Histogram => 2,
+    }
+}
+
+#[inline]
+fn idx_to_kind(idx: usize) -> MetricKind {
+    match idx {
+        0 => MetricKind::Counter,
+        1 => MetricKind::Gauge,
+        2 => MetricKind::Histogram,
+        _ => panic!("invalid index")
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Generational, Registry};
+    use super::{Generational, MetricKind, Registry};
     use std::sync::{
         atomic::{AtomicUsize, Ordering::SeqCst},
         Arc,
@@ -187,7 +259,8 @@ mod tests {
         assert_eq!(entries.len(), 0);
 
         let initial_value = registry.op(
-            1,
+            MetricKind::Counter,
+            &1,
             |h| h.fetch_add(1, SeqCst),
             || Arc::new(AtomicUsize::new(42)),
         );
@@ -202,11 +275,12 @@ mod tests {
             .expect("failed to get first entry");
 
         let (key, (initial_gen, value)) = initial_entry;
-        assert_eq!(key, 1);
+        assert_eq!(key, (MetricKind::Counter, 1));
         assert_eq!(value.load(SeqCst), 43);
 
         let update_value = registry.op(
-            1,
+            MetricKind::Counter,
+            &1,
             |h| h.fetch_add(1, SeqCst),
             || Arc::new(AtomicUsize::new(42)),
         );
@@ -220,16 +294,17 @@ mod tests {
             .next()
             .expect("failed to get updated entry");
 
-        let (key, (updated_gen, value)) = updated_entry;
+        let ((kind, key), (updated_gen, value)) = updated_entry;
+        assert_eq!(kind, MetricKind::Counter);
         assert_eq!(key, 1);
         assert_eq!(value.load(SeqCst), 44);
 
-        assert!(!registry.delete(&key, initial_gen));
+        assert!(!registry.delete(kind, &key, initial_gen));
 
         let entries = registry.get_handles();
         assert_eq!(entries.len(), 1);
 
-        assert!(registry.delete(&key, updated_gen));
+        assert!(registry.delete(kind, &key, updated_gen));
 
         let entries = registry.get_handles();
         assert_eq!(entries.len(), 0);

--- a/metrics-util/src/registry.rs
+++ b/metrics-util/src/registry.rs
@@ -1,13 +1,14 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
+use std::fmt::{self, Debug};
 use std::{hash::BuildHasherDefault, iter::repeat};
 
 use hashbrown::{hash_map::RawEntryMut, HashMap};
+use metrics::KeyHasher;
 use parking_lot::RwLock;
-use t1ha::T1haHasher;
 
 use crate::{Hashable, MetricKind};
 
-type RegistryHasher = T1haHasher;
+type RegistryHasher = KeyHasher;
 type RegistryHashMap<K, V> = HashMap<K, Generational<V>, BuildHasherDefault<RegistryHasher>>;
 
 /// Generation counter.
@@ -18,7 +19,6 @@ type RegistryHashMap<K, V> = HashMap<K, Generational<V>, BuildHasherDefault<Regi
 #[derive(Debug, Clone, PartialEq)]
 pub struct Generation(usize);
 
-#[derive(Debug)]
 pub(crate) struct Generational<H>(AtomicUsize, H);
 
 impl<H> Generational<H> {
@@ -36,6 +36,15 @@ impl<H> Generational<H> {
 
     pub fn get_inner(&self) -> &H {
         &self.1
+    }
+}
+
+impl<H: fmt::Debug> fmt::Debug for Generational<H> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Generational")
+            .field("gen", &self.0)
+            .field("inner", &self.1)
+            .finish()
     }
 }
 
@@ -141,10 +150,15 @@ where
             {
                 v
             } else {
-                shard_write.entry(key.clone()).or_insert_with(|| {
-                    let value = init();
-                    Generational::new(value)
-                })
+                let (_, v) = shard_write
+                    .raw_entry_mut()
+                    .from_key_hashed_nocheck(hash, key)
+                    .or_insert(key.clone(), {
+                        let value = init();
+                        Generational::new(value)
+                    });
+
+                v
             };
 
             let result = op(v.get_inner());
@@ -233,6 +247,7 @@ fn idx_to_kind(idx: usize) -> MetricKind {
 #[cfg(test)]
 mod tests {
     use super::{Generational, MetricKind, Registry};
+    use crate::DefaultHashable;
     use std::sync::{
         atomic::{AtomicUsize, Ordering::SeqCst},
         Arc,
@@ -240,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_generation() {
-        let generational = Generational::new(());
+        let generational = Generational::new(1);
         let start_gen = generational.get_generation();
         let start_gen_extra = generational.get_generation();
         assert_eq!(start_gen, start_gen_extra);
@@ -253,14 +268,16 @@ mod tests {
 
     #[test]
     fn test_registry() {
-        let registry = Registry::<u64, Arc<AtomicUsize>>::new();
+        let registry = Registry::<DefaultHashable<u64>, Arc<AtomicUsize>>::new();
+
+        let key = DefaultHashable(1);
 
         let entries = registry.get_handles();
         assert_eq!(entries.len(), 0);
 
         let initial_value = registry.op(
             MetricKind::Counter,
-            &1,
+            &key,
             |h| h.fetch_add(1, SeqCst),
             || Arc::new(AtomicUsize::new(42)),
         );
@@ -274,13 +291,13 @@ mod tests {
             .next()
             .expect("failed to get first entry");
 
-        let (key, (initial_gen, value)) = initial_entry;
-        assert_eq!(key, (MetricKind::Counter, 1));
+        let (ikey, (initial_gen, value)) = initial_entry;
+        assert_eq!(ikey, (MetricKind::Counter, DefaultHashable(1)));
         assert_eq!(value.load(SeqCst), 43);
 
         let update_value = registry.op(
             MetricKind::Counter,
-            &1,
+            &key,
             |h| h.fetch_add(1, SeqCst),
             || Arc::new(AtomicUsize::new(42)),
         );
@@ -294,9 +311,9 @@ mod tests {
             .next()
             .expect("failed to get updated entry");
 
-        let ((kind, key), (updated_gen, value)) = updated_entry;
+        let ((kind, ukey), (updated_gen, value)) = updated_entry;
         assert_eq!(kind, MetricKind::Counter);
-        assert_eq!(key, 1);
+        assert_eq!(ukey, DefaultHashable(1));
         assert_eq!(value.load(SeqCst), 44);
 
         assert!(!registry.delete(kind, &key, initial_gen));

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Changed
+- Switched from `Key` to `&Key` in `Recorder`.
+- Refactored `KeyData` into `Key`.
 
+### Added
+- Metric keys are now pre-hashed/memoized where possible, which provides a massive speedup to
+  hashing operations over time.
 ## [0.14.2] - 2021-02-13
 ### Added
 - Implemented `Ord`/`PartialOrd` for various key-related types.

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -34,10 +34,11 @@ harness = false
 [dependencies]
 metrics-macros = { version = "^0.2", path = "../metrics-macros" }
 proc-macro-hack = "0.5"
+t1ha = "0.1"
 
 [dev-dependencies]
 log = "0.4"
-criterion = "0.3"
+criterion = { version = "0.3", default-features = false, features = ["html_reports", "cargo_bench_support"] }
 rand = "0.8"
 trybuild = "1"
 

--- a/metrics/benches/macros.rs
+++ b/metrics/benches/macros.rs
@@ -9,7 +9,12 @@ use rand::{thread_rng, Rng};
 #[derive(Default)]
 struct TestRecorder;
 impl Recorder for TestRecorder {
-    fn register_counter(&self, _key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {
+    fn register_counter(
+        &self,
+        _key: &Key,
+        _unit: Option<Unit>,
+        _description: Option<&'static str>,
+    ) {
     }
     fn register_gauge(&self, _key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
     fn register_histogram(

--- a/metrics/benches/macros.rs
+++ b/metrics/benches/macros.rs
@@ -9,19 +9,19 @@ use rand::{thread_rng, Rng};
 #[derive(Default)]
 struct TestRecorder;
 impl Recorder for TestRecorder {
-    fn register_counter(&self, _key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {
+    fn register_counter(&self, _key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {
     }
-    fn register_gauge(&self, _key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
+    fn register_gauge(&self, _key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
     fn register_histogram(
         &self,
-        _key: Key,
+        _key: &Key,
         _unit: Option<Unit>,
         _description: Option<&'static str>,
     ) {
     }
-    fn increment_counter(&self, _key: Key, _value: u64) {}
-    fn update_gauge(&self, _key: Key, _value: GaugeValue) {}
-    fn record_histogram(&self, _key: Key, _value: f64) {}
+    fn increment_counter(&self, _key: &Key, _value: u64) {}
+    fn update_gauge(&self, _key: &Key, _value: GaugeValue) {}
+    fn record_histogram(&self, _key: &Key, _value: f64) {}
 }
 
 fn reset_recorder() {

--- a/metrics/examples/basic.rs
+++ b/metrics/examples/basic.rs
@@ -14,36 +14,36 @@ use metrics::{
 struct PrintRecorder;
 
 impl Recorder for PrintRecorder {
-    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         println!(
             "(counter) registered key {} with unit {:?} and description {:?}",
             key, unit, description
         );
     }
 
-    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         println!(
             "(gauge) registered key {} with unit {:?} and description {:?}",
             key, unit, description
         );
     }
 
-    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn register_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
         println!(
             "(histogram) registered key {} with unit {:?} and description {:?}",
             key, unit, description
         );
     }
 
-    fn increment_counter(&self, key: Key, value: u64) {
+    fn increment_counter(&self, key: &Key, value: u64) {
         println!("(counter) got value {} for key {}", value, key);
     }
 
-    fn update_gauge(&self, key: Key, value: GaugeValue) {
+    fn update_gauge(&self, key: &Key, value: GaugeValue) {
         println!("(gauge) got value {:?} for key {}", value, key);
     }
 
-    fn record_histogram(&self, key: Key, value: f64) {
+    fn record_histogram(&self, key: &Key, value: f64) {
         println!("(histogram) got value {} for key {}", value, key);
     }
 }

--- a/metrics/examples/sizes.rs
+++ b/metrics/examples/sizes.rs
@@ -1,9 +1,8 @@
 //! This example is purely for development.
-use metrics::{Key, KeyData, Label, NameParts, SharedString};
+use metrics::{Key, Label, NameParts, SharedString};
 use std::borrow::Cow;
 
 fn main() {
-    println!("KeyData: {} bytes", std::mem::size_of::<KeyData>());
     println!("Key: {} bytes", std::mem::size_of::<Key>());
     println!("NameParts: {} bytes", std::mem::size_of::<NameParts>());
     println!("Label: {} bytes", std::mem::size_of::<Label>());

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -1,3 +1,7 @@
+use std::hash::Hasher;
+
+use t1ha::T1haHasher;
+
 use crate::cow::Cow;
 
 /// An allocation-optimized string.
@@ -9,6 +13,25 @@ use crate::cow::Cow;
 /// `SharedString` can be converted to from either `&'static str` or `String`, with a method,
 /// `const_str`, from constructing `SharedString` from `&'static str` in a `const` fashion.
 pub type SharedString = Cow<'static, str>;
+
+/// Key-specific hashing algorithm.
+///
+/// Currently uses T1ha (Fast Positive Hash).
+///
+/// For any use-case within a `metrics`-owned or adjacent crate, where hashing of a key is required,
+/// this is the hasher that will be used.
+#[derive(Default)]
+pub struct KeyHasher(T1haHasher);
+
+impl Hasher for KeyHasher {
+    fn finish(&self) -> u64 {
+        self.0.finish()
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write(bytes)
+    }
+}
 
 /// Value of a gauge operation.
 #[derive(Clone, Debug)]

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -1,10 +1,8 @@
 use crate::{cow::Cow, IntoLabels, Label, SharedString};
 use alloc::{string::String, vec::Vec};
 use core::{
-    cmp::Ordering,
     fmt,
-    hash::{Hash, Hasher},
-    ops,
+    hash::Hash,
     slice::Iter,
 };
 
@@ -79,19 +77,16 @@ impl fmt::Display for NameParts {
     }
 }
 
-/// Inner representation of [`Key`].
-///
-/// While [`Key`] is the type that users will interact with via [`Recorder`][crate::Recorder],
-/// [`KeyData`] is responsible for the actual storage of the name and label data.
+/// A metric identifier.
 #[derive(PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord)]
-pub struct KeyData {
+pub struct Key {
     // TODO: once const slicing is possible on stable, we could likely use `beef` for both of these
     name_parts: NameParts,
     labels: Cow<'static, [Label]>,
 }
 
-impl KeyData {
-    /// Creates a [`KeyData`] from a name.
+impl Key {
+    /// Creates a [`Key`] from a name.
     pub fn from_name<N>(name: N) -> Self
     where
         N: Into<SharedString>,
@@ -102,7 +97,7 @@ impl KeyData {
         }
     }
 
-    /// Creates a [`KeyData`] from a name and set of labels.
+    /// Creates a [`Key`] from a name and set of labels.
     pub fn from_parts<N, L>(name: N, labels: L) -> Self
     where
         N: Into<NameParts>,
@@ -114,7 +109,7 @@ impl KeyData {
         }
     }
 
-    /// Creates a [`KeyData`] from a static name and non-static set of labels.
+    /// Creates a [`Key`] from a static name and non-static set of labels.
     pub fn from_hybrid<L>(name_parts: &'static [SharedString], labels: L) -> Self
     where
         L: IntoLabels,
@@ -125,7 +120,7 @@ impl KeyData {
         }
     }
 
-    /// Creates a [`KeyData`] from a non-static name and a static set of labels.
+    /// Creates a [`Key`] from a non-static name and a static set of labels.
     pub fn from_static_labels<N>(name: N, labels: &'static [Label]) -> Self
     where
         N: Into<NameParts>,
@@ -136,14 +131,14 @@ impl KeyData {
         }
     }
 
-    /// Creates a [`KeyData`] from a static name.
+    /// Creates a [`Key`] from a static name.
     ///
     /// This function is `const`, so it can be used in a static context.
     pub const fn from_static_name(name_parts: &'static [SharedString]) -> Self {
         Self::from_static_parts(name_parts, &NO_LABELS)
     }
 
-    /// Creates a [`KeyData`] from a static name and static set of labels.
+    /// Creates a [`Key`] from a static name and static set of labels.
     ///
     /// This function is `const`, so it can be used in a static context.
     pub const fn from_static_parts(
@@ -206,12 +201,12 @@ impl KeyData {
     }
 }
 
-impl fmt::Display for KeyData {
+impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.labels.is_empty() {
-            write!(f, "KeyData({})", self.name_parts)
+            write!(f, "Key({})", self.name_parts)
         } else {
-            write!(f, "KeyData({}, [", self.name_parts)?;
+            write!(f, "Key({}, [", self.name_parts)?;
             let mut first = true;
             for label in self.labels.as_ref() {
                 if first {
@@ -226,19 +221,19 @@ impl fmt::Display for KeyData {
     }
 }
 
-impl From<String> for KeyData {
+impl From<String> for Key {
     fn from(name: String) -> Self {
         Self::from_name(name)
     }
 }
 
-impl From<&'static str> for KeyData {
+impl From<&'static str> for Key {
     fn from(name: &'static str) -> Self {
         Self::from_name(name)
     }
 }
 
-impl<N, L> From<(N, L)> for KeyData
+impl<N, L> From<(N, L)> for Key
 where
     N: Into<SharedString>,
     L: IntoLabels,
@@ -251,136 +246,30 @@ where
     }
 }
 
-/// A metric identifier.
-///
-/// While [`KeyData`] holds the actual name and label data for a metric, [`Key`] works similar to
-/// [`std::borrow::Cow`] in that we can either hold an owned version of the key data, or a static
-/// reference to key data initialized elsewhere.
-///
-/// This allows for flexibility in the ways that [`KeyData`] can be passed around and reused, which
-/// allows us to enable performance optimizations in specific circumstances.
-#[derive(Debug, Clone)]
-pub enum Key {
-    /// A statically borrowed [`KeyData`].
-    ///
-    /// If you are capable of keeping a static [`KeyData`] around, this variant can be used to
-    /// reduce allocations and improve performance.
-    Borrowed(&'static KeyData),
-    /// An owned [`KeyData`].
-    ///
-    /// Useful when you need to modify a borrowed [`KeyData`] in-flight, or when there's no way to
-    /// keep around a static [`KeyData`] reference.
-    Owned(KeyData),
-}
-
-impl PartialEq for Key {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_ref() == other.as_ref()
-    }
-}
-
-impl Eq for Key {}
-
-impl PartialOrd for Key {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Key {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.as_ref().cmp(other.as_ref())
-    }
-}
-
-impl Hash for Key {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            Key::Borrowed(inner) => inner.hash(state),
-            Key::Owned(inner) => inner.hash(state),
-        }
-    }
-}
-
-impl Key {
-    /// Converts any kind of [`Key`] into an owned [`KeyData`].
-    ///
-    /// If this key is owned, the value is returned as is, otherwise, the contents are cloned.
-    pub fn into_owned(self) -> KeyData {
-        match self {
-            Self::Borrowed(val) => val.clone(),
-            Self::Owned(val) => val,
-        }
-    }
-}
-
-impl ops::Deref for Key {
-    type Target = KeyData;
-
-    #[must_use]
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Borrowed(val) => val,
-            Self::Owned(val) => val,
-        }
-    }
-}
-
-impl AsRef<KeyData> for Key {
-    #[must_use]
-    fn as_ref(&self) -> &KeyData {
-        match self {
-            Self::Borrowed(val) => val,
-            Self::Owned(val) => val,
-        }
-    }
-}
-
-impl fmt::Display for Key {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Borrowed(val) => val.fmt(f),
-            Self::Owned(val) => val.fmt(f),
-        }
-    }
-}
-
-impl From<KeyData> for Key {
-    fn from(key_data: KeyData) -> Self {
-        Self::Owned(key_data)
-    }
-}
-
-impl From<&'static KeyData> for Key {
-    fn from(key_data: &'static KeyData) -> Self {
-        Self::Borrowed(key_data)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{Key, KeyData};
+    use super::Key;
     use crate::{Label, SharedString};
     use std::collections::HashMap;
 
     static BORROWED_NAME: [SharedString; 1] = [SharedString::const_str("name")];
     static FOOBAR_NAME: [SharedString; 1] = [SharedString::const_str("foobar")];
-    static BORROWED_BASIC: KeyData = KeyData::from_static_name(&BORROWED_NAME);
+    static BORROWED_BASIC: Key = Key::from_static_name(&BORROWED_NAME);
     static LABELS: [Label; 1] = [Label::from_static_parts("key", "value")];
-    static BORROWED_LABELS: KeyData = KeyData::from_static_parts(&BORROWED_NAME, &LABELS);
+    static BORROWED_LABELS: Key = Key::from_static_parts(&BORROWED_NAME, &LABELS);
 
     #[test]
     fn test_key_ord_and_partialord() {
         let keys_expected: Vec<Key> = vec![
-            KeyData::from_name("aaaa").into(),
-            KeyData::from_name("bbbb").into(),
-            KeyData::from_name("cccc").into(),
+            Key::from_name("aaaa").into(),
+            Key::from_name("bbbb").into(),
+            Key::from_name("cccc").into(),
         ];
 
         let keys_unsorted: Vec<Key> = vec![
-            KeyData::from_name("bbbb").into(),
-            KeyData::from_name("cccc").into(),
-            KeyData::from_name("aaaa").into(),
+            Key::from_name("bbbb").into(),
+            Key::from_name("cccc").into(),
+            Key::from_name("aaaa").into(),
         ];
 
         let keys = {
@@ -399,10 +288,10 @@ mod tests {
     }
 
     #[test]
-    fn test_keydata_eq_and_hash() {
+    fn test_key_eq_and_hash() {
         let mut keys = HashMap::new();
 
-        let owned_basic = KeyData::from_name("name");
+        let owned_basic: Key = Key::from_name("name").into();
         assert_eq!(&owned_basic, &BORROWED_BASIC);
 
         let previous = keys.insert(owned_basic, 42);
@@ -412,7 +301,7 @@ mod tests {
         assert_eq!(previous, Some(&42));
 
         let labels = LABELS.to_vec();
-        let owned_labels = KeyData::from_parts(&BORROWED_NAME[..], labels);
+        let owned_labels = Key::from_parts(&BORROWED_NAME[..], labels);
         assert_eq!(&owned_labels, &BORROWED_LABELS);
 
         let previous = keys.insert(owned_labels, 43);
@@ -423,49 +312,23 @@ mod tests {
     }
 
     #[test]
-    fn test_key_eq_and_hash() {
-        let mut keys = HashMap::new();
-
-        let owned_basic: Key = KeyData::from_name("name").into();
-        let borrowed_basic: Key = Key::from(&BORROWED_BASIC);
-        assert_eq!(owned_basic, borrowed_basic);
-
-        let previous = keys.insert(owned_basic, 42);
-        assert!(previous.is_none());
-
-        let previous = keys.get(&borrowed_basic);
-        assert_eq!(previous, Some(&42));
-
-        let labels = LABELS.to_vec();
-        let owned_labels = Key::from(KeyData::from_parts(&BORROWED_NAME[..], labels));
-        let borrowed_labels = Key::from(&BORROWED_LABELS);
-        assert_eq!(owned_labels, borrowed_labels);
-
-        let previous = keys.insert(owned_labels, 43);
-        assert!(previous.is_none());
-
-        let previous = keys.get(&borrowed_labels);
-        assert_eq!(previous, Some(&43));
-    }
-
-    #[test]
     fn test_key_data_proper_display() {
-        let key1 = KeyData::from_name("foobar");
+        let key1 = Key::from_name("foobar");
         let result1 = key1.to_string();
-        assert_eq!(result1, "KeyData(foobar)");
+        assert_eq!(result1, "Key(foobar)");
 
-        let key2 = KeyData::from_parts(&FOOBAR_NAME[..], vec![Label::new("system", "http")]);
+        let key2 = Key::from_parts(&FOOBAR_NAME[..], vec![Label::new("system", "http")]);
         let result2 = key2.to_string();
-        assert_eq!(result2, "KeyData(foobar, [system = http])");
+        assert_eq!(result2, "Key(foobar, [system = http])");
 
-        let key3 = KeyData::from_parts(
+        let key3 = Key::from_parts(
             &FOOBAR_NAME[..],
             vec![Label::new("system", "http"), Label::new("user", "joe")],
         );
         let result3 = key3.to_string();
-        assert_eq!(result3, "KeyData(foobar, [system = http, user = joe])");
+        assert_eq!(result3, "Key(foobar, [system = http, user = joe])");
 
-        let key4 = KeyData::from_parts(
+        let key4 = Key::from_parts(
             &FOOBAR_NAME[..],
             vec![
                 Label::new("black", "black"),
@@ -476,35 +339,7 @@ mod tests {
         let result4 = key4.to_string();
         assert_eq!(
             result4,
-            "KeyData(foobar, [black = black, lives = lives, matter = matter])"
+            "Key(foobar, [black = black, lives = lives, matter = matter])"
         );
-    }
-
-    #[test]
-    fn key_equality() {
-        let owned_a = KeyData::from_name("a");
-        let owned_b = KeyData::from_name("b");
-
-        static A_NAME: [SharedString; 1] = [SharedString::const_str("a")];
-        static STATIC_A: KeyData = KeyData::from_static_name(&A_NAME);
-        static B_NAME: [SharedString; 1] = [SharedString::const_str("b")];
-        static STATIC_B: KeyData = KeyData::from_static_name(&B_NAME);
-
-        assert_eq!(Key::Owned(owned_a.clone()), Key::Owned(owned_a.clone()));
-        assert_eq!(Key::Owned(owned_b.clone()), Key::Owned(owned_b.clone()));
-
-        assert_eq!(Key::Borrowed(&STATIC_A), Key::Borrowed(&STATIC_A));
-        assert_eq!(Key::Borrowed(&STATIC_B), Key::Borrowed(&STATIC_B));
-
-        assert_eq!(Key::Owned(owned_a.clone()), Key::Borrowed(&STATIC_A));
-        assert_eq!(Key::Owned(owned_b.clone()), Key::Borrowed(&STATIC_B));
-
-        assert_eq!(Key::Borrowed(&STATIC_A), Key::Owned(owned_a.clone()));
-        assert_eq!(Key::Borrowed(&STATIC_B), Key::Owned(owned_b.clone()));
-
-        assert_ne!(Key::Owned(owned_a.clone()), Key::Owned(owned_b.clone()),);
-        assert_ne!(Key::Borrowed(&STATIC_A), Key::Borrowed(&STATIC_B));
-        assert_ne!(Key::Owned(owned_a.clone()), Key::Borrowed(&STATIC_B));
-        assert_ne!(Key::Owned(owned_b.clone()), Key::Borrowed(&STATIC_A));
     }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -157,21 +157,21 @@
 //! struct LogRecorder;
 //!
 //! impl Recorder for LogRecorder {
-//!     fn register_counter(&self, key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
+//!     fn register_counter(&self, key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
 //!
-//!     fn register_gauge(&self, key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
+//!     fn register_gauge(&self, key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
 //!
-//!     fn register_histogram(&self, key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
+//!     fn register_histogram(&self, key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
 //!
-//!     fn increment_counter(&self, key: Key, value: u64) {
+//!     fn increment_counter(&self, key: &Key, value: u64) {
 //!         info!("counter '{}' -> {}", key, value);
 //!     }
 //!
-//!     fn update_gauge(&self, key: Key, value: GaugeValue) {
+//!     fn update_gauge(&self, key: &Key, value: GaugeValue) {
 //!         info!("gauge '{}' -> {:?}", key, value);
 //!     }
 //!
-//!     fn record_histogram(&self, key: Key, value: f64) {
+//!     fn record_histogram(&self, key: &Key, value: f64) {
 //!         info!("histogram '{}' -> {}", key, value);
 //!     }
 //! }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -193,11 +193,8 @@
 //! name, so long as they are of different types.
 //!
 //! As the types are enforced/limited by the [`Recorder`] trait itself, the remaining piece is the
-//! identifier, which we handle by using [`Key`].
-//!
-//! [`Key`] itself is a wrapper for [`KeyData`], which holds not only the name of a metric, but
-//! potentially holds labels for it as well.  Metric name and labels consist entirely of string
-//! values.
+//! identifier, which we handle by using [`Key`]. Keys hold both the metric name, and potentially,
+//! labels related to the metric. The metric name and labels are always string values.
 //!
 //! Internally, `metrics` uses a clone-on-write "smart pointer" for these values to optimize cases
 //! where the values are static strings, which can provide significant performance benefits.  These

--- a/metrics/src/recorder.rs
+++ b/metrics/src/recorder.rs
@@ -23,7 +23,7 @@ pub trait Recorder {
     /// not a metric can be reregistered to provide a unit/description, if one was already passed
     /// or not, as well as how units/descriptions are used by the underlying recorder, is an
     /// implementation detail.
-    fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>);
+    fn register_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>);
 
     /// Registers a gauge.
     ///
@@ -31,7 +31,7 @@ pub trait Recorder {
     /// not a metric can be reregistered to provide a unit/description, if one was already passed
     /// or not, as well as how units/descriptions are used by the underlying recorder, is an
     /// implementation detail.
-    fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>);
+    fn register_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>);
 
     /// Registers a histogram.
     ///
@@ -39,16 +39,16 @@ pub trait Recorder {
     /// not a metric can be reregistered to provide a unit/description, if one was already passed
     /// or not, as well as how units/descriptions are used by the underlying recorder, is an
     /// implementation detail.
-    fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>);
+    fn register_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>);
 
     /// Increments a counter.
-    fn increment_counter(&self, key: Key, value: u64);
+    fn increment_counter(&self, key: &Key, value: u64);
 
     /// Updates a gauge.
-    fn update_gauge(&self, key: Key, value: GaugeValue);
+    fn update_gauge(&self, key: &Key, value: GaugeValue);
 
     /// Records a histogram.
-    fn record_histogram(&self, key: Key, value: f64);
+    fn record_histogram(&self, key: &Key, value: f64);
 }
 
 /// A no-op recorder.
@@ -58,19 +58,19 @@ pub trait Recorder {
 pub struct NoopRecorder;
 
 impl Recorder for NoopRecorder {
-    fn register_counter(&self, _key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {
+    fn register_counter(&self, _key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {
     }
-    fn register_gauge(&self, _key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
+    fn register_gauge(&self, _key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
     fn register_histogram(
         &self,
-        _key: Key,
+        _key: &Key,
         _unit: Option<Unit>,
         _description: Option<&'static str>,
     ) {
     }
-    fn increment_counter(&self, _key: Key, _value: u64) {}
-    fn update_gauge(&self, _key: Key, _value: GaugeValue) {}
-    fn record_histogram(&self, _key: Key, _value: f64) {}
+    fn increment_counter(&self, _key: &Key, _value: u64) {}
+    fn update_gauge(&self, _key: &Key, _value: GaugeValue) {}
+    fn record_histogram(&self, _key: &Key, _value: f64) {}
 }
 
 /// Sets the global recorder to a `&'static Recorder`.

--- a/metrics/src/recorder.rs
+++ b/metrics/src/recorder.rs
@@ -58,7 +58,12 @@ pub trait Recorder {
 pub struct NoopRecorder;
 
 impl Recorder for NoopRecorder {
-    fn register_counter(&self, _key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {
+    fn register_counter(
+        &self,
+        _key: &Key,
+        _unit: Option<Unit>,
+        _description: Option<&'static str>,
+    ) {
     }
     fn register_gauge(&self, _key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
     fn register_histogram(


### PR DESCRIPTION
In timberio/vector#7014, @blt [remarked](https://github.com/timberio/vector/pull/7014#discussion_r608767945) that they spend a lot of time creating temporary `Key` instances, to the point it shows up in profiling.  This gave me an idea that we could, in the static case, avoid this entirely by passing `&Key` around instead of `Key`.

In this PR, we're doing two major things:
- `Recorder` now takes `&Key` instead of `Key`
- `Registry` has been reworked/optimized to support `&Key` in the process

Obviously, we've reworked a lot of boundaries/`Recorder` implementations (i.e. layers) to support the switch to `&Key`.  In turn, `KeyData` is now `Key`.  As now we only have `&Key` to work with, we had to modify `Registry` as well.  Rather than clone the key every time and continue using the `dashmap`/entry API approach, we've reworked `Registry`.

Given the primary use case, we've encoded the metric kind itself into `Registry`, so operating on the registry requires specifying a reference to the key type _and_ the metric kind.  This lets us avoid having to rewrap the key in a new type (another allocation!) but we also avoid having to hash the kind, instead transforming it to an index we use for a fast lookup.

Long story short, we've made `Registry` significantly faster -- 45 to 55% faster --  and we've reduced the number of temporaries required for the optimized static path.