### PR TITLE
metrics-tracing-context: remove unnecessary feature flags on deps

### DIFF
--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-tracing-context"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["MOZGIII <mike-n@narod.ru>"]
 edition = "2018"
 
@@ -27,15 +27,17 @@ name = "layer"
 harness = false
 
 [dependencies]
-itoa = "0.4"
+itoa = { version = "0.4.8", default-features = false }
 metrics = { version = "0.17", path = "../metrics", features = ["std"] }
 metrics-util = { version = "0.10", path = "../metrics-util" }
-lockfree-object-pool = "0.1"
-once_cell = "1.8"
-tracing = "0.1"
-tracing-core = "0.1"
-tracing-subscriber = "0.2"
+lockfree-object-pool = { version = "0.1.3", default-features = false }
+once_cell = { version = "1.8.0", default-features = false, features = ["std"] }
+tracing = { version = "0.1.29", default-features = false }
+tracing-core = { version = "0.1.21", default-features = false }
+tracing-subscriber = { version = "0.2.25", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 parking_lot = "0.11"
+tracing = { version = "0.1.29", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.2.25", default-features = false, features = ["registry"] }

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -217,12 +217,12 @@ where
     fn update_gauge(&self, key: &Key, value: GaugeValue) {
         let new_key = self.enhance_key(key);
         let key = new_key.as_ref().unwrap_or(key);
-        self.inner.update_gauge(&key, value);
+        self.inner.update_gauge(key, value);
     }
 
     fn record_histogram(&self, key: &Key, value: f64) {
         let new_key = self.enhance_key(key);
         let key = new_key.as_ref().unwrap_or(key);
-        self.inner.record_histogram(&key, value);
+        self.inner.record_histogram(key, value);
     }
 }

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
 fn get_pool() -> &'static Arc<LinearObjectPool<Vec<Label>>> {
     static POOL: OnceCell<Arc<LinearObjectPool<Vec<Label>>>> = OnceCell::new();
-    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(|| Vec::new(), |vec| vec.clear())))
+    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(Vec::new, Vec::clear)))
 }
 /// Span fields mapped as metrics labels.
 ///


### PR DESCRIPTION
Essentially, `metrics-tracing-context` didn't constrain its dependencies enough in terms of feature flags, so we pull in a lot of extra stuff.  This affects downstream consumers of the crate, polluting _their_ dependency graph.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>