### PR TITLE
metrics-exporter-prometheus: Single runtime install

### DIFF
--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -194,7 +194,11 @@ impl PrometheusBuilder {
         self
     }
 
-    /// Builds the recorder and exporter and installs them globally.
+    /// Builds the recorder and exporter and installs them globally. Behaves
+    /// differently depending on if called from within a tokio runtime. If
+    /// called within a Runtime, spawns the handler future onto the current
+    /// runtime. If called with no active runtime, spawns a new single-threaded
+    /// tokio runtime and polls the handler future from a new background thread.
     ///
     /// An error will be returned if there's an issue with creating the HTTP server or with
     /// installing the recorder as the global recorder.

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -194,11 +194,11 @@ impl PrometheusBuilder {
         self
     }
 
-    /// Builds the recorder and exporter and installs them globally. Behaves
-    /// differently depending on if called from within a tokio runtime. If
-    /// called within a Runtime, spawns the handler future onto the current
-    /// runtime. If called with no active runtime, spawns a new single-threaded
-    /// tokio runtime and polls the handler future from a new background thread.
+    /// Builds the recorder and exporter and installs them globally.
+    ///
+    /// When called from within a Tokio runtime, the handler future is spawned directly
+    /// into the runtime.  Otherwise, a new single-threaded Tokio runtime is created
+    /// on a background thread, and the handler is spawned there.
     ///
     /// An error will be returned if there's an issue with creating the HTTP server or with
     /// installing the recorder as the global recorder.

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -200,6 +200,25 @@ impl PrometheusBuilder {
     /// installing the recorder as the global recorder.
     #[cfg(feature = "tokio-exporter")]
     pub fn install(self) -> Result<(), InstallError> {
+        if let Ok(handle) = runtime::Handle::try_current() {
+            let (recorder, exporter) = {
+                let _g = handle.enter();
+                self.build_with_exporter()?
+            };
+            metrics::set_boxed_recorder(Box::new(recorder))?;
+
+            handle.spawn(async move {
+                pin!(exporter);
+                loop {
+                    select! {
+                        _ = &mut exporter => {}
+                    }
+                }
+            });
+
+            return Ok(());
+        }
+
         let runtime = runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;


### PR DESCRIPTION
Allow exporter to be installed on an existing tokio runtime when called form
within that runtime.

Fixes #250 