### PR TITLE
Improve performance of `metrics-tracing-context`.

### DIFF
--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -3,7 +3,7 @@ use getopts::Options;
 use hdrhistogram::Histogram;
 use log::{error, info};
 use metrics::{gauge, histogram, increment_counter, GaugeValue, Key, Recorder, Unit};
-use metrics_util::{Handle, MetricKind, NotTracked, Registry, Tracked};
+use metrics_util::{Handle, MetricKind, Registry, Tracked};
 use quanta::{Clock, Instant as QuantaInstant};
 use std::{
     env,

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -32,7 +32,6 @@ metrics = { version = "0.17", path = "../metrics", features = ["std"] }
 metrics-util = { version = "0.10", path = "../metrics-util" }
 lockfree-object-pool = "0.1"
 once_cell = "1.8"
-smallvec = "1.6"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.2"

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -27,12 +27,14 @@ name = "layer"
 harness = false
 
 [dependencies]
-metrics = { version = "^0.17", path = "../metrics", features = ["std"] }
-metrics-util = { version = "^0.10", path = "../metrics-util" }
+itoa = "0.4"
+metrics = { version = "0.17", path = "../metrics", features = ["std"] }
+metrics-util = { version = "0.10", path = "../metrics-util" }
+lockfree-object-pool = "0.1"
+once_cell = "1.8"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.2"
-itoa = "0.4"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -32,6 +32,7 @@ metrics = { version = "0.17", path = "../metrics", features = ["std"] }
 metrics-util = { version = "0.10", path = "../metrics-util" }
 lockfree-object-pool = "0.1"
 once_cell = "1.8"
+smallvec = "1.6"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.2"

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -5,7 +5,6 @@ use lockfree_object_pool::LinearObjectPool;
 use metrics::Label;
 use metrics_tracing_context::Labels;
 use once_cell::sync::OnceCell;
-use smallvec::SmallVec;
 use tracing::Metadata;
 use tracing_core::{
     field::Visit,

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -1,5 +1,10 @@
+use std::sync::Arc;
+
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use lockfree_object_pool::LinearObjectPool;
+use metrics::Label;
 use metrics_tracing_context::Labels;
+use once_cell::sync::OnceCell;
 use tracing::Metadata;
 use tracing_core::{
     field::Visit,
@@ -7,6 +12,11 @@ use tracing_core::{
     metadata::{Kind, Level},
     Callsite, Interest,
 };
+
+fn get_pool() -> &'static Arc<LinearObjectPool<Vec<Label>>> {
+    static POOL: OnceCell<Arc<LinearObjectPool<Vec<Label>>>> = OnceCell::new();
+    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(|| Vec::new(), |vec| vec.clear())))
+}
 
 const BATCH_SIZE: usize = 1000;
 
@@ -29,7 +39,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_str(&field, "test test");
             },
@@ -43,7 +53,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_bool(&field, true);
             },
@@ -57,7 +67,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_bool(&field, false);
             },
@@ -71,7 +81,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_i64(&field, -3423432);
             },
@@ -85,7 +95,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_u64(&field, 3423432);
             },
@@ -100,7 +110,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_debug(&field, &debug_struct);
             },
@@ -114,7 +124,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_debug(&field, &true);
             },
@@ -129,7 +139,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_debug(&field, &value);
             },
@@ -144,7 +154,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(Vec::with_capacity(BATCH_SIZE)),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_debug(&field, &value);
             },

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -40,7 +40,8 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(get_pool().pull_owned()),
+            //|| Labels(get_pool().pull_owned()),
+            || Labels(Vec::new()),
             |labels| {
                 labels.record_str(&field, "test test");
             },
@@ -54,7 +55,8 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(get_pool().pull_owned()),
+            //|| Labels(get_pool().pull_owned()),
+            || Labels(Vec::new()),
             |labels| {
                 labels.record_bool(&field, true);
             },
