### PR TITLE
Bump MSRV to pass tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_version: ['1.46.0', 'stable', 'nightly']
+        rust_version: ['1.49.0', 'stable', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
After upgrading to the latest `ndarray`, they've bumped their MSRV to 1.49.0, so we're following.  This still gives us "three latest versions" worth of support, so we should be fine.