### PR TITLE
metrics-exporter-prometheus: Add support for subnet allow list

### DIFF
--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Added
+- `PrometheusBuilder::add_allowed`, which enables the exporter to be configured with a
+  list of IP addresses or subnets that are allowed to connect. By default, no restrictions
+  are enforced.
 
 ## [0.3.0] - 2021-02-02
 ### Changed

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["metrics", "telemetry", "prometheus"]
 
 [features]
 default = ["tokio-exporter"]
-tokio-exporter = ["hyper", "tokio"]
+tokio-exporter = ["hyper", "ipnet", "tokio"]
 
 [dependencies]
 metrics = { version = "^0.14", path = "../metrics" }
@@ -28,6 +28,7 @@ quanta = "0.7"
 
 # Optional
 hyper = { version = "0.14", default-features = false, features = ["server", "tcp", "http1"], optional = true }
+ipnet = { version = "2", optional = true }
 tokio = { version = "1.0", features = ["rt", "net", "time", "macros"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This enables access to the Prometheus scrape endpoint to be restricted to a defined set of IPs and/or subnets.

Note that this on its own is insufficient for access control, if the exporter is running in an environment alongside applications (such as web browsers) that are susceptible to [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding). I plan to add support for HTTP auth in a subsequent PR.