### PR TITLE
Update tracing subscriber to 0.3

### DIFF
--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -36,5 +36,5 @@ tracing = { version = "0.1.26", optional = true }
 
 [dev-dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 rand = "0.8"

--- a/metrics-exporter-tcp/Cargo.toml
+++ b/metrics-exporter-tcp/Cargo.toml
@@ -31,5 +31,5 @@ built = "0.4"
 [dev-dependencies]
 quanta = "0.9.3"
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 rand = "0.8"

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -34,10 +34,10 @@ lockfree-object-pool = { version = "0.1.3", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features = ["std"] }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.21", default-features = false }
-tracing-subscriber = { version = "0.2.25", default-features = false }
+tracing-subscriber = { version = "0.3.1", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 parking_lot = "0.11"
 tracing = { version = "0.1.29", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.2.25", default-features = false, features = ["registry"] }
+tracing-subscriber = { version = "0.3.1", default-features = false, features = ["registry"] }

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -145,7 +145,7 @@ impl<S> Layer<S> for MetricsLayer<S>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    fn new_span(&self, attrs: &Attributes<'_>, id: &Id, cx: Context<'_, S>) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, cx: Context<'_, S>) {
         let span = cx.span(id).expect("span must already exist!");
         let mut labels = Labels::from_attributes(attrs);
 

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -74,7 +74,7 @@ noisy_float = "0.2"
 pretty-bytes = "0.2"
 tracing = "0.1"
 tracing-appender = "0.1"
-tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt", "ansi"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi"] }
 crossbeam-queue = "0.3"
 quickcheck = "1"
 quickcheck_macros = "1"


### PR DESCRIPTION
Replaces https://github.com/metrics-rs/metrics/pull/237 . Includes the commit from there plus using the renamed `Layer` method `on_new_span`.