### PR TITLE
Switch from t1ha to aHash as the default hasher

### DIFF
--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -56,7 +56,7 @@ sketches-ddsketch = { version = "0.1", optional = true }
 radix_trie = { version = "0.2", optional = true }
 ordered-float = "2.0"
 num_cpus = "1"
-t1ha = "0.1"
+ahash = "0.7.4"
 hashbrown = "0.11"
 
 [dev-dependencies]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -30,7 +30,7 @@ harness = false
 [dependencies]
 metrics-macros = { version = "^0.4", path = "../metrics-macros" }
 proc-macro-hack = "0.5"
-t1ha = "0.1"
+ahash = "0.7.4"
 
 [dev-dependencies]
 log = "0.4"

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -1,6 +1,6 @@
 use std::hash::Hasher;
 
-use t1ha::T1haHasher;
+use ahash::AHasher;
 
 use crate::cow::Cow;
 
@@ -16,12 +16,12 @@ pub type SharedString = Cow<'static, str>;
 
 /// Key-specific hashing algorithm.
 ///
-/// Currently uses T1ha (Fast Positive Hash).
+/// Currently uses AHash - <https://github.com/tkaitchuck/aHash>
 ///
 /// For any use-case within a `metrics`-owned or adjacent crate, where hashing of a key is required,
 /// this is the hasher that will be used.
 #[derive(Default)]
