### PR TITLE
Support non-literal names along with literal labels in macros

### DIFF
--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -425,7 +425,7 @@ fn generate_metric_key(name: &Expr, labels: &Option<Labels>) -> TokenStream2 {
         // to figure out the correct key.
         if has_labels {
             quote! {
-                metrics::Key::Owned(metrics::KeyData::from_parts(#name, & METRIC_LABELS))
+                metrics::Key::Owned(metrics::KeyData::from_static_labels(#name, &METRIC_LABELS))
             }
         } else {
             quote! {

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -227,7 +227,7 @@ fn test_get_expanded_callsite_owned_name_static_inline_labels() {
         "{ ",
         "static METRIC_LABELS : [metrics :: Label ; 1usize] = [metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . myop_mytype (metrics :: Key :: Owned (metrics :: KeyData :: from_parts (String :: from (\"owned\") , & METRIC_LABELS)) , 1) ; ",
+        "recorder . myop_mytype (metrics :: Key :: Owned (metrics :: KeyData :: from_static_labels (String :: from (\"owned\") , & METRIC_LABELS)) , 1) ; ",
         "} ",
         "}",
     );

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -125,6 +125,17 @@ impl KeyData {
         }
     }
 
+    /// Creates a [`KeyData`] from a non-static name and a static set of labels.
+    pub fn from_static_labels<N>(name: N, labels: &'static [Label]) -> Self
+    where
+        N: Into<NameParts>,
+    {
+        Self {
+            name_parts: name.into(),
+            labels: Cow::<[Label]>::const_slice(labels),
+        }
+    }
+
     /// Creates a [`KeyData`] from a static name.
     ///
     /// This function is `const`, so it can be used in a static context.

--- a/metrics/tests/macros/01_basic.rs
+++ b/metrics/tests/macros/01_basic.rs
@@ -1,12 +1,28 @@
 use metrics::counter;
 
-fn static_key() {
+fn literal_key() {
     counter!("abcdef", 1);
 }
 
-fn dynamic_key() {
+fn literal_key_literal_labels() {
+    counter!("abcdef", 1, "uvw" => "xyz");
+}
+
+fn nonliteral_key() {
     let some_u16 = 0u16;
     counter!(format!("response_status_{}", some_u16), 1);
+}
+
+fn nonliteral_key_literal_labels() {
+    let some_u16 = 0u16;
+    counter!(format!("response_status_{}", some_u16), 1, "uvw" => "xyz");
+}
+
+fn nonliteral_key_nonliteral_labels() {
+    let some_u16 = 0u16;
+    let dynamic_val = "xyz";
+    let labels = [("uvw", format!("{}!", dynamic_val))];
+    counter!(format!("response_status_{}", some_u16), 12, &labels);
 }
 
 fn main() {}


### PR DESCRIPTION
Arrays of Labels don't implement `IntoLabels`. They have already a static lifetime and can be borrowed instead of owned. Introduce `KeyedData::from_static_labels(..)` to support the use case of a non-literal name and a literal label set. Also add tests for that case.

Fixes #196.

Without the change, the newly added test cases fail with

```
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0277]: the trait bound `Label: From<&Label>` is not satisfied
   --> $DIR/01_basic.rs:18:5
    |
18  |     counter!(format!("response_status_{}", some_u16), 1, "uvw" => "xyz");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&Label>` is not implemented for `Label`
    |
   ::: $WORKSPACE/metrics/src/key.rs
    |
    |         L: IntoLabels,
    |            ---------- required by this bound in `KeyData::from_parts`
    |
    = help: the following implementations were found:
              <Label as From<&(K, V)>>
    = note: required because of the requirements on the impl of `Into<Label>` for `&Label`
    = note: required because of the requirements on the impl of `IntoLabels` for `&[Label; 1]`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```