### PR TITLE
chore: some release helper tooling + CHANGELOG updates galore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ members = [
   "metrics-observer",
   "metrics-benchmark",
 ]
-
-[profile.release]
-debug = true

--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+- Updated various dependencies in order to properly scope dependencies to only the necessary feature
+  flags, and thus optimize build times and reduce transitive dependencies.
+- Updated to the new handle-based design of `metrics`.
+
 ## [0.7.0] - 2021-12-16
 
 ### Changed

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -334,8 +334,6 @@ impl PrometheusBuilder {
 
         #[cfg(feature = "push-gateway")]
         if let Some(push_gateway_config) = push_gateway_config {
-            //let push_interval = push_gateway_config.push_interval;
-            //let push_address = push_gateway_config.address;
             let exporter = async move {
                 let client = reqwest::Client::default();
                 loop {

--- a/metrics-exporter-tcp/CHANGELOG.md
+++ b/metrics-exporter-tcp/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+- Updated various dependencies in order to properly scope dependencies to only the necessary feature
+  flags, and thus optimize build times and reduce transitive dependencies.
+- Updated to the new handle-based design of `metrics`.
+
 ## [0.5.1] - 2021-09-16
 
 ### Changed

--- a/metrics-exporter-tcp/Cargo.toml
+++ b/metrics-exporter-tcp/Cargo.toml
@@ -21,7 +21,7 @@ bytes = { version = "1", default-features = false }
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 prost = { version = "0.9", default-features = false }
 prost-types = { version = "0.9", default-features = false, features = ["std"] }
-mio = { version = "0.7", default-features = false, features = ["os-poll", "tcp"] }
+mio = { version = "0.8", default-features = false, features = ["os-poll", "net"] }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 
 [build-dependencies]

--- a/metrics-macros/CHANGELOG.md
+++ b/metrics-macros/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+- Correctly scoped the required features of various dependencies to reduce build times/transitive dependencies.
+- Updated macros to coincide with the update to `metrics` for metric handles.  This includes
+  renaming `register_*` macros to `describe_*`, which are purely for providing data that describes a
+  metric but does not initialize it in any way, and providing new `register_*` macros which do
+  initialize a metric.
+
+### Removed
+- Two unecessary dependencies, `lazy_static` and `regex`.
+
 ## [0.4.1] - 2021-12-16
 
 ### Changed

--- a/metrics-observer/CHANGELOG.md
+++ b/metrics-observer/CHANGELOG.md
@@ -9,3 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 ### Added
 - Update hdrhistogram dependency to 7.2
+
+### Changed
+- Updated various dependencies in order to properly scope dependencies to only the necessary feature
+  flags, and thus optimize build times and reduce transitive dependencies.

--- a/metrics-observer/Cargo.toml
+++ b/metrics-observer/Cargo.toml
@@ -8,15 +8,15 @@ publish = false
 license = "MIT"
 
 [dependencies]
-bytes = "1"
-crossbeam-channel = "0.5"
-prost = "0.9"
-prost-types = "0.9"
-tui = "0.16"
-termion = "1.5"
-chrono = "0.4"
-metrics = { version = "^0.17", path = "../metrics" }
-metrics-util = { version = "^0.10", path = "../metrics-util" }
+metrics = { version = "^0.17", path = "../metrics", default-features = false }
+metrics-util = { version = "^0.10", path = "../metrics-util", default-features = false, features = ["summary"] }
+bytes = { version = "1", default-features = false }
+crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
+prost = { version = "0.9", default-features = false }
+prost-types = { version = "0.9", default-features = false }
+tui = { version = "0.16", default-features = false, features = ["termion"] }
+termion = { version = "1.5", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [build-dependencies]
 prost-build = "0.9"

--- a/metrics-tracing-context/CHANGELOG.md
+++ b/metrics-tracing-context/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+- Updated various dependencies in order to properly scope dependencies to only the necessary feature
+  flags, and thus optimize build times and reduce transitive dependencies.
+- Updated to the new handle-based design of `metrics`.
+
 ## [0.9.0] - 2021-12-16
 
 ### Changed

--- a/metrics-util/CHANGELOG.md
+++ b/metrics-util/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+- Updated various dependencies in order to properly scope dependencies to only the necessary feature
+  flags, and thus optimize build times and reduce transitive dependencies.
+- Many types are now behind their own feature flags to allow for optimizing build times and
+  dependency tree.
+- Updated to the new handle-based design of `metrics`.
+- Updated `AtomicBucket` to use `MaybeUninit` and better documented the safety invariants in the
+  various areas that use `unsafe`.
+- `AtomicBucket` now correctly drops only initialized slots in a `Block`.
+
 ## [0.10.2] - 2021-12-12
 
 ### Changed

--- a/metrics-util/src/bucket.rs
+++ b/metrics-util/src/bucket.rs
@@ -24,12 +24,12 @@ struct Block<T> {
 
     // Read bitmap.
     //
-    // Internally, we track the write index whicxh indicates what slot should be written by the next
+    // Internally, we track the write index which indicates what slot should be written by the next
     // writer.  This works fine as writers race via CAS to "acquire" a slot to write to.  The
     // trouble comes when attempting to read written values, as writers may still have writes
-    // in-flight, this leading to potential uninitialized reads, UB, and the world imploding.
+    // in-flight, thus leading to potential uninitialized reads, UB, and the world imploding.
     //
-    // We use a simplete scheme where writers acknowledge their writes by setting a bit in `read`
+    // We use a simple scheme where writers acknowledge their writes by setting a bit in `read`
     // that corresponds to the index that they've written.  For example, a write at index 5 being
     // complete can be verified by checking if `1 << 5` in `read` is set.  This allows writers to
     // concurrently update `read` despite non-sequential indexes.

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -8,8 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+- A new macro, `absolute_counter!`, for setting the value of a counter to an absolute value.
+
 ### Changed
-- Switched to metric handles through the `Recorder` API. ([#240](https://github.com/metrics-rs/metrics/pull/240))
+- Switched to metric handles through the `Recorder` API.
+  ([#240](https://github.com/metrics-rs/metrics/pull/240)).  Due to the size of this change, the
+  details are further documented and discussed in [RELEASES.md](RELEASES.md).
+- `Unit` is now `Copy`.
+- Removed the half-baked attempt to allow turning off `std` usage, as `metrics` is not meaningfully
+  usable (at the moment) without libstd support.
 
 ## [0.17.1] - 2021-12-16
 

--- a/metrics/RELEASES.md
+++ b/metrics/RELEASES.md
@@ -54,7 +54,8 @@ Simply put, handles represent an incredibly thin layer over compatible implement
 metric type.  There are now three traits, one for each metric type, that must be implemented to
 satisfy being wrapped in the corresponding handle type.  Internally, this is wrapped in an [`Arc<T>`][arc] to make it usable in multi-threaded scenarios.
 
-Implementations of `Counter` and `Gauge` based on atomic integers can be found in [`metrics`][metrics], and an example of `Histogram` can be found in [`metrics-util`][metrics-util].
+Implementations of `Counter` and `Gauge` based on atomic integers can be found in
+[`metrics`][metrics], and an example of `Histogram` can be found in [`metrics-util`][metrics-util].
 
 #### Limitations of handles
 

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -61,9 +61,15 @@
 //! ## Emission
 //! Metrics are emitted by utilizing the registration or emission macros.  There is a macro for
 //! registering and emitting each fundamental metric type:
-//! - [`describe_counter!`], [`counter!`], and [`increment_counter!`] for counters
-//! - [`describe_gauge!`], [`gauge!`], [`increment_gauge!`], and [`decrement_gauge!`] for gauges
-//! - [`describe_histogram!`] and [`histogram!`] for histograms
+//! - [`register_counter!`], [`counter!`], and [`increment_counter!`] for counters
+//! - [`register_gauge!`], [`gauge!`], [`increment_gauge!`], and [`decrement_gauge!`] for gauges
+//! - [`register_histogram!`] and [`histogram!`] for histograms
+//!
+//! Additionally, metrics can be described -- setting either the unit of measure or long-form
+//! description -- by using the `describe_*` macros:
+//! - [`describe_counter!`] for counters
+//! - [`describe_gauge!`] for gauges
+//! - [`describe_histogram!`] for histograms
 //!
 //! In order to register or emit a metric, you need a way to record these events, which is where
 //! [`Recorder`] comes into play.
@@ -624,13 +630,14 @@ pub use metrics_macros::increment_counter;
 /// Sets a counter to an absolute value.
 ///
 /// Counters represent a single monotonic value, which means the value can only be incremented, not
-/// decremented, and always starts out with an initial value of zero.
+/// decremented, and will always start out with an initial value of zero.
 ///
-/// Counters can be set to an absolute value, but users will observe the following: if a value is
-/// given that is less than the current value of the counter, then the change will not be mad.  In
-/// this way, counters can be set to an absolute value the counter itself will always uphold its
-/// monotonicity.  This can be useful for translating external metrics, where only the absolute
-/// value is available, into `metrics`, without having to manually keep track of changes over time.
+/// Using this macro, users can specify an absolute value for the counter instead of the typical
+/// delta.  This can be useful when dealing with forwarding metrics from an external system into the
+/// normal application metrics, without having to track the delta of the metrics from the external
+/// system.  Users should beware, though, that implementations will enforce the monotonicity
+/// property of counters by refusing to update the value unless it is greater than current value of
+/// the counter.
 ///
 /// Metric names are shown below using string literals, but they can also be owned `String` values,
 /// which includes using macros such as `format!` directly at the callsite. String literals are

--- a/scripts/show-package-changes.sh
+++ b/scripts/show-package-changes.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+PACKAGE_NAME=$1
+PACKAGE_GIT_TAG=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | "\(.name)-v\(.version)"' | grep "${PACKAGE_NAME}-v")
+
+echo "changes to $PACKAGE_NAME since last release ($PACKAGE_GIT_TAG):"
+git diff $PACKAGE_GIT_TAG..HEAD $PACKAGE_NAME

--- a/scripts/show-release-candidates.sh
+++ b/scripts/show-release-candidates.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+while read PACKAGE_NAME PACKAGE_GIT_TAG; do
+	if git diff --name-only $PACKAGE_GIT_TAG..HEAD | grep -q -E "^${PACKAGE_NAME}/"; then
+		echo "$PACKAGE_NAME: changes since last release ($PACKAGE_GIT_TAG)";
+	fi
+done < <(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | "\(.name) \(.name)-v\(.version)"')


### PR DESCRIPTION
This PR started out as better/any tooling for trying to better sniff out changes to crates since their last released version, but turned into also updating changelogs and dependencies and fixing spelling errors and updating docs and what not.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>