### PR TITLE
Fix minium version of crossbeam-epoch

### DIFF
--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -44,7 +44,7 @@ harness = false
 
 [dependencies]
 metrics = { version = "^0.16", path = "../metrics", features = ["std"] }
-crossbeam-epoch = { version = "0.9", optional = true }
+crossbeam-epoch = { version = "0.9.2", optional = true }
 crossbeam-utils = { version = "0.8", default-features = false, optional = true }
 atomic-shim = { version = "0.1", optional = true }
 aho-corasick = { version = "0.7", optional = true }


### PR DESCRIPTION
The Atomic::compare_exchange function only appears in 0.9.2.