### PR TITLE
chore: massive overhaul of prom exporter feature flags + builder + docs

### DIFF
--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -8,10 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+- New builder method, `PrometheusBuilder::install_recorder`, which builds and installs the
+  recorder and returns a `PrometheusHandle` that can be used to interact with the recorder.
+
 ### Changed
 - Updated various dependencies in order to properly scope dependencies to only the necessary feature
   flags, and thus optimize build times and reduce transitive dependencies.
 - Updated to the new handle-based design of `metrics`.
+- Renamed `tokio-exporter` feature flag to `http-listener`.
+- Renamed `PrometheusBuilder::build` to `build_recorder`.
+- Renamed `PrometheusBuilder::build_with_exporter` to `build`.
+- `InstallError` is now `BuildError`, and contains many more variants with hopefully) better error
+  messages for understanding when something went wrong.
+- Most builder methods are now fallible to help avoid runtime panics for invalid data given when
+  building, and to better surface this upfront to users.
 
 ### Fixed
 - Label keys and values, as well as metric descriptions, are now correctly sanitized according to

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -32,7 +32,7 @@ indexmap = { version = "1", default-features = false }
 # Optional
 hyper = { version = "0.14", default-features = false, features = ["tcp", "http1"], optional = true }
 ipnet = { version = "2", optional = true }
-tokio = { version = "1", features = ["rt", "net", "time", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "net", "time"], optional = true }
 tracing = { version = "0.1.26", optional = true }
 
 [dev-dependencies]

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 license = "MIT"
 
-description = "A metrics-compatible exporter that serves a Prometheus scrape endpoint."
+description = "A metrics-compatible exporter for sending metrics to Prometheus."
 homepage = "https://github.com/metrics-rs/metrics"
 repository = "https://github.com/metrics-rs/metrics"
 documentation = "https://docs.rs/metrics-exporter-prometheus"
@@ -16,9 +16,10 @@ categories = ["development-tools::debugging"]
 keywords = ["metrics", "telemetry", "prometheus"]
 
 [features]
-default = ["tokio-exporter"]
-tokio-exporter = ["hyper", "ipnet", "tokio"]
-push-gateway = ["reqwest", "tracing", "tokio-exporter"]
+default = ["http-listener", "push-gateway"]
+async-runtime = ["tokio", "hyper"]
+http-listener = ["async-runtime", "hyper/server", "ipnet"]
+push-gateway = ["async-runtime", "hyper/client", "tracing"]
 
 [dependencies]
 metrics = { version = "^0.17", path = "../metrics" }
@@ -29,10 +30,9 @@ quanta = { version = "0.9.3", default-features = false }
 indexmap = { version = "1", default-features = false }
 
 # Optional
-hyper = { version = "0.14", default-features = false, features = ["server", "tcp", "http1"], optional = true }
+hyper = { version = "0.14", default-features = false, features = ["tcp", "http1"], optional = true }
 ipnet = { version = "2", optional = true }
-tokio = { version = "1.0", features = ["rt", "net", "time", "macros"], optional = true }
-reqwest = { version = "0.11.4", optional = true }
+tokio = { version = "1", features = ["rt", "net", "time", "macros"], optional = true }
 tracing = { version = "0.1.26", optional = true }
 
 [dev-dependencies]
@@ -47,4 +47,8 @@ required-features = ["push-gateway"]
 
 [[example]]
 name = "prometheus_server"