@@ -68,7 +70,8 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(get_pool().pull_owned()),
+            //|| Labels(get_pool().pull_owned()),
+            || Labels(Vec::new()),
             |labels| {
                 labels.record_bool(&field, false);
             },
@@ -82,7 +85,8 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(get_pool().pull_owned()),
+            //|| Labels(get_pool().pull_owned()),
+            || Labels(Vec::new()),
             |labels| {
                 labels.record_i64(&field, -3423432);
             },
@@ -96,7 +100,8 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(get_pool().pull_owned()),
+            //|| Labels(get_pool().pull_owned()),
+            || Labels(Vec::new()),
             |labels| {
                 labels.record_u64(&field, 3423432);
             },
@@ -111,7 +116,8 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(get_pool().pull_owned()),
+            //|| Labels(get_pool().pull_owned()),
+            || Labels(Vec::new()),
             |labels| {
                 labels.record_debug(&field, &debug_struct);
             },
@@ -125,7 +131,8 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(get_pool().pull_owned()),
+            //|| Labels(get_pool().pull_owned()),
+            || Labels(Vec::new()),
             |labels| {
                 labels.record_debug(&field, &true);
             },
@@ -140,7 +147,8 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(get_pool().pull_owned()),
+            //|| Labels(get_pool().pull_owned()),
+            || Labels(Vec::new()),
             |labels| {
                 labels.record_debug(&field, &value);
             },
@@ -155,7 +163,8 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            || Labels(get_pool().pull_owned()),
+            //|| Labels(get_pool().pull_owned()),
+            || Labels(Vec::new()),
             |labels| {
                 labels.record_debug(&field, &value);
             },

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -14,9 +14,9 @@ use tracing_core::{
     Callsite, Interest,
 };
 
-fn get_pool() -> &'static Arc<LinearObjectPool<SmallVec<[Label; 4]>>> {
-    static POOL: OnceCell<Arc<LinearObjectPool<SmallVec<[Label; 4]>>>> = OnceCell::new();
-    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(|| SmallVec::new(), |vec| vec.clear())))
+fn get_pool() -> &'static Arc<LinearObjectPool<Vec<Label>>> {
+    static POOL: OnceCell<Arc<LinearObjectPool<Vec<Label>>>> = OnceCell::new();
+    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(|| Vec::new(), |vec| vec.clear())))
 }
 
 const BATCH_SIZE: usize = 1000;
@@ -40,8 +40,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            //|| Labels(get_pool().pull_owned()),
-            || Labels(Vec::new()),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_str(&field, "test test");
             },
@@ -55,8 +54,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            //|| Labels(get_pool().pull_owned()),
-            || Labels(Vec::new()),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_bool(&field, true);
             },
@@ -70,8 +68,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            //|| Labels(get_pool().pull_owned()),
-            || Labels(Vec::new()),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_bool(&field, false);
             },
@@ -85,8 +82,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            //|| Labels(get_pool().pull_owned()),
-            || Labels(Vec::new()),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_i64(&field, -3423432);
             },
@@ -100,8 +96,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            //|| Labels(get_pool().pull_owned()),
-            || Labels(Vec::new()),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_u64(&field, 3423432);
             },
@@ -116,8 +111,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            //|| Labels(get_pool().pull_owned()),
-            || Labels(Vec::new()),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_debug(&field, &debug_struct);
             },
@@ -131,8 +125,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            //|| Labels(get_pool().pull_owned()),
-            || Labels(Vec::new()),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_debug(&field, &true);
             },
@@ -147,8 +140,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            //|| Labels(get_pool().pull_owned()),
-            || Labels(Vec::new()),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_debug(&field, &value);
             },
