### PR TITLE
metrics-exporter-prometheus: sanitize matchers the same as input keys

### DIFF
--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -118,7 +118,7 @@ impl PrometheusBuilder {
     /// It only affects matching metrics if set_buckets was not used.
     pub fn set_buckets_for_metric(mut self, matcher: Matcher, values: &[f64]) -> Self {
         let buckets = self.bucket_overrides.get_or_insert_with(HashMap::new);
-        buckets.insert(matcher, values.to_vec());
+        buckets.insert(matcher.sanitized(), values.to_vec());
         self
     }
 
@@ -349,27 +349,27 @@ mod tests {
 
         let recorder = PrometheusBuilder::new()
             .set_buckets_for_metric(
-                Matcher::Full("metrics_testing_foo".to_owned()),
+                Matcher::Full("metrics.testing foo".to_owned()),
                 &FULL_VALUES[..],
             )
             .set_buckets_for_metric(
-                Matcher::Prefix("metrics_testing".to_owned()),
+                Matcher::Prefix("metrics.testing".to_owned()),
                 &PREFIX_VALUES[..],
             )
             .set_buckets_for_metric(Matcher::Suffix("foo".to_owned()), &SUFFIX_VALUES[..])
             .set_buckets(&DEFAULT_VALUES[..])
             .build();
 
-        let full_key = Key::from_name("metrics_testing_foo");
+        let full_key = Key::from_name("metrics.testing_foo");
         recorder.record_histogram(&full_key, FULL_VALUES[0]);
 
-        let prefix_key = Key::from_name("metrics_testing_bar");
+        let prefix_key = Key::from_name("metrics.testing_bar");
         recorder.record_histogram(&prefix_key, PREFIX_VALUES[1]);
 
         let suffix_key = Key::from_name("metrics_testin_foo");
         recorder.record_histogram(&suffix_key, SUFFIX_VALUES[2]);
 
-        let default_key = Key::from_name("metrics_wee");
+        let default_key = Key::from_name("metrics.wee");
         recorder.record_histogram(&default_key, DEFAULT_VALUES[2] + 1.0);
 
         let full_data = concat!(

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -6,7 +6,7 @@ use parking_lot::RwLock;
 use metrics::{GaugeValue, Key, Recorder, Unit};
 use metrics_util::{Handle, MetricKind, Recency, Registry};
 
-use crate::common::Snapshot;
+use crate::common::{sanitize_key_name, Snapshot};
 use crate::distribution::{Distribution, DistributionBuilder};
 
 pub(crate) struct Inner {
@@ -294,8 +294,7 @@ impl PrometheusHandle {
 }
 
 fn key_to_parts(key: &Key, defaults: &HashMap<String, String>) -> (String, Vec<String>) {
-    let sanitize = |c| c == '.' || c == '=' || c == '{' || c == '}' || c == '+' || c == '-';
-    let name = key.name().to_string().replace(sanitize, "_");
+    let name = sanitize_key_name(key.name());
     let mut values = defaults.clone();
     key.labels().into_iter().for_each(|label| {
         values.insert(label.key().into(), label.value().into());


### PR DESCRIPTION
This PR addresses #173, which is related to the mismatch/ergonomics of how matchers are used against metric keys.

Now, we ensure that matchers are "sanitized" in the same way we sanitize keys to match the Prometheus restrictions.  In addition, we've also improved the key sanitation.  While the previous sanitizer code dealt with _known_ issues, the new code is closer to the actual specification for what a Prometheus metric name can be.