-required-features = ["tokio-exporter"]
+required-features = ["http-listener"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/metrics-exporter-prometheus/examples/prometheus_server.rs
+++ b/metrics-exporter-prometheus/examples/prometheus_server.rs
@@ -34,7 +34,7 @@ fn main() {
         "The iterations of the TCP server event loop so far."
     );
     describe_histogram!(
-        "tcp_server_loop_delta_ns",
+        "tcp_server_loop_delta_secs",
         "The time taken for iterations of the TCP server event loop."
     );
 
@@ -50,7 +50,7 @@ fn main() {
 
         if let Some(t) = last {
             let delta: Duration = clock.now() - t;
-            histogram!("tcp_server_loop_delta_ns", delta, "system" => "foo");
+            histogram!("tcp_server_loop_delta_secs", delta, "system" => "foo");
         }
 
         let increment_gauge = thread_rng().gen_bool(0.75);

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -1,47 +1,93 @@
 use std::collections::HashMap;
-#[cfg(feature = "tokio-exporter")]
+#[cfg(feature = "push-gateway")]
+use std::convert::TryFrom;
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 use std::future::Future;
+#[cfg(feature = "http-listener")]
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-#[cfg(feature = "tokio-exporter")]
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+use std::pin::Pin;
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 use std::thread;
 use std::time::Duration;
 
-#[cfg(feature = "tokio-exporter")]
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+use hyper::Body;
+
+#[cfg(feature = "http-listener")]
 use hyper::{
     server::{conn::AddrStream, Server},
     service::{make_service_fn, service_fn},
-    StatusCode, {Body, Error as HyperError, Response},
+    Response, StatusCode,
 };
+
+#[cfg(feature = "push-gateway")]
+use hyper::{
+    body::{aggregate, Buf},
+    client::Client,
+    Method, Request, Uri,
+};
+
 use indexmap::IndexMap;
+#[cfg(feature = "http-listener")]
+use ipnet::IpNet;
 use parking_lot::RwLock;
 use quanta::Clock;
-#[cfg(feature = "tokio-exporter")]
-use tokio::{pin, runtime, select};
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+use tokio::runtime;
+#[cfg(feature = "push-gateway")]
+use tracing::error;
 
 use metrics_util::{parse_quantiles, recency::Recency, MetricKindMask, Quantile, Registry};
 
-#[cfg(feature = "tokio-exporter")]
-use crate::common::InstallError;
 use crate::common::Matcher;
 use crate::distribution::DistributionBuilder;
 use crate::recorder::{Inner, PrometheusRecorder};
-#[cfg(feature = "tokio-exporter")]
-use std::pin::Pin;
+use crate::{common::BuildError, PrometheusHandle};
 
-#[cfg(feature = "push-gateway")]
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+type ExporterFuture = Pin<Box<dyn Future<Output = Result<(), hyper::Error>> + Send + 'static>>;
+
 #[derive(Clone)]
-pub struct PrometheusPushGatewayConfig {
-    address: String,
-    push_interval: std::time::Duration,
+enum ExporterConfig {
+    // Run an HTTP listener on the given `listen_address`.
+    #[cfg(feature = "http-listener")]
+    HttpListener { listen_address: SocketAddr },
+
+    // Run a push gateway task sending to the given `endpoint` after `interval` time has elapsed,
+    // infinitely.
+    #[cfg(feature = "push-gateway")]
+    PushGateway { endpoint: Uri, interval: Duration },
+
+    #[allow(dead_code)]
+    Unconfigured,
+}
+
+impl ExporterConfig {
+    #[cfg_attr(
+        not(any(feature = "http-listener", feature = "push-gateway")),
+        allow(dead_code)
+    )]
+    fn as_type_str(&self) -> &'static str {
+        match self {
+            #[cfg(feature = "http-listener")]
+            Self::HttpListener { .. } => "http-listener",
+            #[cfg(feature = "push-gateway")]
+            Self::PushGateway { .. } => "push-gateway",
+            Self::Unconfigured => "unconfigured,",
+        }
+    }
 }
 
 /// Builder for creating and installing a Prometheus recorder/exporter.
 pub struct PrometheusBuilder {
-    listen_address: Option<SocketAddr>,
-    #[cfg(feature = "push-gateway")]
-    push_gateway_config: Option<PrometheusPushGatewayConfig>,
-    #[cfg(feature = "tokio-exporter")]
-    allow_ips: Option<Vec<ipnet::IpNet>>,
+    #[cfg_attr(
+        not(any(feature = "http-listener", feature = "push-gateway")),
+        allow(dead_code)
+    )]
+    exporter_config: ExporterConfig,
+    #[cfg(feature = "http-listener")]
+    allowed_addresses: Option<Vec<IpNet>>,
     quantiles: Vec<Quantile>,
     buckets: Option<Vec<f64>>,
     bucket_overrides: Option<HashMap<Matcher, Vec<f64>>>,
@@ -55,62 +101,108 @@ impl PrometheusBuilder {
     pub fn new() -> Self {
         let quantiles = parse_quantiles(&[0.0, 0.5, 0.9, 0.95, 0.99, 0.999, 1.0]);
 
+        #[cfg(feature = "http-listener")]
+        let exporter_config = ExporterConfig::HttpListener {
+            listen_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9000),
+        };
+        #[cfg(not(feature = "http-listener"))]
+        let exporter_config = ExporterConfig::Unconfigured;
+
         Self {
-            listen_address: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9000)),
-            #[cfg(feature = "tokio-exporter")]
-            allow_ips: None,
+            exporter_config,
+            #[cfg(feature = "http-listener")]
+            allowed_addresses: None,
             quantiles,
             buckets: None,
             bucket_overrides: None,
             idle_timeout: None,
             recency_mask: MetricKindMask::NONE,
             global_labels: None,
-            #[cfg(feature = "push-gateway")]
-            push_gateway_config: None,
         }
     }
 
-    /// Sets the listen address for the Prometheus scrape endpoint.
+    /// Configures the exporter to expose an HTTP listener that functions as a [scrape endpoint].
     ///
     /// The HTTP listener that is spawned will respond to GET requests on any request path.
     ///