-pub struct KeyHasher(T1haHasher);
+pub struct KeyHasher(AHasher);
 
 impl Hasher for KeyHasher {
     fn finish(&self) -> u64 {


### PR DESCRIPTION
The t1ha crate/hasher causes a global-buffer-overflow when testing under ASAN. This
change switches the default hash implementation to aHash which has a
similar performance approach. The switch to aHash removes the global-buffer-overflow and the tests
complete successfully.

In general, cargo bench shows performance improvements as high as 31% on
specific benches.

There are 3 regressions and 29 improvements total.

ASAN Error: 
```
$ RUSTFLAGS="-Z sanitizer=address" cargo +nightly test --target x86_64-unknown-linux-gnu
warning: unused import: `NotTracked`
 --> metrics-benchmark/src/main.rs:6:40
  |
6 | use metrics_util::{Handle, MetricKind, NotTracked, Registry, Tracked};
  |                                        ^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 0.08s
     Running unittests (target/x86_64-unknown-linux-gnu/debug/deps/metrics-8494627d15b7e631)

running 4 tests
=================================================================
==1972657==ERROR: AddressSanitizer: global-buffer-overflow on address 0x565030342364 at pc 0x5650302053aa bp 0x7f94a8bf7de0 sp 0x7f94a8bf75a8
READ of size 8 at 0x565030342364 thread T3 (key::tests::tes)
    #0 0x5650302053a9 in __asan_memcpy /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:22:3
    #1 0x5650302e70f8 in core::intrinsics::copy_nonoverlapping::hefa96bf49f99146f /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/core/src/intrinsics.rs:1861:14
    #2 0x5650302e683b in core::ptr::read::hc4f75bbcc0c6f5b7 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/core/src/ptr/mod.rs:694:9
    #3 0x5650302e9869 in _$LT$t1ha..bits..LittenEndianAligned$LT$T$GT$$u20$as$u20$t1ha..bits..MemoryModel$GT$::fetch::hc2a7ff3e263707b3 /home/jeff/.cargo/registry/src/github.com-1ecc6299db9ec823/t1ha-0.1.0/src/bits.rs:52:9
    #4 0x5650302e9869 in _$LT$t1ha..bits..LittenEndianAligned$LT$T$GT$$u20$as$u20$t1ha..bits..MemoryModel$GT$::tail::h4d06e0c71207275b /home/jeff/.cargo/registry/src/github.com-1ecc6299db9ec823/t1ha-0.1.0/src/bits.rs:61:9
    #5 0x5650302e9869 in t1ha::t1ha1::t1h1_body::h70ca5bde7754e66d /home/jeff/.cargo/registry/src/github.com-1ecc6299db9ec823/t1ha-0.1.0/src/t1ha1.rs:107:38
    #6 0x5650302e9869 in t1ha::t1ha1::t1ha1_le::h33799f67811a964c /home/jeff/.cargo/registry/src/github.com-1ecc6299db9ec823/t1ha-0.1.0/src/t1ha1.rs:30:18
    #7 0x5650302e6ff1 in t1ha::t1ha0::h1912a789ea47854f /home/jeff/.cargo/registry/src/github.com-1ecc6299db9ec823/t1ha-0.1.0/src/lib.rs:146:5
    #8 0x56503029cc2f in _$LT$t1ha..T1haHasher$u20$as$u20$core..hash..Hasher$GT$::write::h9c2e0d93b3705b89 /home/jeff/.cargo/registry/src/github.com-1ecc6299db9ec823/t1ha-0.1.0/src/lib.rs:93:28
    #9 0x56503029de9b in _$LT$metrics..common..KeyHasher$u20$as$u20$core..hash..Hasher$GT$::write::hfa04ecc9115c2706 /home/jeff/code/metrics-github/metrics/src/common.rs:32:9
    #10 0x56503029c9d9 in core::hash::impls::_$LT$impl$u20$core..hash..Hash$u20$for$u20$str$GT$::hash::h4c0d344377df0387 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/core/src/hash/mod.rs:638:13
    #11 0x56503026e403 in _$LT$metrics..cow..Cow$LT$T$GT$$u20$as$u20$core..hash..Hash$GT$::hash::hf0c112dd17012290 /home/jeff/code/metrics-github/metrics/src/cow.rs:122:9
    #12 0x5650302a58de in metrics::key::key_hasher_impl::hcfca68b14c3a082e /home/jeff/code/metrics-github/metrics/src/key.rs:136:5
    #13 0x56503028b22b in metrics::key::generate_key_hash::hf690e4b34460810e /home/jeff/code/metrics-github/metrics/src/key.rs:131:5
    #14 0x56503028ac29 in metrics::key::Key::builder::h26bce8df8039857a /home/jeff/code/metrics-github/metrics/src/key.rs:78:20
    #15 0x5650302a4ff5 in metrics::key::Key::from_name::h643c953bcbf95097 /home/jeff/code/metrics-github/metrics/src/key.rs:30:9
    #16 0x565030245b36 in metrics::key::tests::test_key_eq_and_hash::h5632655e6ef0fe17 /home/jeff/code/metrics-github/metrics/src/key.rs:264:32
    #17 0x5650302876a9 in metrics::key::tests::test_key_eq_and_hash::_$u7b$$u7b$closure$u7d$$u7d$::h02cb1d5f6f7a0804 /home/jeff/code/metrics-github/metrics/src/key.rs:261:5
    #18 0x565030291cff in core::ops::function::FnOnce::call_once::ha8415c1e398bd39b /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/core/src/ops/function.rs:227:5
    #19 0x5650302d1f42 in core::ops::function::FnOnce::call_once::h27530275e622330b /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/core/src/ops/function.rs:227:5
    #20 0x5650302d1f42 in test::__rust_begin_short_backtrace::h44c82cc7d0f4937d /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/test/src/lib.rs:577:5
    #21 0x5650302d09db in _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h20c7d4b3f228af07 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/alloc/src/boxed.rs:1575:9
    #22 0x5650302d09db in _$LT$std..panic..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::hbecd070b87bd6780 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/panic.rs:347:9
    #23 0x5650302d09db in std::panicking::try::do_call::h5b1333e8bd607b9c /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/panicking.rs:401:40
    #24 0x5650302d09db in std::panicking::try::h057fd2077bd509e5 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/panicking.rs:365:19
    #25 0x5650302d09db in std::panic::catch_unwind::h2f57d52ee610e8fc /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/panic.rs:434:14
    #26 0x5650302d09db in test::run_test_in_process::h9a32ca2677c7f812 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/test/src/lib.rs:600:18
    #27 0x5650302d09db in test::run_test::run_test_inner::_$u7b$$u7b$closure$u7d$$u7d$::hb449ab58fec32d94 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/test/src/lib.rs:492:39
    #28 0x5650302aa091 in test::run_test::run_test_inner::_$u7b$$u7b$closure$u7d$$u7d$::h08d55d9698ad3c92 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/test/src/lib.rs:519:37
    #29 0x5650302aa091 in std::sys_common::backtrace::__rust_begin_short_backtrace::h739a7c7a988c8471 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/sys_common/backtrace.rs:125:18
    #30 0x5650302adc97 in std::thread::Builder::spawn_unchecked::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::hff87f6709b4599d6 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/thread/mod.rs:481:17
    #31 0x5650302adc97 in _$LT$std..panic..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::heedb21d3eb169296 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/panic.rs:347:9
    #32 0x5650302adc97 in std::panicking::try::do_call::h74a412fd6dfdff13 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/panicking.rs:401:40
    #33 0x5650302adc97 in std::panicking::try::h90801934282c25f3 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/panicking.rs:365:19
    #34 0x5650302adc97 in std::panic::catch_unwind::hee752c1088dd1104 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/panic.rs:434:14
    #35 0x5650302adc97 in std::thread::Builder::spawn_unchecked::_$u7b$$u7b$closure$u7d$$u7d$::h36779ab69c69bb28 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/thread/mod.rs:480:30
    #36 0x5650302adc97 in core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h3dcc0d5454468332 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/core/src/ops/function.rs:227:5
    #37 0x56503030ea26 in _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::hd1f9b751a68dd2ac /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/alloc/src/boxed.rs:1575:9
    #38 0x56503030ea26 in _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h22d732940e85619f /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/alloc/src/boxed.rs:1575:9
    #39 0x56503030ea26 in std::sys::unix::thread::Thread::new::thread_start::h04c7a9e17ed1032c /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/sys/unix/thread.rs:71:17
    #40 0x7f94ac960608 in start_thread /build/glibc-eX1tMB/glibc-2.31/nptl/pthread_create.c:477:8
    #41 0x7f94ac732292 in clone /build/glibc-eX1tMB/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

0x565030342364 is located 60 bytes to the left of global variable 'alloc658' defined in '1yuj5mt4khbr5bfe' (0x5650303423a0) of size 6
0x565030342364 is located 0 bytes to the right of global variable 'alloc638' defined in '1yuj5mt4khbr5bfe' (0x565030342360) of size 4
SUMMARY: AddressSanitizer: global-buffer-overflow /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:22:3 in __asan_memcpy
Shadow bytes around the buggy address:
  0x0aca86060410: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0aca86060420: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0aca86060430: 00 00 00 00 00 00 00 00 00 00 00 00 00 01 f9 f9
  0x0aca86060440: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 01 f9
  0x0aca86060450: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0aca86060460: 00 00 00 00 00 00 00 00 00 00 00 00[04]f9 f9 f9
  0x0aca86060470: f9 f9 f9 f9 06 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0aca86060480: 03 f9 f9 f9 f9 f9 f9 f9 05 f9 f9 f9 f9 f9 f9 f9
  0x0aca86060490: 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x0aca860604a0: 04 f9 f9 f9 f9 f9 f9 f9 00 00 02 f9 f9 f9 f9 f9
  0x0aca860604b0: 00 00 00 00 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
Thread T3 (key::tests::tes) created by T0 here:
    #0 0x5650301f044c in pthread_create /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:205:3
    #1 0x56503030e8a4 in std::sys::unix::thread::Thread::new::h4e78387dd5b3d472 /rustc/149f4836dd6d9e789a26dca16dc034588866894e/library/std/src/sys/unix/thread.rs:50:19

==1972657==ABORTING
error: test failed, to rerun pass '-p metrics --lib'
```

After switching to aHash:
```
$ RUSTFLAGS="-Z sanitizer=address" cargo +nightly test --target x86_64-unknown-linux-gnu
warning: unused import: `NotTracked`
 --> metrics-benchmark/src/main.rs:6:40
  |
6 | use metrics_util::{Handle, MetricKind, NotTracked, Registry, Tracked};
  |                                        ^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running unittests (target/x86_64-unknown-linux-gnu/debug/deps/metrics-4d1fcb456d5a672c)

running 4 tests
test common::tests::test_unit_conversions ... ok
test key::tests::test_key_eq_and_hash ... ok
test key::tests::test_key_ord_and_partialord ... ok
test key::tests::test_key_data_proper_display ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/macros.rs (target/x86_64-unknown-linux-gnu/debug/deps/macros-6b4fca3b432ad167)

running 1 test
   Compiling metrics-tests v0.0.0 (/home/jeff/code/metrics-github/target/tests/metrics)
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s


test tests/macros/01_basic.rs ... ok
test tests/macros/02_trailing_comma.rs ... ok


test macros ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s

     Running unittests (target/x86_64-unknown-linux-gnu/debug/deps/metrics_benchmark-b7600f67b3844b18)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/x86_64-unknown-linux-gnu/debug/deps/metrics_exporter_prometheus-53fce0383cff9bd7)

running 6 tests
test common::tests::test_sanitize_key_name ... ok
test builder::tests::test_global_labels ... ok
test builder::tests::test_global_labels_overrides ... ok
test builder::tests::test_idle_timeout ... ok
test builder::tests::test_render ... ok
test builder::tests::test_buckets ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/x86_64-unknown-linux-gnu/debug/deps/metrics_exporter_tcp-35a59e6933d074b7)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/metrics_macros-7c22414d9d792a7c)

running 15 tests
test tests::test_labels_to_quoted_inline_labels_empty ... ok
test tests::test_get_expanded_callsite_static_name_existing_labels ... ok
test tests::test_labels_to_quoted_existing_labels ... ok
test tests::test_get_expanded_callsite_owned_name_no_labels ... ok
test tests::test_get_expanded_registration ... ok
test tests::test_get_expanded_callsite_static_name_no_labels ... ok
test tests::test_get_expanded_registration_with_description ... ok
test tests::test_get_expanded_callsite_static_name_static_inline_labels ... ok
test tests::test_get_expanded_callsite_owned_name_existing_labels ... ok
test tests::test_get_expanded_callsite_owned_name_dynamic_inline_labels ... ok
test tests::test_get_expanded_registration_with_unit ... ok
test tests::test_get_expanded_callsite_static_name_dynamic_inline_labels ... ok
test tests::test_get_expanded_callsite_owned_name_static_inline_labels ... ok
test tests::test_get_expanded_registration_with_unit_and_description ... ok
test tests::test_labels_to_quoted_inline_labels ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/x86_64-unknown-linux-gnu/debug/deps/metrics_observer-e3ead45079c83515)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/x86_64-unknown-linux-gnu/debug/deps/metrics_tracing_context-adb6030bfa52c75b)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration.rs (target/x86_64-unknown-linux-gnu/debug/deps/integration-a44f6694556d5b63)

running 6 tests
test test_macro_forms ... ok
test test_multiple_paths_to_the_same_callsite ... ok
test test_basic_functionality ... ok
test test_label_filtering ... ok
test test_nested_spans ... ok
test test_no_labels ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

cargo bench after switch to aHash:

```
    Finished bench [optimized] target(s) in 5.15s
     Running unittests (target/release/deps/macros-e36525eba027ca0a)
macros/uninitialized/no_labels
                        time:   [1.3966 ns 1.4035 ns 1.4111 ns]
                        change: [-14.552% -13.779% -13.058%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe
macros/uninitialized/with_static_labels
                        time:   [1.3975 ns 1.4056 ns 1.4151 ns]
                        change: [-17.785% -16.974% -16.126%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
macros/initialized/no_labels
                        time:   [2.0971 ns 2.1093 ns 2.1235 ns]
                        change: [-1.5451% -0.6670% +0.2067%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild
macros/initialized/with_static_labels
                        time:   [2.3598 ns 2.3854 ns 2.4115 ns]
                        change: [+10.042% +11.169% +12.327%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
macros/initialized/with_dynamic_labels
                        time:   [78.566 ns 79.379 ns 80.207 ns]
                        change: [-32.672% -31.823% -30.991%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

     Running unittests (target/release/deps/layer-ad2db68d370eb019)
layer/base case         time:   [1.1601 ns 1.1678 ns 1.1770 ns]
                        change: [-17.834% -16.816% -15.703%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
layer/no integration    time:   [1.4014 ns 1.4111 ns 1.4219 ns]
                        change: [-3.3540% -2.3082% -1.2032%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
layer/tracing layer only
                        time:   [1.1672 ns 1.1771 ns 1.1877 ns]
                        change: [-17.400% -16.516% -15.579%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
layer/metrics layer only
                        time:   [151.03 ns 151.98 ns 153.10 ns]
                        change: [-13.220% -12.309% -11.399%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe
layer/full integration  time:   [346.11 ns 348.65 ns 351.41 ns]
                        change: [-14.821% -13.881% -12.920%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

     Running unittests (target/release/deps/visit-2879d631cc78cddd)
visit/record_str        time:   [49.996 ns 50.354 ns 50.733 ns]
                        change: [-2.9810% -2.0707% -1.0603%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
visit/record_bool[true] time:   [26.115 ns 26.310 ns 26.522 ns]
                        change: [-4.5274% -3.3128% -2.1280%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
visit/record_bool[false]
                        time:   [26.052 ns 26.200 ns 26.358 ns]
                        change: [-5.7206% -4.7410% -3.7908%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
visit/record_i64        time:   [58.156 ns 58.561 ns 58.993 ns]
                        change: [-4.9803% -3.8683% -2.8382%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
visit/record_u64        time:   [58.760 ns 59.179 ns 59.613 ns]
                        change: [-1.7825% -0.8497% +0.1025%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
visit/record_debug      time:   [356.78 ns 358.99 ns 361.48 ns]
                        change: [-0.1194% +0.8390% +1.7872%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
visit/record_debug[bool]
                        time:   [74.128 ns 74.510 ns 74.933 ns]
                        change: [-2.8560% -1.9758% -1.0365%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
  visit/record_debug[i64] time:   [93.752 ns 94.344 ns 94.968 ns]
                        change: [-3.1306% -2.2607% -1.3815%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
visit/record_debug[u64] time:   [87.151 ns 87.691 ns 88.279 ns]
                        change: [-6.8422% -5.7358% -4.5939%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running unittests (target/release/deps/absolute-ba51fc926251c787)
absolute/no match       time:   [17.202 ns 17.282 ns 17.373 ns]
                        change: [-3.3926% -2.5104% -1.5597%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  8 (8.00%) high mild
  6 (6.00%) high severe
absolute/match (same value)
                        time:   [71.651 ns 72.082 ns 72.584 ns]
                        change: [-3.8320% -2.7990% -1.6832%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
absolute/match (updating value)
                        time:   [56.868 ns 57.477 ns 58.093 ns]
                        change: [-0.2061% +0.7192% +1.6497%] (p = 0.12 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild
absolute/noop recorder overhead (increment_counter)
                        time:   [1.1619 ns 1.1686 ns 1.1762 ns]
                        change: [-0.8209% -0.0680% +0.7305%] (p = 0.87 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

     Running unittests (target/release/deps/bucket-900c58820470d506)
bucket/write            time:   [5.7140 us 5.7477 us 5.7837 us]
                        thrpt:  [43.570 Melem/s 43.844 Melem/s 44.102 Melem/s]
                 change:
                        time:   [-1.4663% -0.5136% +0.4082%] (p = 0.30 > 0.05)
                        thrpt:  [-0.4065% +0.5163% +1.4881%]
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

     Running unittests (target/release/deps/filter-cc6d38cb0b9c32a8)
filter/match            time:   [24.089 ns 24.218 ns 24.358 ns]
                        change: [-0.8157% -0.0180% +0.7355%] (p = 0.96 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
filter/no match         time:   [18.062 ns 18.156 ns 18.263 ns]
                        change: [-0.6784% +0.0657% +0.7951%] (p = 0.86 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe
filter/noop recorder overhead (increment_counter)
                        time:   [1.3974 ns 1.4049 ns 1.4135 ns]
                        change: [+19.446% +20.590% +21.734%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe

     Running unittests (target/release/deps/prefix-54a1d5155e5fd3ff)
prefix/basic            time:   [61.377 ns 61.751 ns 62.186 ns]
                        change: [-25.094% -24.433% -23.766%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
prefix/noop recorder overhead (increment_counter)
                        time:   [1.1597 ns 1.1660 ns 1.1731 ns]
                        change: [-16.994% -16.275% -15.580%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe

     Running unittests (target/release/deps/registry-aa64b8454ad01d97)
registry (not tracked)/cached op (basic)
                        time:   [18.976 ns 19.069 ns 19.177 ns]
                        change: [-3.6738% -2.7765% -1.7388%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
registry (not tracked)/cached op (labels)
                        time:   [23.007 ns 23.124 ns 23.261 ns]
                        change: [-0.0163% +0.8187% +1.6403%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
registry (not tracked)/uncached op (basic)
                        time:   [222.20 ns 225.05 ns 227.79 ns]
                        change: [-11.944% -7.3273% -2.4040%] (p = 0.00 < 0.05)
                        Performance has improved.
registry (not tracked)/uncached op (labels)
                        time:   [303.29 ns 307.27 ns 311.23 ns]
                        change: [-20.655% -17.212% -13.359%] (p = 0.00 < 0.05)
                        Performance has improved.
registry (not tracked)/creation overhead
                        time:   [1.0883 us 1.1001 us 1.1127 us]
                        change: [-1.6889% -0.4924% +0.7202%] (p = 0.42 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

registry (tracked)/cached op (basic)
                        time:   [23.105 ns 23.239 ns 23.382 ns]
                        change: [-4.7187% -3.6377% -2.5487%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
registry (tracked)/cached op (labels)
                        time:   [27.280 ns 27.431 ns 27.596 ns]
                        change: [-2.1195% -1.1711% -0.1867%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) high mild
  5 (5.00%) high severe
registry (tracked)/uncached op (basic)
                        time:   [234.55 ns 237.74 ns 240.85 ns]
                        change: [-12.443% -7.6765% -2.9698%] (p = 0.00 < 0.05)
                        Performance has improved.
registry (tracked)/uncached op (labels)
                        time:   [319.88 ns 325.32 ns 331.45 ns]
                        change: [-17.498% -13.969% -10.067%] (p = 0.00 < 0.05)
                        Performance has improved.
registry (tracked)/creation overhead
                        time:   [1.0494 us 1.0556 us 1.0629 us]
                        change: [-6.2865% -5.2458% -4.1631%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

registry (common)/const key overhead (basic)
                        time:   [5.4013 ns 5.4556 ns 5.5155 ns]
                        change: [+0.1552% +1.3523% +2.5034%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild                        
  registry (common)/const key data overhead (labels)
                        time:   [2.4895 ns 2.5180 ns 2.5458 ns]
                        change: [+2.7567% +3.9636% +5.3190%] (p = 0.00 < 0.05)
                        Performance has regressed.
registry (common)/owned key overhead (basic)
                        time:   [22.395 ns 22.553 ns 22.730 ns]
                        change: [-18.948% -18.127% -17.312%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
registry (common)/owned key overhead (labels)
                        time:   [47.764 ns 48.027 ns 48.327 ns]
                        change: [-30.076% -29.443% -28.791%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) high mild

     Running unittests (target/release/deps/router-13846a8800e2d41e)
router/default target (via mask)
                        time:   [3.5020 ns 3.5265 ns 3.5529 ns]
                        change: [-4.5250% -3.4960% -2.4921%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
router/default target (via fallback)
                        time:   [34.782 ns 34.973 ns 35.188 ns]
                        change: [-2.6570% -1.4520% -0.2067%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
router/routed target    time:   [81.533 ns 82.165 ns 82.883 ns]
                        change: [-1.2445% -0.0314% +1.2495%] (p = 0.97 > 0.05)
                        No change in performance detected.
```