### PR TITLE
metrics-exporter-prometheus: fix sanitization across the board

### DIFF
--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flags, and thus optimize build times and reduce transitive dependencies.
 - Updated to the new handle-based design of `metrics`.
 
+### Fixed
+- Label keys and values, as well as metric descriptions, are now correctly sanitized according to
+  the Prometheus [data model](https://prometheus.io/docs/concepts/data_model/) and [exposition
+  format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md).
+  ([#248](https://github.com/metrics-rs/metrics/issues/248))
+- Metric descriptions are correctly mapped to metrics whose names have been modified during sanitization.
+
 ## [0.7.0] - 2021-12-16
 
 ### Changed

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -24,8 +24,9 @@ push-gateway = ["reqwest", "tracing", "tokio-exporter"]
 metrics = { version = "^0.17", path = "../metrics" }
 metrics-util = { version = "^0.10", path = "../metrics-util", default-features = false, features = ["recency", "registry", "summary"] }
 parking_lot = { version = "0.11", default-features = false }
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "1", default-features = false }
 quanta = { version = "0.9.3", default-features = false }
+indexmap = { version = "1", default-features = false }
 
 # Optional
 hyper = { version = "0.14", default-features = false, features = ["server", "tcp", "http1"], optional = true }
@@ -38,6 +39,7 @@ tracing = { version = "0.1.26", optional = true }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 rand = "0.8"
+proptest = "1"
 
 [[example]]
 name = "prometheus_push_gateway"

--- a/metrics-exporter-prometheus/proptest-regressions/common.txt
+++ b/metrics-exporter-prometheus/proptest-regressions/common.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 814a8d86ca8784415c115d0afb1059cefec40319d488b91224db04fb16427bfc # shrinks to input = "\""
+cc 897cd6506ca8b7f3b341f3a228970054025679e97a241abee69ac86d2524e6ad # shrinks to input = "\n"
+cc 4ced71ea0799af0549ca88705b383b34b1c744115abf2d9ade2d59e2dcee5c2e # shrinks to input = "\\\""

--- a/metrics-exporter-prometheus/src/common.rs
+++ b/metrics-exporter-prometheus/src/common.rs
@@ -33,9 +33,9 @@ impl Matcher {
     /// Creates a sanitized version of this matcher.
     pub(crate) fn sanitized(self) -> Matcher {
         match self {
-            Matcher::Prefix(prefix) => Matcher::Prefix(sanitize_key_name(prefix.as_str())),
-            Matcher::Suffix(suffix) => Matcher::Suffix(sanitize_key_name(suffix.as_str())),
-            Matcher::Full(full) => Matcher::Full(sanitize_key_name(full.as_str())),
+            Matcher::Prefix(prefix) => Matcher::Prefix(sanitize_metric_name(prefix.as_str())),
+            Matcher::Suffix(suffix) => Matcher::Suffix(sanitize_metric_name(suffix.as_str())),
+            Matcher::Full(full) => Matcher::Full(sanitize_metric_name(full.as_str())),
         }
     }
 }
@@ -63,28 +63,270 @@ pub struct Snapshot {
     pub distributions: HashMap<String, HashMap<Vec<String>, Distribution>>,
 }
 
-pub fn sanitize_key_name(key: &str) -> String {
-    // Replace anything that isn't [a-zA-Z0-9_:].
-    let sanitize = |c: char| !(c.is_alphanumeric() || c == '_' || c == ':');
-    key.to_string().replace(sanitize, "_")
+#[inline]
+fn invalid_metric_name_start_character(c: char) -> bool {
+    // Essentially, needs to match the regex pattern of [a-zA-Z_:].
+    !(c.is_ascii_alphabetic() || c == '_' || c == ':')
+}
+
+#[inline]
+fn invalid_metric_name_character(c: char) -> bool {
+    // Essentially, needs to match the regex pattern of [a-zA-Z0-9_:].
+    !(c.is_ascii_alphanumeric() || c == '_' || c == ':')
+}
+
+#[inline]
+fn invalid_label_key_start_character(c: char) -> bool {
+    // Essentially, needs to match the regex pattern of [a-zA-Z_].
+    !(c.is_ascii_alphabetic() || c == '_')
+}
+
+#[inline]
+fn invalid_label_key_character(c: char) -> bool {
+    // Essentially, needs to match the regex pattern of [a-zA-Z0-9_].
+    !(c.is_ascii_alphanumeric() || c == '_')
+}
+
+pub fn sanitize_metric_name(name: &str) -> String {
+    // The first character must be [a-zA-Z_:], and all subsequent characters must be [a-zA-Z0-9_:].
+    name.replacen(invalid_metric_name_start_character, "_", 1)
+        .replace(invalid_metric_name_character, "_")
+}
+
+pub fn sanitize_label_key(key: &str) -> String {
+    // The first character must be [a-zA-Z_], and all subsequent characters must be [a-zA-Z0-9_].
+    key.replacen(invalid_label_key_start_character, "_", 1)
+        .replace(invalid_label_key_character, "_")
+}
+
+pub fn sanitize_label_value(value: &str) -> String {
+    sanitize_label_value_or_descpiption(value, false)
+}
+
+pub fn sanitize_description(value: &str) -> String {
+    sanitize_label_value_or_descpiption(value, true)
+}
+
+fn sanitize_label_value_or_descpiption(value: &str, is_desc: bool) -> String {
+    // All Unicode characters are valid, but backslashes, double quotes, and line feeds must be
+    // escaped.
+    let mut sanitized = String::with_capacity(value.as_bytes().len());
+
+    let mut previous_backslash = false;
+    for c in value.chars() {
+        match c {
+            // Any raw newlines get escaped, period.
+            '\n' => sanitized.push_str("\\n"),
+            // Any double quote we see gets escaped, but only for label values, not descriptions.
+            '"' if !is_desc => {
+                previous_backslash = false;
+                sanitized.push_str("\\\"");
+            }
+            // If we see a backslash, we might be either seeing one that is being used to escape
+            // something, or seeing one that has being escaped. If our last character was a
+            // backslash, then we know this one has already been escaped, and we just emit the
+            // escaped backslash.
+            '\\' => {
+                if !previous_backslash {
+                    // Either we have a backslash as the first character of the label value, or we're in
+                    // the middle of the value and we're seeing this backslash, which might be on its
+                    // own or might be escaping the next character.
+                    //
+                    // We're not yet sure since we haven't seen the next character, so we hold on to
+                    // this backslash and (potentially) use it in the next iteration.
+                    previous_backslash = true;
+                } else {
+                    // This backslash was preceded by another backslash, so we can safely emit an
+                    // escaped backslash.
+                    previous_backslash = false;
+                    sanitized.push_str("\\\\");
+                }
+            }
+            c => {
+                // If we had a backslash in holding, and we're here, we know it wasn't escaping
+                // something we care about, so it's on its own, and we emit an escaped backslash,
+                // before emitting the actual character we're handling.
+                if previous_backslash {
+                    previous_backslash = false;
+                    sanitized.push_str("\\\\");
+                }
+                sanitized.push(c);
+            }
+        }
+    }
+
+    // Handle any dangling backslash by writing it out in an escaped fashion.
+    if previous_backslash {
+        sanitized.push_str("\\\\");
+    }
+
+    sanitized
 }
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_key_name;
+    use crate::common::*;
+    use proptest::prelude::*;
 
     #[test]
-    fn test_sanitize_key_name() {
-        let test_cases = vec![
-            ("____", "____"),
-            ("foo bar", "foo_bar"),
-            ("abcd:efgh", "abcd:efgh"),
-            ("lars.andersen", "lars_andersen"),
+    fn test_sanitize_metric_name_known_cases() {
+        let cases = &[
+            ("*", "_"),
+            ("\"", "_"),
+            ("foo_bar", "foo_bar"),
+            ("1foobar", "_foobar"),
         ];
 
-        for (input, expected) in test_cases {
-            let result = sanitize_key_name(input);
-            assert_eq!(expected, result);
+        for (input, expected) in cases {
+            let result = sanitize_metric_name(input);
+            assert_eq!(expected, &result);
+        }
+    }
+
+    #[test]
+    fn test_sanitize_label_key_known_cases() {
+        let cases = &[
+            ("*", "_"),
+            ("\"", "_"),
+            (":", "_"),
+            ("foo_bar", "foo_bar"),
+            ("1foobar", "_foobar"),
+        ];
+
+        for (input, expected) in cases {
+            let result = sanitize_label_key(input);
+            assert_eq!(expected, &result);
+        }
+    }
+
+    #[test]
+    fn test_sanitize_label_value_known_cases() {
+        let cases = &[
+            ("*", "*"),
+            ("\"", "\\\""),
+            ("\\", "\\\\"),
+            ("\\\\", "\\\\"),
+            ("\n", "\\n"),
+            ("foo_bar", "foo_bar"),
+            ("1foobar", "1foobar"),
+        ];
+
+        for (input, expected) in cases {
+            let result = sanitize_label_value(input);
+            assert_eq!(expected, &result);
+        }
+    }
+
+    #[test]
+    fn test_sanitize_description_known_cases() {
+        let cases = &[
+            ("*", "*"),
+            ("\"", "\""),
+            ("\\", "\\\\"),
+            ("\\\\", "\\\\"),
+            ("\n", "\\n"),
+            ("foo_bar", "foo_bar"),
+            ("1foobar", "1foobar"),
+        ];
+
+        for (input, expected) in cases {
+            let result = sanitize_description(input);
+            assert_eq!(expected, &result);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_sanitize_metric_name(input in "[\n\"\\\\]?.*[\n\"\\\\]?") {
+            let result = sanitize_metric_name(&input);
+            let as_chars = result.chars().collect::<Vec<_>>();
+
+            if let Some(c) = as_chars.first() {
+                assert_eq!(false, invalid_metric_name_start_character(*c),
+                    "first character of metric name was not valid");
+            }
+
+            assert!(!as_chars.iter().any(|c| invalid_metric_name_character(*c)),
+                "invalid character in metric name");
+        }
+
+        #[test]
+        fn test_sanitize_label_key(input in "[\n\"\\\\:]?.*[\n\"\\\\:]?") {
+            let result = sanitize_label_key(&input);
+            let as_chars = result.chars().collect::<Vec<_>>();
+
+            if let Some(c) = as_chars.first() {
+                assert_eq!(false, invalid_label_key_start_character(*c),
+                    "first character of label key was not valid");
+            }
+
+            assert!(!as_chars.iter().any(|c| invalid_label_key_character(*c)),
+                "invalid character in label key");
+        }
+
+        #[test]
+        fn test_sanitize_label_value(input in "[\n\"\\\\]?.*[\n\"\\\\]?") {
+            let result = sanitize_label_value(&input);
+
+            // If any raw newlines are still present, then we messed up.
+            assert!(!result.contains('\n'), "raw/unescaped newlines present");
+
+            // We specifically remove instances of "\\" because we only care about dangling backslashes.
+            let delayered_backslashes = result.replace("\\\\", "");
+            let as_chars = delayered_backslashes.chars().collect::<Vec<_>>();
+
+            // If the first character is a double quote, then we messed up.
+            assert!(as_chars.first().map(|c| *c != '"').unwrap_or(true),
+                "first character cannot be a double quote: {}", result);
+
+            // Now look for unescaped characters in the rest of the string, in a windowed fashion.
+            let contained_unescaped_chars = as_chars.as_slice()
+                .windows(2)
+                .any(|s| {
+                    let first = s[0];
+                    let second = s[1];
+
+                    match (first, second) {
+                        // If there's a double quote, it has to have been preceded by an escaping
+                        // backslash.
+                        (c, '"') => c != '\\',
+                        // If there's a backslash, it can only be in front of an 'n' for escaping
+                        // newlines.
+                        ('\\', c) => c != 'n',
+                        // Everything else is valid.
+                        _ => false,
+                    }
+                });
+            assert!(!contained_unescaped_chars, "invalid or missing escape detected");
+        }
+
+        #[test]
+        fn test_sanitize_description(input in "[\n\"\\\\]?.*[\n\"\\\\]?") {
+            let result = sanitize_description(&input);
+
+            // If any raw newlines are still present, then we messed up.
+            assert!(!result.contains('\n'), "raw/unescaped newlines present");
+
+            // We specifically remove instances of "\\" because we only care about dangling backslashes.
+            let delayered_backslashes = result.replace("\\\\", "");
+            let as_chars = delayered_backslashes.chars().collect::<Vec<_>>();
+
+            // Now look for unescaped characters in the rest of the string, in a windowed fashion.
+            let contained_unescaped_chars = as_chars.as_slice()
+                .windows(2)
+                .any(|s| {
+                    let first = s[0];
+                    let second = s[1];
+
+                    match (first, second) {
+                        // If there's a backslash, it can only be in front of an 'n' for escaping
+                        // newlines.
+                        ('\\', c) => c != 'n',
+                        // Everything else is valid.
+                        _ => false,
+                    }
+                });
+            assert!(!contained_unescaped_chars, "invalid or missing escape detected");
         }
     }
 }


### PR DESCRIPTION
This PR ensures that metric names, label keys and values, and metric descriptions are all correctly sanitized according to the Prometheus [data model](https://prometheus.io/docs/concepts/data_model/) and [exposition format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md).

Additionally, we fixed a bug where metric descriptions were stored mapped to the original metric name, but searched for by the sanitized name, leading to not rendering the help text for metrics whose names were changed when sanitized.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>

Fixes #248.