### PR TITLE
Fix name of constant in macro expansion

### DIFF
--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -425,7 +425,7 @@ fn generate_metric_key(name: &Expr, labels: &Option<Labels>) -> TokenStream2 {
         // to figure out the correct key.
         if has_labels {
             quote! {
-                metrics::Key::Owned(metrics::KeyData::from_parts(#name, & METRICS_LABELS))
+                metrics::Key::Owned(metrics::KeyData::from_parts(#name, & METRIC_LABELS))
             }
         } else {
             quote! {

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -227,7 +227,7 @@ fn test_get_expanded_callsite_owned_name_static_inline_labels() {
         "{ ",
         "static METRIC_LABELS : [metrics :: Label ; 1usize] = [metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Owned (metrics :: KeyData :: from_parts (String :: from (\"owned\") , & METRICS_LABELS)) , 1) ; ",
+        "recorder . myop_mytype (metrics :: Key :: Owned (metrics :: KeyData :: from_parts (String :: from (\"owned\") , & METRIC_LABELS)) , 1) ; ",
         "} ",
         "}",
     );


### PR DESCRIPTION
One macro branch errorneously referenced METRIC_LABELS as METRICS_LABELS, leading to compilation failures.