@@ -163,8 +155,7 @@ fn visit_benchmark(c: &mut Criterion) {
             .field("test")
             .expect("test field missing");
         b.iter_batched_ref(
-            //|| Labels(get_pool().pull_owned()),
-            || Labels(Vec::new()),
+            || Labels(get_pool().pull_owned()),
             |labels| {
                 labels.record_debug(&field, &value);
             },

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -5,6 +5,7 @@ use lockfree_object_pool::LinearObjectPool;
 use metrics::Label;
 use metrics_tracing_context::Labels;
 use once_cell::sync::OnceCell;
+use smallvec::SmallVec;
 use tracing::Metadata;
 use tracing_core::{
     field::Visit,
@@ -13,9 +14,9 @@ use tracing_core::{
     Callsite, Interest,
 };
 
-fn get_pool() -> &'static Arc<LinearObjectPool<Vec<Label>>> {
-    static POOL: OnceCell<Arc<LinearObjectPool<Vec<Label>>>> = OnceCell::new();
-    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(|| Vec::new(), |vec| vec.clear())))
+fn get_pool() -> &'static Arc<LinearObjectPool<SmallVec<[Label; 4]>>> {
+    static POOL: OnceCell<Arc<LinearObjectPool<SmallVec<[Label; 4]>>>> = OnceCell::new();
+    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(|| SmallVec::new(), |vec| vec.clear())))
 }
 
 const BATCH_SIZE: usize = 1000;

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -4,7 +4,7 @@
 //! contextual data maintained via `span!` macro from the [`tracing`] crate
 //! into the metrics.
 //!
-//! # Use
+//! # Usage
 //!
 //! First, set up `tracing` and `metrics` crates:
 //!
@@ -16,13 +16,13 @@
 //! use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 //!
 //! // Prepare tracing.
-//! # let mysubscriber = Registry::default();
-//! let subscriber = mysubscriber.with(MetricsLayer::new());
+//! # let my_subscriber = Registry::default();
+//! let subscriber = my_subscriber.with(MetricsLayer::new());
 //! tracing::subscriber::set_global_default(subscriber).unwrap();
 //!
 //! // Prepare metrics.
-//! # let myrecorder = DebuggingRecorder::new();
-//! let recorder = TracingContextLayer::all().layer(myrecorder);
+//! # let my_recorder = DebuggingRecorder::new();
+//! let recorder = TracingContextLayer::all().layer(my_recorder);
 //! metrics::set_boxed_recorder(Box::new(recorder)).unwrap();
 //! ```
 //!
@@ -52,6 +52,46 @@
 //! the following labels:
 //! - `service=login_service`
 //! - `user=ferris`
+//!
+//! # Implementation
+//!
+//! The integration layer works by capturing all fields present when a span is created and storing
+//! them as an extension to the span.  If a metric is emitted while a span is entered, we check that
+//! span to see if it has any fields in the extension data, and if it does, we add those fields as
+//! labels to the metric key.
+//!
+//! There are two important behaviors to be aware of:
+//! - we only capture the fields present when the span is created
+//! - we store all fields that a span has, including the fields of its parent span(s)
+//!
+//! ## Lack of dynamism
+//!
+//! This means that if you use [`Span::record`][tracing::Span::record] to add fields to a span after
+//! it has been created, those fields will not be captured and added to your metric key.
+//!
+//! ## Span fields and ancestry
+//!
+//! Likewise, we capture the sum of all fields for a span and its parent span(s), meaning that if you have the
+//! following span stack:
+//!
+//! ```text
+//! root span        (fieldA => valueA)
+//!  ⤷ mid-tier span (fieldB => valueB)
+//!     ⤷ leaf span  (fieldC => valueC)
+//! ```
+//!
+//! Then a metric emitted while within the leaf span would get, as labels, all three fields: A, B,
+//! and C.  As well, this layer does _not_ deduplicate the fields.  If you have two instance of the
+//! same field name, both versions will be included in your metric labels.  Whether or not those are
+//! deduplicated, and how they're deduplicated, is an exporter-specific implementation detail.
+//!
+//! In addition, for performance purposes, span fields are held in pooled storage, and additionally
+//! will copy the fields of parent spans.  Following the example span stack from above, the mid-tier
+//! span would hold both field A and B, while the leaf span would hold fields A, B, and C.
+//!
+//! In practice, these extra memory consumption used by these techniques should not matter for
+//! modern systems, but may represent an unacceptable amount of memory usage on constrained systems
+//! such as embedded platforms, etc.
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
 