-    /// Defaults to `0.0.0.0:9000`.
-    pub fn listen_address(mut self, addr: impl Into<SocketAddr>) -> Self {
-        self.listen_address = Some(addr.into());
+    /// Running in HTTP listener mode is mutually exclusive with the push gateway i.e. enabling the
+    /// HTTP listener will disable the push gateway, and vise versa.
+    ///
+    /// Defaults to enabled, listening at `0.0.0.0:9000`.
+    ///
+    /// [scrape endpoint]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
+    #[cfg(feature = "http-listener")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http-listener")))]
+    pub fn with_http_listener(mut self, addr: impl Into<SocketAddr>) -> Self {
+        self.exporter_config = ExporterConfig::HttpListener {
+            listen_address: addr.into(),
+        };
         self
     }
 
-    /// Disable the HTTP listener. This is useful when you only want to use the
-    /// Prometheus push gateway.
-    pub fn disable_http_listener(mut self) -> Self {
-        self.listen_address = None;
-        self
-    }
-
-    /// Sets the push gateway address and push interval for the Prometheus push gateway.
+    /// Configures the exporter to push periodic requests to a Prometheus [push gateway].
+    ///
+    /// Running in push gateway mode is mutually exclusive with the HTTP listener i.e. enabling the
+    /// push gateway will disable the HTTP listener, and vise versa.
+    ///
+    /// Defaults to disabled.
+    ///
+    /// ## Errors
+    ///
+    /// If the given endpoint cannot be parsed into a valid URI, an error variant will be
+    /// returned describing the error.
+    ///
+    /// [push gateway]: https://prometheus.io/docs/instrumenting/pushing/
     #[cfg(feature = "push-gateway")]
-    pub fn push_gateway_config<T>(mut self, addr: T, interval: std::time::Duration) -> Self
+    #[cfg_attr(docsrs, doc(cfg(feature = "push-gateway")))]
+    pub fn with_push_gateway<T>(
+        mut self,
+        endpoint: T,
+        interval: Duration,
+    ) -> Result<Self, BuildError>
     where
         T: AsRef<str>,
     {
-        self.push_gateway_config = Some(PrometheusPushGatewayConfig {
-            address: addr.as_ref().to_string(),
-            push_interval: interval,
-        });
-        self
+        self.exporter_config = ExporterConfig::PushGateway {
+            endpoint: Uri::try_from(endpoint.as_ref())
+                .map_err(|e| BuildError::InvalidPushGatewayEndpoint(e.to_string()))?,
+            interval,
+        };
+
+        Ok(self)
     }
 
-    /// Adds an IP address or subnet that is allowed to connect to the Prometheus scrape endpoint.
+    /// Adds an IP address or subnet to the allowlist for the scrape endpoint.
     ///
-    /// By default (if this method is never called), no restrictions are enforced.
+    /// If a client makes a request to the scrape endpoint and their IP is not present in the
+    /// allowlist, either directly or within any of the allowed subnets, they will receive a 403
+    /// Forbidden response.
     ///
-    /// Note that this on its own is insufficient for access control, if the exporter is running in
-    /// an environment alongside applications (such as web browsers) that are susceptible to
-    /// [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding).
-    #[cfg(feature = "tokio-exporter")]
-    pub fn add_allowed(mut self, subnet: ipnet::IpNet) -> Self {
-        self.allow_ips.get_or_insert(vec![]).push(subnet);
-        self
+    /// Defaults to allowing all IPs.
+    ///
+    /// ## Security Considerations
+    ///
+    /// On its own, an IP allowlist is insufficient for access control, if the exporter is running
+    /// in an environment alongside applications (such as web browsers) that are susceptible to [DNS
+    /// rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) attacks.
+    ///
+    /// ## Errors
+    ///
+    /// If the given address cannot be parsed into an IP address or subnet, an error variant will be
+    /// returned describing the error.
+    #[cfg(feature = "http-listener")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http-listener")))]
+    pub fn add_allowed_address<A>(mut self, address: A) -> Result<Self, BuildError>
+    where
+        A: AsRef<str>,
+    {
+        use std::str::FromStr;
+
+        let address = IpNet::from_str(address.as_ref())
+            .map_err(|e| BuildError::InvalidAllowlistAddress(e.to_string()))?;
+        self.allowed_addresses.get_or_insert(vec![]).push(address);
+
+        Ok(self)
     }
 
     /// Sets the quantiles to use when rendering histograms.
@@ -118,24 +210,40 @@ impl PrometheusBuilder {
     /// Quantiles represent a scale of 0 to 1, where percentiles represent a scale of 1 to 100, so
     /// a quantile of 0.99 is the 99th percentile, and a quantile of 0.99 is the 99.9th percentile.
     ///
-    /// By default, the quantiles will be set to: 0.0, 0.5, 0.9, 0.95, 0.99, 0.999, and 1.0. This means
+    /// Defaults to a hard-coded set of quantiles: 0.0, 0.5, 0.9, 0.95, 0.99, 0.999, and 1.0. This means
     /// that all histograms will be exposed as Prometheus summaries.
     ///
     /// If buckets are set (via [`set_buckets`][Self::set_buckets] or
     /// [`set_buckets_for_metric`][Self::set_buckets_for_metric]) then all histograms will be exposed
     /// as summaries instead.
-    pub fn set_quantiles(mut self, quantiles: &[f64]) -> Self {
+    ///
+    /// ## Errors
+    ///
+    /// If `quantiles` is empty, an error variant will be thrown.
+    pub fn set_quantiles(mut self, quantiles: &[f64]) -> Result<Self, BuildError> {
+        if quantiles.is_empty() {
+            return Err(BuildError::EmptyBucketsOrQuantiles);
+        }
+
         self.quantiles = parse_quantiles(quantiles);
-        self
+        Ok(self)
     }
 
     /// Sets the buckets to use when rendering histograms.
     ///
     /// Buckets values represent the higher bound of each buckets.  If buckets are set, then all
     /// histograms will be rendered as true Prometheus histograms, instead of summaries.
-    pub fn set_buckets(mut self, values: &[f64]) -> Self {
+    ///
+    /// ## Errors
+    ///
+    /// If `values` is empty, an error variant will be thrown.
+    pub fn set_buckets(mut self, values: &[f64]) -> Result<Self, BuildError> {
+        if values.is_empty() {
+            return Err(BuildError::EmptyBucketsOrQuantiles);
+        }
+
         self.buckets = Some(values.to_vec());
-        self
+        Ok(self)
     }
 
     /// Sets the bucket for a specific pattern.
@@ -149,11 +257,23 @@ impl PrometheusBuilder {
     /// histograms that match will be rendered as true Prometheus histograms, instead of summaries.
     ///
     /// This option changes the observer's output of histogram-type metric into summaries.
-    /// It only affects matching metrics if set_buckets was not used.
-    pub fn set_buckets_for_metric(mut self, matcher: Matcher, values: &[f64]) -> Self {
+    /// It only affects matching metrics if [`set_buckets`] was not used.
+    ///
+    /// ## Errors
+    ///
+    /// If `values` is empty, an error variant will be thrown.
+    pub fn set_buckets_for_metric(
+        mut self,
+        matcher: Matcher,
+        values: &[f64],
+    ) -> Result<Self, BuildError> {
+        if values.is_empty() {
+            return Err(BuildError::EmptyBucketsOrQuantiles);
+        }
+
         let buckets = self.bucket_overrides.get_or_insert_with(HashMap::new);
         buckets.insert(matcher.sanitized(), values.to_vec());
-        self
+        Ok(self)
     }
 
     /// Sets the idle timeout for metrics.
@@ -197,61 +317,207 @@ impl PrometheusBuilder {
 
     /// Builds the recorder and exporter and installs them globally.
     ///
-    /// When called from within a Tokio runtime, the handler future is spawned directly
+    /// When called from within a Tokio runtime, the exporter future is spawned directly
     /// into the runtime.  Otherwise, a new single-threaded Tokio runtime is created
-    /// on a background thread, and the handler is spawned there.
+    /// on a background thread, and the exporter is spawned there.
     ///
-    /// An error will be returned if there's an issue with creating the HTTP server or with
-    /// installing the recorder as the global recorder.
-    #[cfg(feature = "tokio-exporter")]
-    pub fn install(self) -> Result<(), InstallError> {
-        if let Ok(handle) = runtime::Handle::try_current() {
+    /// ## Errors
+    ///
+    /// If there is an error while either building the recorder and exporter, or installing the
+    /// recorder and exporter, an error variant will be returned describing the error.
+    #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "http-listener", feature = "push-gateway")))
+    )]
+    pub fn install(self) -> Result<(), BuildError> {
+        let recorder = if let Ok(handle) = runtime::Handle::try_current() {
             let (recorder, exporter) = {
                 let _g = handle.enter();
-                self.build_with_exporter()?
+                self.build()?
             };
-            metrics::set_boxed_recorder(Box::new(recorder))?;
 
-            handle.spawn(async move {
-                pin!(exporter);
-                loop {
-                    select! {
-                        _ = &mut exporter => {}
-                    }
-                }
-            });
+            handle.spawn(exporter);
 
-            return Ok(());
-        }
+            recorder
+        } else {
+            let thread_name = format!(
+                "metrics-exporter-prometheus-{}",
+                self.exporter_config.as_type_str()
+            );
 
-        let runtime = runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
+            let runtime = runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| BuildError::FailedToCreateRuntime(e.to_string()))?;
 
-        let (recorder, exporter) = {
-            let _g = runtime.enter();
-            self.build_with_exporter()?
+            let (recorder, exporter) = {
+                let _g = runtime.enter();
+                self.build()?
+            };
+
+            thread::Builder::new()
+                .name(thread_name)
+                .spawn(move || runtime.block_on(exporter))
+                .map_err(|e| BuildError::FailedToCreateRuntime(e.to_string()))?;
+
+            recorder
         };
-        metrics::set_boxed_recorder(Box::new(recorder))?;
 
-        thread::Builder::new()
-            .name("metrics-exporter-prometheus-http".to_string())
-            .spawn(move || {
-                runtime.block_on(async move {
-                    pin!(exporter);
-                    loop {
-                        select! {
-                            _ = &mut exporter => {}
-                        }
-                    }
-                });
-            })?;
+        metrics::set_boxed_recorder(Box::new(recorder))?;
 
         Ok(())
     }
 
+    /// Builds the recorder and installs it globally, returning a handle to it.
+    ///
+    /// The handle can be used to generate valid Prometheus scrape endpoint payloads directly.
+    ///
+    /// ## Errors
+    ///
+    /// If there is an error while building the recorder, or installing the recorder, an error
+    /// variant will be returned describing the error.
+    pub fn install_recorder(self) -> Result<PrometheusHandle, BuildError> {
+        let recorder = self.build_recorder();
+        let handle = recorder.handle();
+
+        metrics::set_boxed_recorder(Box::new(recorder))?;
+
+        Ok(handle)
+    }
+
+    /// Builds the recorder and exporter and returns them both.
+    ///
+    /// In most cases, users should prefer to use [`install`][PrometheusBuilder::install] to create
+    /// and install the recorder and exporter automatically for them.  If a caller is combining
+    /// recorders, or needs to schedule the exporter to run in a particular way, this method, or
+    /// [`build_recorder`][PrometheusBuilder::build_recorder], provide the flexibility to do so.
+    ///
+    /// ## Panics
+    ///
+    /// This method must be called from within an existing Tokio runtime or it will panic.
+    ///
+    /// ## Errors
+    ///
+    /// If there is an error while building the recorder and exporter, an error variant will be
+    /// returned describing the error.
+    #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "http-listener", feature = "push-gateway")))
+    )]
+    #[cfg_attr(not(feature = "http-listener"), allow(unused_mut))]
+    pub fn build(mut self) -> Result<(PrometheusRecorder, ExporterFuture), BuildError> {
+        #[cfg(feature = "http-listener")]
+        let allowed_addresses = self.allowed_addresses.take();
+
+        let exporter_config = self.exporter_config.clone();
+        let recorder = self.build_recorder();
+        let handle = recorder.handle();
+
+        match exporter_config {
+            ExporterConfig::Unconfigured => Err(BuildError::MissingExporterConfiguration),
+            #[cfg(feature = "http-listener")]
+            ExporterConfig::HttpListener { listen_address } => {
+                let server = Server::try_bind(&listen_address)
+                    .map_err(|e| BuildError::FailedToCreateHTTPListener(e.to_string()))?;
+                let exporter = async move {
+                    let make_svc = make_service_fn(move |socket: &AddrStream| {
+                        let remote_addr = socket.remote_addr().ip();
+
+                        // If the allowlist is empty, the request is allowed.  Otherwise, it must
+                        // match one of the entries in the allowlist or it will be denied.
+                        let is_allowed = allowed_addresses.as_ref().map_or(true, |addresses| {
+                            addresses
+                                .iter()
+                                .any(|address| address.contains(&remote_addr))
+                        });
+
+                        let handle = handle.clone();
+
+                        async move {
+                            Ok::<_, hyper::Error>(service_fn(move |_| {
+                                let handle = handle.clone();
+
+                                async move {
+                                    if is_allowed {
+                                        let output = handle.render();
+                                        Ok::<_, hyper::Error>(Response::new(Body::from(output)))
+                                    } else {
+                                        Ok::<_, hyper::Error>(
+                                            Response::builder()
+                                                .status(StatusCode::FORBIDDEN)
+                                                .body(Body::empty())
+                                                .expect("static response is valid"),
+                                        )
+                                    }
+                                }
+                            }))
+                        }
+                    });
+                    server.serve(make_svc).await
+                };
+
+                Ok((recorder, Box::pin(exporter)))
+            }
+
+            #[cfg(feature = "push-gateway")]
+            ExporterConfig::PushGateway { endpoint, interval } => {
+                let exporter = async move {
+                    let client = Client::new();
+
+                    loop {
+                        // Sleep for `interval` amount of time, and then do a push.
+                        tokio::time::sleep(interval).await;
+
+                        let output = handle.render();
+                        let result = Request::builder()
+                            .method(Method::PUT)
+                            .uri(endpoint.clone())
+                            .body(Body::from(output));
+                        let req = match result {
+                            Ok(req) => req,
+                            Err(e) => {
+                                error!("failed to build push gateway request: {}", e);
+                                continue;
+                            }
+                        };
+
+                        match client.request(req).await {
+                            Ok(response) => {
+                                if !response.status().is_success() {
+                                    let status = response.status();
+                                    let status = status
+                                        .canonical_reason()
+                                        .unwrap_or_else(|| status.as_str());
+                                    let body = aggregate(response.into_body()).await;
+                                    let body = body
+                                        .map_err(|_| ())
+                                        .map(|mut b| b.copy_to_bytes(b.remaining()))
+                                        .map(|b| (&b[..]).to_vec())
+                                        .and_then(|s| String::from_utf8(s).map_err(|_| ()))
+                                        .unwrap_or_else(|_| {
+                                            String::from("<failed to read response body>")
+                                        });
+                                    error!(
+                                        message = "unexpected status after pushing metrics to push gateway",
+                                        status,
+                                        %body,
+                                    );
+                                }
+                            }
+                            Err(e) => error!("error sending request to push gateway: {:?}", e),
+                        }
+                    }
+                };
+
+                Ok((recorder, Box::pin(exporter)))
+            }
+        }
+    }
+
     /// Builds the recorder and returns it.
-    pub fn build(self) -> PrometheusRecorder {
+    pub fn build_recorder(self) -> PrometheusRecorder {
         self.build_with_clock(Clock::new())
     }
 
@@ -270,100 +536,6 @@ impl PrometheusBuilder {
         };
 
         PrometheusRecorder::from(inner)
-    }
-
-    /// Builds the recorder and exporter and returns them both.
-    ///
-    /// In most cases, users should prefer to use [`PrometheusBuilder::install`] to create and
-    /// install the recorder and exporter automatically for them.  If a caller is combining
-    /// recorders, or needs to schedule the exporter to run in a particular way, this method
-    /// provides the flexibility to do so.
-    #[cfg(feature = "tokio-exporter")]
-    pub fn build_with_exporter(
-        mut self,
-    ) -> Result<
-        (
-            PrometheusRecorder,
-            Pin<Box<dyn Future<Output = Result<(), HyperError>> + Send + 'static>>,
-        ),
-        InstallError,
-    > {
-        let address = self.listen_address;
-        let allow_ips = self.allow_ips.take();
-        #[cfg(feature = "push-gateway")]
-        let push_gateway_config = self.push_gateway_config.take();
-        let recorder = self.build();
-        let handle = recorder.handle();
-
-        if let Some(address) = &address {
-            let server = Server::try_bind(address)?;
-            let exporter = async move {
-                let make_svc = make_service_fn(move |socket: &AddrStream| {
-                    let remote_addr = socket.remote_addr().ip();
-                    let allowed = allow_ips
-                        .as_ref()
-                        .map(|subnets| subnets.iter().any(|subnet| subnet.contains(&remote_addr)))
-                        // If no subnets specified, allow all IPs.
-                        .unwrap_or(true);
-
-                    let handle = handle.clone();
-
-                    async move {
-                        Ok::<_, HyperError>(service_fn(move |_| {
-                            let handle = handle.clone();
-
-                            async move {
-                                if allowed {
-                                    let output = handle.render();
-                                    Ok::<_, HyperError>(Response::new(Body::from(output)))
-                                } else {
-                                    Ok::<_, HyperError>(
-                                        Response::builder()
-                                            .status(StatusCode::FORBIDDEN)
-                                            .body(Body::empty())
-                                            .expect("static response is valid"),
-                                    )
-                                }
-                            }
-                        }))
-                    }
-                });
-                server.serve(make_svc).await
-            };
-            return Ok((recorder, Box::pin(exporter)));
-        }
-
-        #[cfg(feature = "push-gateway")]
-        if let Some(push_gateway_config) = push_gateway_config {
-            let exporter = async move {
-                let client = reqwest::Client::default();
-                loop {
-                    tokio::time::sleep(push_gateway_config.push_interval).await;
-                    let output = handle.render();
-                    let response = client
-                        .put(push_gateway_config.address.as_str())
-                        .body(output)
-                        .send()
-                        .await;
-                    match response {
-                        Ok(response) => {
-                            if let Err(e) = response.error_for_status() {
-                                tracing::error!(
-                                    "error status code for pushing metrics to push gateway: {:?}",
-                                    e
-                                )
-                            }
-                        }
-                        Err(e) => {
-                            tracing::error!("error pushing metrics to push gateway: {:?}", e)
-                        }
-                    }
-                }
-            };
-            return Ok((recorder, Box::pin(exporter)));
-        }
-
-        unimplemented!("must specify at least one of listen_address or push_gateway_config");
     }
 }
 
@@ -386,7 +558,7 @@ mod tests {
 
     #[test]
     fn test_render() {
-        let recorder = PrometheusBuilder::new().build();
+        let recorder = PrometheusBuilder::new().build_recorder();
 
         let key = Key::from_name("basic_counter");
         let counter1 = recorder.register_counter(&key);
@@ -445,13 +617,17 @@ mod tests {
                 Matcher::Full("metrics.testing foo".to_owned()),
                 &FULL_VALUES[..],
             )
+            .expect("bounds should not be empty")
             .set_buckets_for_metric(
                 Matcher::Prefix("metrics.testing".to_owned()),
                 &PREFIX_VALUES[..],
             )
+            .expect("bounds should not be empty")
             .set_buckets_for_metric(Matcher::Suffix("foo".to_owned()), &SUFFIX_VALUES[..])
+            .expect("bounds should not be empty")
             .set_buckets(&DEFAULT_VALUES[..])
-            .build();
+            .expect("bounds should not be empty")
+            .build_recorder();
 
         let full_key = Key::from_name("metrics.testing_foo");
         let full_key_histo = recorder.register_histogram(&full_key);
@@ -561,7 +737,7 @@ mod tests {
         let recorder = PrometheusBuilder::new()
             .add_global_label("foo", "foo")
             .add_global_label("foo", "bar")
-            .build();
+            .build_recorder();
         let key = Key::from_name("basic_counter");
         let counter1 = recorder.register_counter(&key);
         counter1.increment(42);
@@ -577,7 +753,7 @@ mod tests {
     pub fn test_global_labels_overrides() {
         let recorder = PrometheusBuilder::new()
             .add_global_label("foo", "foo")
-            .build();
+            .build_recorder();
 
         let key =
             Key::from_name("overridden").with_extra_labels(vec![Label::new("foo", "overridden")]);
@@ -595,7 +771,7 @@ mod tests {
     pub fn test_sanitized_render() {
         let recorder = PrometheusBuilder::new()
             .add_global_label("foo:", "foo")
-            .build();
+            .build_recorder();
 
         let key = Key::from_name("yee_haw:lets go")
             .with_extra_labels(vec![Label::new("øhno", "\"yeet\nies\\\"")]);

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -257,7 +257,7 @@ impl PrometheusBuilder {
     /// histograms that match will be rendered as true Prometheus histograms, instead of summaries.
     ///
     /// This option changes the observer's output of histogram-type metric into summaries.
-    /// It only affects matching metrics if [`set_buckets`] was not used.
+    /// It only affects matching metrics if [`set_buckets`][Self::set_buckets] was not used.
     ///
     /// ## Errors
     ///

--- a/metrics-exporter-prometheus/src/distribution.rs
+++ b/metrics-exporter-prometheus/src/distribution.rs
@@ -21,14 +21,14 @@ pub enum Distribution {
 }
 
 impl Distribution {
-    pub fn new_histogram(buckets: &[f64]) -> Option<Distribution> {
-        let hist = Histogram::new(buckets)?;
-        Some(Distribution::Histogram(hist))
+    pub fn new_histogram(buckets: &[f64]) -> Distribution {
+        let hist = Histogram::new(buckets).expect("buckets should never be empty");
+        Distribution::Histogram(hist)
     }
 
-    pub fn new_summary(quantiles: Arc<Vec<Quantile>>) -> Option<Distribution> {
+    pub fn new_summary(quantiles: Arc<Vec<Quantile>>) -> Distribution {
         let summary = Summary::with_defaults();
-        Some(Distribution::Summary(summary, quantiles, 0.0))
+        Distribution::Summary(summary, quantiles, 0.0)
     }
 
     pub fn record_samples(&mut self, samples: &[f64]) {
@@ -69,7 +69,7 @@ impl DistributionBuilder {
         }
     }
 
-    pub fn get_distribution(&self, name: &str) -> Option<Distribution> {
+    pub fn get_distribution(&self, name: &str) -> Distribution {
         if let Some(ref overrides) = self.bucket_overrides {
             for (matcher, buckets) in overrides.iter() {
                 if matcher.matches(name) {

--- a/metrics-exporter-prometheus/src/lib.rs
+++ b/metrics-exporter-prometheus/src/lib.rs
@@ -1,8 +1,107 @@
-//! Records metrics in the Prometheus exposition format.
+//! A [`metrics`]-compatible exporter for sending metrics to Prometheus.
+//!
+//! ## Basics
+//!
+//! `metrics-exporter-prometheus` is a [`metrics`]-compatible exporter for either exposing an HTTP
+//! endpoint that can be scraped by Prometheus, or that can push metrics to a Prometheus push
+//! gateway.
+//!
+//! ## High-level features
+//!
+//! - scrape endpoint support
+//! - push gateway support
+//! - IP-based allowlist for scrape endpoint
+//! - ability to push histograms as either aggregated summaries or aggregated histograms, with
+//!   configurable quantiles/buckets
+//! - ability to control bucket configuration on a per-metric basis
+//! - configurable global labels (applied to all metrics, overridden by metric's own labels if present)
+//!
+//! ## Behavior
+//!
+//! In general, interacting with the exporter should look and feel like interacting with any other
+//! implementation of a Prometheus scrape endpoint or push gateway implementation, but there are
+//! some small caveats around metric naming.
+//!
+//! We strive to match both the Prometheus [data model] and follow the [exposition format]
+//! specification, but due to the decoupled nature of [`metrics`][metrics], the exporter makes some
+//! specific trade-offs when ensuring compliance with the specification when it comes to metric
+//! names and label keys.  Below is a matrix of scenarios where the exporter will modify a metric
+//! name or label key:
+//!
+//! - metric name starts with, or contains, an invalid character: **replace character with
+//!   underscore**
+//! - label key starts with, or contains, an invalid character: **replace character with
+//!   underscore**
+//! - label key starts with two underscores: **add additional underscore** (three underscores total)
+//!
+//! This behavior may be confusing at first since [`metrics`][metrics] itself allows any valid UTF-8
+//! string for a metric name or label, but there is no way to report to the user that a metric name
+//! or label key is invalid only when using the Prometheus exporter, so we must cope with these
+//! situations by replacing invalid characters at runtime.
+//!
+//! ## Usage
+//!
+//! Using the exporter is straightforward:
+//!
+//! ```ignore
+//! // First, create a builder.
+//! //
+//! // The builder can configure many aspects of the exporter, such as changing the
+//! // listen address, adjusting how histograms will be reported, changing how long
+//! // metrics can be idle before being removed, and more.
+//! let builder = PrometheusBuilder::new();
+//!
+//! // Normally, most users will want to "install" the exporter which sets it as the
+//! // global recorder for all `metrics` calls, and installs either an HTTP listener
+//! // when running as a scrape endpoint, or a simple asynchronous task which pushes
+//! // to the configured push gateway on the given interval.
+//! //
+//! // If you're already inside a Tokio runtime, this will spawn a task for the
+//! // exporter on that runtime, and otherwise, a new background thread will be
+//! // spawned which a Tokio single-threaded runtime is launched on to, where we then
+//! // finally launch the exporter:
+//! builder.install().expect("failed to install recorder/exporter");
+//!
+//! // Maybe you already have an HTTP endpoint that you want to expose a metrics
+//! // endpoint on.. no problem!  You can build the recorder and install it, and get
+//! // back a handle that can be used to generate the Prometheus scrape output on
+//! // demand:
+//! let handle = builder.install_recorder().expect("failed to install recorder");
+//!
+//! // Maybe you have a more complicated setup and want to be handed back the recorder
+//! // object and a future that can run the HTTP listener / push gateway so you can
+//! // install/spawn them in a specific way.. also not a problem!
+//! //
+//! // As this is a more advanced method, it _must_ be called from within an existing
+//! // Tokio runtime when the exporter is running in HTTP listener/scrape endpoint mode.
+//! let (recorder, exporter) = builder.build().expect("failed to build recorder/exporter");
+//!
+//! // Finally, maybe you literally only want to build the recorder and nothing else,
+//! // and we've got you covered there, too:
+//! let recorder = builder.build_recorder().expect("failed to build recorder");
+//! ```
+//!
+//! ## Features
+//!
+//! Two main feature flags control which modes that exporter can run in:
+//! - **`http-listener`**: allows running the exporter as a scrape endpoint (_enabled by default_)
+//! - **`push-gateway`**: allows running the exporter in push gateway mode (_enabled by default_)
+//!
+//! Neither of these flags are required to create, or install, only a recorder.  However, in order
+//! to create or build an exporter, at least one of these feature flags must be enabled.  Builder
+//! methods that require certain feature flags will be documented as such.
+//!
+//! [metrics]: https://docs.rs/metrics/latest/metrics/
+//! [data model]: https://prometheus.io/docs/concepts/data_model/
+//! [exposition format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
+#![deny(clippy::all)]
+#![deny(clippy::pedantic)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::module_name_repetitions)]
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 mod common;
-pub use self::common::Matcher;
+pub use self::common::{BuildError, Matcher};
 
 mod distribution;
 

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -198,7 +198,8 @@ impl Inner {
 /// [`metrics::set_boxed_recorder`].
 ///
 /// Most users will not need to interact directly with the recorder, and can simply deal with the
-/// builder methods on [`PrometheusBuilder`] for building and installing the recorder/exporter.
+/// builder methods on [`PrometheusBuilder`](crate::PrometheusBuilder) for building and installing
+/// the recorder/exporter.
 pub struct PrometheusRecorder {
     inner: Arc<Inner>,
 }

--- a/metrics-exporter-tcp/src/lib.rs
+++ b/metrics-exporter-tcp/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! [metrics]: https://docs.rs/metrics
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 use std::io::{self, Write};
 use std::net::SocketAddr;
 use std::sync::{

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -93,7 +93,7 @@
 //! modern systems, but may represent an unacceptable amount of memory usage on constrained systems
 //! such as embedded platforms, etc.
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 
 use metrics::{Counter, Gauge, Histogram, Key, Label, Recorder, Unit};
 use metrics_util::layers::Layer;

--- a/metrics-util/src/lib.rs
+++ b/metrics-util/src/lib.rs
@@ -1,6 +1,6 @@
 //! Helper types and functions used within the metrics ecosystem.
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 
 #[cfg(feature = "handles")]
 mod bucket;

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -256,7 +256,7 @@
 //! [AtomicBucket]: https://docs.rs/metrics-util/0.5.0/metrics_util/struct.AtomicBucket.html
 //! [Handle]: https://docs.rs/metrics-util/0.5.0/metrics_util/enum.Handle.html
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 
 extern crate alloc;
 


### PR DESCRIPTION
This PR started off trying to address #223 but morphed into a bit more:
- we did make the feature flag situation better (better names, flags show in docs.rs)
- builder methods are named more appropriately for build only vs build/install
- module-level docs!
- cleaned up a bunch of code in various sections (although we made up for it, line count-wise, with all the `#[cfg]` statements we've added)

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>

Fixes #223.