### PR TITLE
metrics-util: make generation tracking configurable in Registry

### DIFF
--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -3,7 +3,7 @@ use getopts::Options;
 use hdrhistogram::Histogram;
 use log::{error, info};
 use metrics::{gauge, histogram, increment_counter, GaugeValue, Key, Recorder, Unit};
-use metrics_util::{Handle, MetricKind, Registry};
+use metrics_util::{Handle, MetricKind, Registry, Tracked};
 use quanta::{Clock, Instant as QuantaInstant};
 use std::{
     env,
@@ -19,7 +19,7 @@ use std::{
 const LOOP_SAMPLE: u64 = 1000;
 
 pub struct Controller {
-    registry: Arc<Registry<Key, Handle>>,
+    registry: Arc<Registry<Key, Handle, Tracked<Handle>>>,
 }
 
 impl Controller {
@@ -40,14 +40,14 @@ impl Controller {
 ///
 /// Simulates typical recorder implementations by utilizing `Registry`, clearing histogram buckets, etc.
 pub struct BenchmarkingRecorder {
-    registry: Arc<Registry<Key, Handle>>,
+    registry: Arc<Registry<Key, Handle, Tracked<Handle>>>,
 }
 
 impl BenchmarkingRecorder {
     /// Creates a new `BenchmarkingRecorder`.
     pub fn new() -> BenchmarkingRecorder {
         BenchmarkingRecorder {
-            registry: Arc::new(Registry::new()),
+            registry: Arc::new(Registry::<Key, Handle, Tracked<Handle>>::tracked()),
         }
     }
 

--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -3,7 +3,7 @@ use getopts::Options;
 use hdrhistogram::Histogram;
 use log::{error, info};
 use metrics::{gauge, histogram, increment_counter, GaugeValue, Key, Recorder, Unit};
-use metrics_util::{Handle, MetricKind, Registry, Tracked};
+use metrics_util::{Handle, MetricKind, NotTracked, Registry, Tracked};
 use quanta::{Clock, Instant as QuantaInstant};
 use std::{
     env,

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 
 use metrics::{GaugeValue, Key, Recorder, Unit};
-use metrics_util::{Handle, MetricKind, Recency, Registry};
+use metrics_util::{Handle, MetricKind, Recency, Registry, Tracked};
 
 use crate::common::{sanitize_key_name, Snapshot};
 use crate::distribution::{Distribution, DistributionBuilder};
 
 pub(crate) struct Inner {
-    pub registry: Registry<Key, Handle>,
+    pub registry: Registry<Key, Handle, Tracked<Handle>>,
     pub recency: Recency<Key>,
     pub distributions: RwLock<HashMap<String, HashMap<Vec<String>, Distribution>>>,
     pub distribution_builder: DistributionBuilder,
@@ -19,7 +19,7 @@ pub(crate) struct Inner {
 }
 
 impl Inner {
-    pub fn registry(&self) -> &Registry<Key, Handle> {
+    pub fn registry(&self) -> &Registry<Key, Handle, Tracked<Handle>> {
         &self.registry
     }
 

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -1,18 +1,18 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use metrics::{Key, Label};
-use metrics_util::{MetricKind, Registry};
+use metrics_util::{MetricKind, NotTracked, Registry};
 
 fn registry_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("registry");
+    let mut group = c.benchmark_group("registry (not tracked)");
     group.bench_function("cached op (basic)", |b| {
-        let registry: Registry<Key, ()> = Registry::new();
+        let registry = Registry::<Key, (), NotTracked<()>>::untracked();
         static KEY_NAME: &'static str = "simple_key";
         static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
 
         b.iter(|| registry.op(MetricKind::Counter, &KEY_DATA, |_| (), || ()))
     });
     group.bench_function("cached op (labels)", |b| {
-        let registry: Registry<Key, ()> = Registry::new();
+        let registry = Registry::<Key, (), NotTracked<()>>::untracked();
         static KEY_NAME: &'static str = "simple_key";
         static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
         static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
@@ -21,7 +21,7 @@ fn registry_benchmark(c: &mut Criterion) {
     });
     group.bench_function("uncached op (basic)", |b| {
         b.iter_batched_ref(
-            || Registry::<Key, ()>::new(),
+            || Registry::<Key, (), NotTracked<()>>::untracked(),
             |registry| {
                 let key = "simple_key".into();
                 registry.op(MetricKind::Counter, &key, |_| (), || ())
@@ -31,7 +31,7 @@ fn registry_benchmark(c: &mut Criterion) {
     });
     group.bench_function("uncached op (labels)", |b| {
         b.iter_batched_ref(
-            || Registry::<Key, ()>::new(),
+            || Registry::<Key, (), NotTracked<()>>::untracked(),
             |registry| {
                 let labels = vec![Label::new("type", "http")];
                 let key = ("simple_key", labels).into();
@@ -43,7 +43,7 @@ fn registry_benchmark(c: &mut Criterion) {
     group.bench_function("registry overhead", |b| {
         b.iter_batched(
             || (),
-            |_| Registry::<Key, ()>::new(),
+            |_| Registry::<Key, (), NotTracked<()>>::untracked(),
             BatchSize::NumIterations(1),
         )
     });

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use metrics::{Key, Label};
-use metrics_util::{MetricKind, NotTracked, Registry};
+use metrics_util::{MetricKind, NotTracked, Registry, Tracked};
 
 fn registry_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("registry (not tracked)");
@@ -40,13 +40,62 @@ fn registry_benchmark(c: &mut Criterion) {
             BatchSize::SmallInput,
         )
     });
-    group.bench_function("registry overhead", |b| {
+    group.bench_function("creation overhead", |b| {
         b.iter_batched(
             || (),
             |_| Registry::<Key, (), NotTracked<()>>::untracked(),
             BatchSize::NumIterations(1),
         )
     });
+    group.finish();
+
+    let mut group = c.benchmark_group("registry (tracked)");
+    group.bench_function("cached op (basic)", |b| {
+        let registry = Registry::<Key, (), Tracked<()>>::tracked();
+        static KEY_NAME: &'static str = "simple_key";
+        static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
+
+        b.iter(|| registry.op(MetricKind::Counter, &KEY_DATA, |_| (), || ()))
+    });
+    group.bench_function("cached op (labels)", |b| {
+        let registry = Registry::<Key, (), Tracked<()>>::tracked();
+        static KEY_NAME: &'static str = "simple_key";
+        static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
+        static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+
+        b.iter(|| registry.op(MetricKind::Counter, &KEY_DATA, |_| (), || ()))
+    });
+    group.bench_function("uncached op (basic)", |b| {
+        b.iter_batched_ref(
+            || Registry::<Key, (), Tracked<()>>::tracked(),
+            |registry| {
+                let key = "simple_key".into();
+                registry.op(MetricKind::Counter, &key, |_| (), || ())
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("uncached op (labels)", |b| {
+        b.iter_batched_ref(
+            || Registry::<Key, (), NotTracked<()>>::tracked(),
+            |registry| {
+                let labels = vec![Label::new("type", "http")];
+                let key = ("simple_key", labels).into();
+                registry.op(MetricKind::Counter, &key, |_| (), || ())
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("creation overhead", |b| {
+        b.iter_batched(
+            || (),
+            |_| Registry::<Key, (), Tracked<()>>::tracked(),
+            BatchSize::NumIterations(1),
+        )
+    });
+    group.finish();
+
+    let mut group = c.benchmark_group("registry (common)");
     group.bench_function("const key overhead (basic)", |b| {
         b.iter(|| {
             static KEY_NAME: &'static str = "simple_key";

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -2,7 +2,7 @@ use core::hash::Hash;
 use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, fmt::Debug};
 
-use crate::{handle::Handle, kind::MetricKind, registry::Registry, CompositeKey};
+use crate::{handle::Handle, kind::MetricKind, registry::Registry, CompositeKey, NotTracked};
 
 use indexmap::IndexMap;
 use metrics::{GaugeValue, Key, Recorder, Unit};
@@ -25,7 +25,7 @@ pub enum DebugValue {
 
 /// Captures point-in-time snapshots of `DebuggingRecorder`.
 pub struct Snapshotter {
-    registry: Arc<Registry<Key, Handle>>,
+    registry: Arc<Registry<Key, Handle, NotTracked<Handle>>>,
     metrics: Option<Arc<Mutex<IndexMap<CompositeKey, ()>>>>,
     units: UnitMap,
     descs: DescriptionMap,
@@ -99,7 +99,7 @@ impl Snapshotter {
 /// Callers can easily take snapshots of the metrics at any given time and get access
 /// to the raw values.
 pub struct DebuggingRecorder {
-    registry: Arc<Registry<Key, Handle>>,
+    registry: Arc<Registry<Key, Handle, NotTracked<Handle>>>,
     metrics: Option<Arc<Mutex<IndexMap<CompositeKey, ()>>>>,
     units: Arc<Mutex<HashMap<CompositeKey, Unit>>>,
     descs: Arc<Mutex<HashMap<CompositeKey, &'static str>>>,
@@ -124,7 +124,7 @@ impl DebuggingRecorder {
         };
 
         DebuggingRecorder {
-            registry: Arc::new(Registry::new()),
+            registry: Arc::new(Registry::<Key, Handle, NotTracked<Handle>>::untracked()),
             metrics,
             units: Arc::new(Mutex::new(HashMap::new())),
             descs: Arc::new(Mutex::new(HashMap::new())),

--- a/metrics-util/src/lib.rs
+++ b/metrics-util/src/lib.rs
@@ -24,7 +24,7 @@ pub use quantile::{parse_quantiles, Quantile};
 #[cfg(feature = "std")]
 mod registry;
 #[cfg(feature = "std")]
-pub use registry::{Generation, Registry};
+pub use registry::{Generation, Generational, NotTracked, Registry, Tracked};
 
 mod common;
 pub use common::*;

--- a/metrics-util/src/recency.rs
+++ b/metrics-util/src/recency.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 use std::{collections::HashMap, ops::DerefMut};
 
-use crate::{kind::MetricKindMask, Generation, Hashable, MetricKind, Registry};
+use crate::{kind::MetricKindMask, Generation, Generational, Hashable, MetricKind, Registry};
 
 use parking_lot::Mutex;
 use quanta::{Clock, Instant};
@@ -64,16 +64,17 @@ impl<K> Recency<K> {
     /// If the generation does not match, this indicates that the key was updated between querying
     /// it from the registry and calling this method, and this method will return `true` in those
     /// cases, and `false` for all remaining cases.
-    pub fn should_store<H>(
+    pub fn should_store<H, G>(
         &self,
         kind: MetricKind,
         key: &K,
         gen: Generation,
-        registry: &Registry<K, H>,
+        registry: &Registry<K, H, G>,
     ) -> bool
     where
         K: Debug + Eq + Hashable + Clone + 'static,
         H: Debug + Clone + 'static,
+        G: Generational<H>,
     {
         if let Some(idle_timeout) = self.idle_timeout {
             if self.mask.matches(kind) {

--- a/metrics-util/src/recency.rs
+++ b/metrics-util/src/recency.rs
@@ -90,7 +90,7 @@ impl<K> Recency<K> {
                             // If the delete returns false, that means that our generation counter is
                             // out-of-date, and that the metric has been updated since, so we don't
                             // actually want to delete it yet.
-                            if registry.delete(kind, &key, gen) {
+                            if registry.delete_with_gen(kind, &key, gen) {
                                 return false;
                             }
                         }


### PR DESCRIPTION
We added generation tracking to `Registry` back when we were adding the ability to cull idle metrics from `metrics-exporter-prometheus`.  This imposes extra overhead on every registry access in the form of ticking up an atomic.  Not the end of the world in low-throughput use cases, but it can be a noticeable impact on performance at the top end.

This PR makes generation tracking configurable by introducing a new trait -- `Generational` -- that allows tracking to be enabled or disabled via a type parameter in `Registry`.  We've introduced two types -- `Tracked` and `NotTracked` -- that control how generations are manipulated.  While `Registry::op` itself is still blindly calling `increment_generation`, it can be compiled into a no-op (ha) when `NotTracked` is used, and so on.

In microbenchmarks, the performance between the two is only seemingly good for 1-3ns savings, but under full load in `metrics-benchmark`, we can observe a 20% _increase_ in throughput when generation tracking is disabled for a single producer, and a 14% increase in throughput for four producers.