@@ -101,7 +141,7 @@ where
     }
 }
 
-/// [`TracingContext`] is a [`metrics::Recorder`] that injects labels from[`tracing::Span`]s.
+/// [`TracingContext`] is a [`metrics::Recorder`] that injects labels from [`tracing::Span`]s.
 pub struct TracingContext<R, F> {
     inner: R,
     label_filter: F,
@@ -111,31 +151,43 @@ impl<R, F> TracingContext<R, F>
 where
     F: LabelFilter,
 {
-    fn enhance_labels(&self, labels: &mut Vec<Label>) {
+    fn enhance_key(&self, key: &Key) -> Option<Key> {
+        // Care is taken to only create a new key if absolutely necessary, which means avoiding
+        // creating a new key if there are no tracing fields at all.
+        //
+        // Technically speaking, we would also want to avoid creating a new key if all the tracing
+        // fields ended up being filtered out, but we don't have a great way of doing that without
+        // first scanning the tracing fields to see if one of them would match, where the cost of
+        // doing the iteration would likely exceed the cost of simply constructing the new key.
         tracing::dispatcher::get_default(|dispatch| {
             let current = dispatch.current_span();
             if let Some(id) = current.id() {
+                // We're currently within a live tracing span, so see if we have an available
+                // metrics context to grab any fields/labels out of.
                 if let Some(ctx) = dispatch.downcast_ref::<WithContext>() {
                     let mut f = |new_labels: &[Label]| {
-                        labels.extend(
-                            new_labels
+                        if !new_labels.is_empty() {
+                            let (name, mut labels) = key.clone().into_parts();
+
+                            let filtered_labels = new_labels
                                 .iter()
-                                .filter(|&label| self.label_filter.should_include_label(label))
-                                .cloned(),
-                        );
+                                .filter(|label| self.label_filter.should_include_label(label))
+                                .cloned();
+                            labels.extend(filtered_labels);
+
+                            Some(Key::from_parts(name, labels))
+                        } else {
+                            None
+                        }
                     };
-                    ctx.with_labels(dispatch, id, &mut f);
+
+                    // Pull in the span's fields/labels if they exist.
+                    return ctx.with_labels(dispatch, id, &mut f);
                 }
             }
-        });
-    }
 
-    fn enhance_key(&self, key: &Key) -> Key {
-        // TODO: probably should make this return Option<Key> so that we can avoid
-        // the clone by deferring in `enhance_labels` until we know we have labels to add
-        let (name, mut labels) = key.clone().into_parts();
-        self.enhance_labels(&mut labels);
-        Key::from_parts(name, labels)
+            None
+        })
     }
 }
 
@@ -157,17 +209,20 @@ where
     }
 
     fn increment_counter(&self, key: &Key, value: u64) {
-        let key = self.enhance_key(key);
-        self.inner.increment_counter(&key, value);
+        let new_key = self.enhance_key(key);
+        let key = new_key.as_ref().unwrap_or(key);
+        self.inner.increment_counter(key, value);
     }
 
     fn update_gauge(&self, key: &Key, value: GaugeValue) {
-        let key = self.enhance_key(key);
+        let new_key = self.enhance_key(key);
+        let key = new_key.as_ref().unwrap_or(key);
         self.inner.update_gauge(&key, value);
     }
 
     fn record_histogram(&self, key: &Key, value: f64) {
-        let key = self.enhance_key(key);
+        let new_key = self.enhance_key(key);
+        let key = new_key.as_ref().unwrap_or(key);
         self.inner.record_histogram(&key, value);
     }
 }

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -168,24 +168,3 @@ where
         MetricsLayer::new()
     }
 }
-
-/// An extention to the `tracing::Span`, enabling the access to labels.
-pub trait SpanExt {
-    /// Run the provided function with a read-only access to labels.
-    fn with_labels<F>(&self, f: F)
-    where
-        F: FnMut(&[Label]);
-}
-
-impl SpanExt for tracing::Span {
-    fn with_labels<F>(&self, mut f: F)
-    where
-        F: FnMut(&[Label]),
-    {
-        self.with_subscriber(|(id, subscriber)| {
-            if let Some(ctx) = subscriber.downcast_ref::<WithContext>() {
-                ctx.with_labels(subscriber, id, &mut f)
-            }
-        });
-    }
-}

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -1,17 +1,24 @@
 //! The code that integrates with the `tracing` crate.
 
+use lockfree_object_pool::{LinearObjectPool, LinearOwnedReusable};
 use metrics::Label;
+use once_cell::sync::OnceCell;
+use std::sync::Arc;
 use std::{any::TypeId, marker::PhantomData};
 use tracing_core::span::{Attributes, Id, Record};
 use tracing_core::{field::Visit, Dispatch, Field, Subscriber};
 use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
+fn get_pool() -> &'static Arc<LinearObjectPool<Vec<Label>>> {
+    static POOL: OnceCell<Arc<LinearObjectPool<Vec<Label>>>> = OnceCell::new();
+    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(|| Vec::new(), |vec| vec.clear())))
+}
 /// Per-span extension for collecting labels from fields.
 ///
 /// Hidden from documentation as there is no need for end users to ever touch this type, but it must
 /// be public in order to be pulled in by external benchmark code.
 #[doc(hidden)]
-pub struct Labels(pub Vec<Label>);
+pub struct Labels(pub LinearOwnedReusable<Vec<Label>>);
 
 impl Visit for Labels {
     fn record_str(&mut self, field: &Field, value: &str) {
@@ -49,7 +56,9 @@ impl Visit for Labels {
 
 impl Labels {
     fn from_attributes(attrs: &Attributes<'_>) -> Self {
-        let mut labels = Self(Vec::new()); // TODO: Vec::with_capacity?
+        let labels = get_pool().pull_owned();
+        assert!(labels.len() == 0);
+        let mut labels = Self(labels); // TODO: Vec::with_capacity?
         let record = Record::new(attrs.values());
         record.record(&mut labels);
         labels


### PR DESCRIPTION
Compared to the rest of the utilities in the `metrics` ecosystem, the `metrics`/`tracing` integration -- `metrics-tracing-context` -- is comparatively slow.  As we rebuild `Key`s on every metric emission, and shuffle around vectors of strings and so on, we generally perform a lot of extra work in the critical path of emitting metrics that readily shows up in profiling.

As a practical example, the usage of `metrics`, `tracing`, and `metrics-tracing-context` within a popular open-source observability project, [Vector](https://vector.dev), represents nearly 40-50% of all computation on certain workloads.  This is an untenable position for any project that is performance-conscious and goes against one of the core goals of `metrics` to be a zero-cost abstraction.

In this PR, we've significantly altered how the integration layer accomplishes its job.  In no specific order:
- span fields are now denormalized amongst spans to avoid traversing span stacks every time we want to access them
- the underlying field storage is now pooled so it can be re-used over time
- we've reworked the way we enter the `tracing` codepath to avoid needlessly generating objects which involve expensive computation in their `Drop` implementations

As I work on Vector officially, we'll demonstrate the performance benefits of this PR using it as an example: with these changes, we see a roughly 17% improvement in performance on a representative workload that emits roughly 250K metrics/second, purely from reducing the overhead of emitting those metrics.