### PR TITLE
Massive rework to make metric description more succinct.

### DIFF
--- a/metrics-exporter-prometheus/examples/prometheus_push_gateway.rs
+++ b/metrics-exporter-prometheus/examples/prometheus_push_gateway.rs
@@ -21,10 +21,7 @@ fn main() {
     tracing_subscriber::fmt::init();
 
     PrometheusBuilder::new()
-        .with_push_gateway(
-            "http://127.0.0.1:9091/metrics/job/example",
-            Duration::from_secs(10),
-        )
+        .with_push_gateway("http://127.0.0.1:9091/metrics/job/example", Duration::from_secs(10))
         .expect("push gateway endpoint should be valid")
         .idle_timeout(
             MetricKindMask::COUNTER | MetricKindMask::HISTOGRAM,
@@ -39,10 +36,7 @@ fn main() {
     //
     // Registering metrics ahead of using them is not required, but is the only way to specify the
     // description of a metric.
-    describe_counter!(
-        "tcp_server_loops",
-        "The iterations of the TCP server event loop so far."
-    );
+    describe_counter!("tcp_server_loops", "The iterations of the TCP server event loop so far.");
     describe_histogram!(
         "tcp_server_loop_delta_secs",
         "The time taken for iterations of the TCP server event loop."

--- a/metrics-exporter-prometheus/examples/prometheus_server.rs
+++ b/metrics-exporter-prometheus/examples/prometheus_server.rs
@@ -29,10 +29,7 @@ fn main() {
     //
     // Registering metrics ahead of using them is not required, but is the only way to specify the
     // description of a metric.
-    describe_counter!(
-        "tcp_server_loops",
-        "The iterations of the TCP server event loop so far."
-    );
+    describe_counter!("tcp_server_loops", "The iterations of the TCP server event loop so far.");
     describe_histogram!(
         "tcp_server_loop_delta_secs",
         "The time taken for iterations of the TCP server event loop."

--- a/metrics-exporter-prometheus/src/common.rs
+++ b/metrics-exporter-prometheus/src/common.rs
@@ -185,12 +185,7 @@ mod tests {
 
     #[test]
     fn test_sanitize_metric_name_known_cases() {
-        let cases = &[
-            ("*", "_"),
-            ("\"", "_"),
-            ("foo_bar", "foo_bar"),
-            ("1foobar", "_foobar"),
-        ];
+        let cases = &[("*", "_"), ("\"", "_"), ("foo_bar", "foo_bar"), ("1foobar", "_foobar")];
 
         for (input, expected) in cases {
             let result = sanitize_metric_name(input);

--- a/metrics-exporter-tcp/build.rs
+++ b/metrics-exporter-tcp/build.rs
@@ -2,7 +2,5 @@ fn main() {
     println!("cargo:rerun-if-changed=proto/event.proto");
     let mut prost_build = prost_build::Config::new();
     prost_build.btree_map(&["."]);
-    prost_build
-        .compile_protos(&["proto/event.proto"], &["proto/"])
-        .unwrap();
+    prost_build.compile_protos(&["proto/event.proto"], &["proto/"]).unwrap();
 }

--- a/metrics-exporter-tcp/examples/tcp_server.rs
+++ b/metrics-exporter-tcp/examples/tcp_server.rs
@@ -18,7 +18,11 @@ fn main() {
     let clock = Clock::new();
     let mut last = None;
 
-    describe_histogram!("tcp_server_loop_delta_secs", Unit::Seconds);
+    describe_histogram!(
+        "tcp_server_loop_delta_secs",
+        Unit::Seconds,
+        "amount of time spent in the core server loop["
+    );
 
     loop {
         increment_counter!("tcp_server_loops", "system" => "foo");

--- a/metrics-macros/CHANGELOG.md
+++ b/metrics-macros/CHANGELOG.md
@@ -8,12 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+- When describing a metric, a constant can now be used for the description itself.
+
 ### Changed
 - Correctly scoped the required features of various dependencies to reduce build times/transitive dependencies.
 - Updated macros to coincide with the update to `metrics` for metric handles.  This includes
   renaming `register_*` macros to `describe_*`, which are purely for providing data that describes a
   metric but does not initialize it in any way, and providing new `register_*` macros which do
   initialize a metric.
+- Updated the `describe_*` macros -- née `register_*` -- to require a description, and an optional
+  unit.  As describing a metric does not register it in the sense of ensuring that it is present on
+  the output of an exporter, having the description be optional no longer makes sense.
+- Additionally, the describe macros no longer take labels.  In practice, varying the description of
+  a specific metric based on label values would be counter-intuitive, and to support this corner
+  case requires adds significant complexity to the macro parsing logic.
 
 ### Removed
 - Two unecessary dependencies, `lazy_static` and `regex`.

--- a/metrics-observer/build.rs
+++ b/metrics-observer/build.rs
@@ -2,7 +2,5 @@ fn main() {
     println!("cargo:rerun-if-changed=proto/event.proto");
     let mut prost_build = prost_build::Config::new();
     prost_build.btree_map(&["."]);
-    prost_build
-        .compile_protos(&["proto/event.proto"], &["proto/"])
-        .unwrap();
+    prost_build.compile_protos(&["proto/event.proto"], &["proto/"]).unwrap();
 }

--- a/metrics-observer/src/main.rs
+++ b/metrics-observer/src/main.rs
@@ -34,9 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut terminal = Terminal::new(backend)?;
 
     let mut events = InputEvents::new();
-    let address = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:5000".to_owned());
+    let address = std::env::args().nth(1).unwrap_or_else(|| "127.0.0.1:5000".to_owned());
     let client = metrics_inner::Client::new(address);
     let mut selector = Selector::new();
 
@@ -71,10 +69,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let header_block = Block::default()
                 .title(vec![
-                    Span::styled(
-                        "metrics-observer",
-                        Style::default().add_modifier(Modifier::BOLD),
-                    ),
+                    Span::styled("metrics-observer", Style::default().add_modifier(Modifier::BOLD)),
                     Span::raw(current_dt),
                 ])
                 .borders(Borders::ALL);
@@ -86,9 +81,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     Span::raw("up/down = scroll, q = quit"),
                 ]),
             ];
-            let header = Paragraph::new(text)
-                .block(header_block)
-                .wrap(Wrap { trim: true });
+            let header = Paragraph::new(text).block(header_block).wrap(Wrap { trim: true });
 
             f.render_widget(header, chunks[0]);
 
@@ -119,15 +112,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                     MetricData::Histogram(value) => {
                         let min = value.min();
                         let max = value.max();
-                        let p50 = value
-                            .quantile(0.5)
-                            .expect("sketch shouldn't exist if no values");
-                        let p99 = value
-                            .quantile(0.99)
-                            .expect("sketch shouldn't exist if no values");
-                        let p999 = value
-                            .quantile(0.999)
-                            .expect("sketch shouldn't exist if no values");
+                        let p50 = value.quantile(0.5).expect("sketch shouldn't exist if no values");
+                        let p99 =
+                            value.quantile(0.99).expect("sketch shouldn't exist if no values");
+                        let p999 =
+                            value.quantile(0.999).expect("sketch shouldn't exist if no values");
 
                         format!(
                             "min: {} p50: {} p99: {} p999: {} max: {}",
@@ -142,26 +131,18 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                 let name_length = display_name.chars().count();
                 let value_length = display_value.chars().count();
-                let space = line_width
-                    .saturating_sub(name_length)
-                    .saturating_sub(value_length);
+                let space = line_width.saturating_sub(name_length).saturating_sub(value_length);
 
                 let display = format!("{}{}{}", display_name, " ".repeat(space), display_value);
                 items.push(ListItem::new(display));
             }
             selector.set_length(items.len());
 
-            let metrics_block = Block::default()
-                .title("observed metrics")
-                .borders(Borders::ALL);
+            let metrics_block = Block::default().title("observed metrics").borders(Borders::ALL);
 
             let metrics = List::new(items)
                 .block(metrics_block)
-                .highlight_style(
-                    Style::default()
-                        .add_modifier(Modifier::BOLD)
-                        .fg(Color::LightCyan),
-                )
+                .highlight_style(Style::default().add_modifier(Modifier::BOLD).fg(Color::LightCyan))
                 .highlight_symbol(">> ");
 
             f.render_stateful_widget(metrics, chunks[1], selector.state());
@@ -395,13 +376,7 @@ impl fmt::Debug for TruncatedDuration {
             fmt_decimal(f, secs, sub_nanos, 100_000_000, 3)?;
             f.write_str("s")
         } else if nanos >= 1_000_000 {
-            fmt_decimal(
-                f,
-                nanos as u64 / 1_000_000,
-                (nanos % 1_000_000) as u32,
-                100_000,
-                2,
-            )?;
+            fmt_decimal(f, nanos as u64 / 1_000_000, (nanos % 1_000_000) as u32, 100_000, 2)?;
             f.write_str("ms")
         } else if nanos >= 1_000 {
             fmt_decimal(f, nanos as u64 / 1_000, (nanos % 1_000) as u32, 100, 1)?;

--- a/metrics-observer/src/metrics.rs
+++ b/metrics-observer/src/metrics.rs
@@ -56,11 +56,7 @@ impl Client {
             })
         };
 
-        Client {
-            state,
-            metrics,
-            metadata,
-        }
+        Client { state, metrics, metadata }
     }
 
     pub fn state(&self) -> ClientState {
@@ -107,13 +103,7 @@ impl Runner {
         metrics: Arc<RwLock<BTreeMap<CompositeKey, MetricData>>>,
         metadata: Arc<RwLock<HashMap<(MetricKind, String), (Option<Unit>, Option<String>)>>>,
     ) -> Runner {
-        Runner {
-            state: RunnerState::Disconnected,
-            addr,
-            client_state: state,
-            metrics,
-            metadata,
-        }
+        Runner { state: RunnerState::Disconnected, addr, client_state: state, metrics, metadata }
     }
 
     pub fn run(&mut self) {

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -33,11 +33,7 @@ static CALLSITE_METADATA: Metadata = metadata! {
 fn visit_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("visit");
     group.bench_function("record_str", |b| {
-        let field = CALLSITE
-            .metadata()
-            .fields()
-            .field("test")
-            .expect("test field missing");
+        let field = CALLSITE.metadata().fields().field("test").expect("test field missing");
         b.iter_batched_ref(
             || Labels(get_pool().pull_owned()),
             |labels| {
@@ -47,11 +43,7 @@ fn visit_benchmark(c: &mut Criterion) {
         )
     });
     group.bench_function("record_bool[true]", |b| {
-        let field = CALLSITE
-            .metadata()
-            .fields()
-            .field("test")
-            .expect("test field missing");
+        let field = CALLSITE.metadata().fields().field("test").expect("test field missing");
         b.iter_batched_ref(
             || Labels(get_pool().pull_owned()),
             |labels| {
@@ -61,11 +53,7 @@ fn visit_benchmark(c: &mut Criterion) {
         )
     });
     group.bench_function("record_bool[false]", |b| {
-        let field = CALLSITE
-            .metadata()
-            .fields()
-            .field("test")
-            .expect("test field missing");
+        let field = CALLSITE.metadata().fields().field("test").expect("test field missing");
         b.iter_batched_ref(
             || Labels(get_pool().pull_owned()),
             |labels| {
@@ -75,11 +63,7 @@ fn visit_benchmark(c: &mut Criterion) {
         )
     });
     group.bench_function("record_i64", |b| {
-        let field = CALLSITE
-            .metadata()
-            .fields()
-            .field("test")
-            .expect("test field missing");
+        let field = CALLSITE.metadata().fields().field("test").expect("test field missing");
         b.iter_batched_ref(
             || Labels(get_pool().pull_owned()),
             |labels| {
@@ -89,11 +73,7 @@ fn visit_benchmark(c: &mut Criterion) {
         )
     });
     group.bench_function("record_u64", |b| {
-        let field = CALLSITE
-            .metadata()
-            .fields()
-            .field("test")
-            .expect("test field missing");
+        let field = CALLSITE.metadata().fields().field("test").expect("test field missing");
         b.iter_batched_ref(
             || Labels(get_pool().pull_owned()),
             |labels| {
@@ -104,11 +84,7 @@ fn visit_benchmark(c: &mut Criterion) {
     });
     group.bench_function("record_debug", |b| {
         let debug_struct = DebugStruct::new();
-        let field = CALLSITE
-            .metadata()
-            .fields()
-            .field("test")
-            .expect("test field missing");
+        let field = CALLSITE.metadata().fields().field("test").expect("test field missing");
         b.iter_batched_ref(
             || Labels(get_pool().pull_owned()),
             |labels| {
@@ -118,11 +94,7 @@ fn visit_benchmark(c: &mut Criterion) {
         )
     });
     group.bench_function("record_debug[bool]", |b| {
-        let field = CALLSITE
-            .metadata()
-            .fields()
-            .field("test")
-            .expect("test field missing");
+        let field = CALLSITE.metadata().fields().field("test").expect("test field missing");
         b.iter_batched_ref(
             || Labels(get_pool().pull_owned()),
             |labels| {
@@ -133,11 +105,7 @@ fn visit_benchmark(c: &mut Criterion) {
     });
     group.bench_function("record_debug[i64]", |b| {
         let value: i64 = -3423432;
-        let field = CALLSITE
-            .metadata()
-            .fields()
-            .field("test")
-            .expect("test field missing");
+        let field = CALLSITE.metadata().fields().field("test").expect("test field missing");
         b.iter_batched_ref(
             || Labels(get_pool().pull_owned()),
             |labels| {
@@ -148,11 +116,7 @@ fn visit_benchmark(c: &mut Criterion) {
     });
     group.bench_function("record_debug[u64]", |b| {
         let value: u64 = 3423432;
-        let field = CALLSITE
-            .metadata()
-            .fields()
-            .field("test")
-            .expect("test field missing");
+        let field = CALLSITE.metadata().fields().field("test").expect("test field missing");
         b.iter_batched_ref(
             || Labels(get_pool().pull_owned()),
             |labels| {
@@ -173,10 +137,7 @@ struct DebugStruct {
 
 impl DebugStruct {
     pub fn new() -> DebugStruct {
-        DebugStruct {
-            field1: format!("yeehaw!"),
-            field2: 324242343243,
-        }
+        DebugStruct { field1: format!("yeehaw!"), field2: 324242343243 }
     }
 }
 

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -11,9 +11,9 @@
 //! ```rust
 //! # use metrics_util::DebuggingRecorder;
 //! # use tracing_subscriber::Registry;
+//! use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 //! use metrics_util::layers::Layer;
 //! use tracing_subscriber::layer::SubscriberExt;
-//! use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 //!
 //! // Prepare tracing.
 //! # let my_subscriber = Registry::default();
@@ -95,7 +95,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 
-use metrics::{Counter, Gauge, Histogram, Key, Label, Recorder, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Label, Recorder, Unit};
 use metrics_util::layers::Layer;
 
 pub mod label_filter;
@@ -121,9 +121,7 @@ impl<F> TracingContextLayer<F> {
 impl TracingContextLayer<label_filter::IncludeAll> {
     /// Creates a new [`TracingContextLayer`].
     pub fn all() -> Self {
-        Self {
-            label_filter: label_filter::IncludeAll,
-        }
+        Self { label_filter: label_filter::IncludeAll }
     }
 }
 
@@ -134,10 +132,7 @@ where
     type Output = TracingContext<R, F>;
 
     fn layer(&self, inner: R) -> Self::Output {
-        TracingContext {
-            inner,
-            label_filter: self.label_filter.clone(),
-        }
+        TracingContext { inner, label_filter: self.label_filter.clone() }
     }
 }
 
@@ -196,16 +191,16 @@ where
     R: Recorder,
     F: LabelFilter,
 {
-    fn describe_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
-        self.inner.describe_counter(key, unit, description)
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+        self.inner.describe_counter(key_name, unit, description)
     }
 
-    fn describe_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
-        self.inner.describe_gauge(key, unit, description)
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+        self.inner.describe_gauge(key_name, unit, description)
     }
 
-    fn describe_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
-        self.inner.describe_histogram(key, unit, description)
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+        self.inner.describe_histogram(key_name, unit, description)
     }
 
     fn register_counter(&self, key: &Key) -> Counter {

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -108,14 +108,9 @@ where
 {
     /// Create a new `MetricsLayer`.
     pub fn new() -> Self {
-        let ctx = WithContext {
-            with_labels: Self::with_labels,
-        };
+        let ctx = WithContext { with_labels: Self::with_labels };
 
-        Self {
-            ctx,
-            _subscriber: PhantomData,
-        }
+        Self { ctx, _subscriber: PhantomData }
     }
 
     fn with_labels(
@@ -126,15 +121,10 @@ where
         let subscriber = dispatch
             .downcast_ref::<S>()
             .expect("subscriber should downcast to expected type; this is a bug!");
-        let span = subscriber
-            .span(id)
-            .expect("registry should have a span for the current ID");
+        let span = subscriber.span(id).expect("registry should have a span for the current ID");
 
-        let result = if let Some(labels) = span.extensions().get::<Labels>() {
-            f(labels)
-        } else {
-            None
-        };
+        let result =
+            if let Some(labels) = span.extensions().get::<Labels>() { f(labels) } else { None };
         result
     }
 }

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -78,10 +78,8 @@ where
     metrics::clear_recorder();
     metrics::set_boxed_recorder(Box::new(recorder)).expect("failed to install recorder");
 
-    let test_guard = TestGuard {
-        _test_mutex_guard: test_mutex_guard,
-        _tracing_guard: tracing_guard,
-    };
+    let test_guard =
+        TestGuard { _test_mutex_guard: test_mutex_guard, _tracing_guard: tracing_guard };
     (test_guard, snapshotter)
 }
 

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -60,9 +60,7 @@ fn registry_benchmark(c: &mut Criterion) {
             Key::from_static_parts(&KEY_NAME, &LABELS)
         })
     });
-    group.bench_function("owned key overhead (basic)", |b| {
-        b.iter(|| Key::from_name("simple_key"))
-    });
+    group.bench_function("owned key overhead (basic)", |b| b.iter(|| Key::from_name("simple_key")));
     group.bench_function("owned key overhead (labels)", |b| {
         b.iter(|| {
             let key = "simple_key";

--- a/metrics-util/examples/bucket-crusher.rs
+++ b/metrics-util/examples/bucket-crusher.rs
@@ -14,10 +14,7 @@ use tracing::{debug, error, info};
 const COUNTER_LOOP: usize = 1024;
 
 fn main() {
-    tracing_subscriber::fmt()
-        .with_ansi(true)
-        .with_level(true)
-        .init();
+    tracing_subscriber::fmt().with_ansi(true).with_level(true).init();
 
     let args: Vec<String> = env::args().collect();
     let program = &args[0];
@@ -45,11 +42,7 @@ fn main() {
         .parse()
         .map(Duration::from_secs)
         .unwrap_or(Duration::from_secs(60));
-    let producers = matches
-        .opt_str("producers")
-        .unwrap_or_else(|| "1".to_owned())
-        .parse()
-        .unwrap();
+    let producers = matches.opt_str("producers").unwrap_or_else(|| "1".to_owned()).parse().unwrap();
 
     info!("duration: {:?}", duration);
     info!("producers: {}", producers);
@@ -95,14 +88,8 @@ fn main() {
             let ptotal = producer_total.load(Ordering::SeqCst);
             let pcounter = producer_counter.load(Ordering::SeqCst);
 
-            info!(
-                "Producer(s) reported: {} total, with {} values produced",
-                ptotal, pcounter
-            );
-            info!(
-                "Consumer reported:    {} total, with {} values consumed",
-                ctotal, ccounter
-            );
+            info!("Producer(s) reported: {} total, with {} values produced", ptotal, pcounter);
+            info!("Consumer reported:    {} total, with {} values consumed", ctotal, ccounter);
         }
     }
 }
@@ -198,12 +185,7 @@ fn print_usage(program: &str, opts: &Options) {
 pub fn opts() -> Options {
     let mut opts = Options::new();
 
-    opts.optopt(
-        "d",
-        "duration",
-        "number of seconds to run the crusher test",
-        "INTEGER",
-    );
+    opts.optopt("d", "duration", "number of seconds to run the crusher test", "INTEGER");
     opts.optopt("p", "producers", "number of producers", "INTEGER");
     opts.optflag("h", "help", "print this help menu");
 

--- a/metrics-util/examples/segqueue-torture.rs
+++ b/metrics-util/examples/segqueue-torture.rs
@@ -14,10 +14,7 @@ use tracing::{error, info};
 const COUNTER_LOOP: usize = 1024;
 
 fn main() {
-    tracing_subscriber::fmt()
-        .with_ansi(true)
-        .with_level(true)
-        .init();
+    tracing_subscriber::fmt().with_ansi(true).with_level(true).init();
 
     let args: Vec<String> = env::args().collect();
     let program = &args[0];
@@ -45,11 +42,7 @@ fn main() {
         .parse()
         .map(Duration::from_secs)
         .unwrap_or(Duration::from_secs(60));
-    let producers = matches
-        .opt_str("producers")
-        .unwrap_or_else(|| "1".to_owned())
-        .parse()
-        .unwrap();
+    let producers = matches.opt_str("producers").unwrap_or_else(|| "1".to_owned()).parse().unwrap();
 
     info!("duration: {:?}", duration);
     info!("producers: {}", producers);
@@ -95,14 +88,8 @@ fn main() {
             let ptotal = producer_total.load(Ordering::SeqCst);
             let pcounter = producer_counter.load(Ordering::SeqCst);
 
-            println!(
-                "Producer(s) reported: {} total, with {} values produced",
-                ptotal, pcounter
-            );
-            println!(
-                "Consumer reported:    {} total, with {} values consumed",
-                ctotal, ccounter
-            );
+            println!("Producer(s) reported: {} total, with {} values produced", ptotal, pcounter);
+            println!("Consumer reported:    {} total, with {} values consumed", ctotal, ccounter);
         }
     }
 }
@@ -178,12 +165,7 @@ fn print_usage(program: &str, opts: &Options) {
 pub fn opts() -> Options {
     let mut opts = Options::new();
 
-    opts.optopt(
-        "d",
-        "duration",
-        "number of seconds to run the crusher test",
-        "INTEGER",
-    );
+    opts.optopt("d", "duration", "number of seconds to run the crusher test", "INTEGER");
     opts.optopt("p", "producers", "number of producers", "INTEGER");
     opts.optflag("h", "help", "print this help menu");
 

--- a/metrics-util/src/bucket.rs
+++ b/metrics-util/src/bucket.rs
@@ -122,11 +122,7 @@ impl<T> Block<T> {
         //   it, ensuring no uninitialized access.
         unsafe {
             // Update the slot.
-            self.slots
-                .get_unchecked(index)
-                .assume_init_ref()
-                .get()
-                .write(value);
+            self.slots.get_unchecked(index).assume_init_ref().get().write(value);
         }
 
         // Scoot our read index forward.
@@ -149,11 +145,7 @@ impl<T> Drop for Block<T> {
         unsafe {
             let len = self.len();
             for i in 0..len {
-                self.slots
-                    .get_unchecked(i)
-                    .assume_init_ref()
-                    .get()
-                    .drop_in_place();
+                self.slots.get_unchecked(i).assume_init_ref().get().drop_in_place();
             }
         }
     }
@@ -198,9 +190,7 @@ pub struct AtomicBucket<T> {
 impl<T> AtomicBucket<T> {
     /// Creates a new, empty bucket.
     pub fn new() -> Self {
-        AtomicBucket {
-            tail: Atomic::null(),
-        }
+        AtomicBucket { tail: Atomic::null() }
     }
 
     /// Checks whether or not this bucket is empty.
@@ -434,9 +424,7 @@ impl<T> AtomicBucket<T> {
 
 impl<T> Default for AtomicBucket<T> {
     fn default() -> Self {
-        Self {
-            tail: Atomic::null(),
-        }
+        Self { tail: Atomic::null() }
     }
 }
 

--- a/metrics-util/src/histogram.rs
+++ b/metrics-util/src/histogram.rs
@@ -26,12 +26,7 @@ impl Histogram {
 
         let buckets = vec![0u64; bounds.len()];
 
-        Some(Histogram {
-            count: 0,
-            bounds: Vec::from(bounds),
-            buckets,
-            sum: 0.0,
-        })
+        Some(Histogram { count: 0, bounds: Vec::from(bounds), buckets, sum: 0.0 })
     }
 
     /// Gets the sum of all samples.
@@ -49,11 +44,7 @@ impl Histogram {
     /// Buckets are tuples, where the first element is the bucket limit itself, and the second
     /// element is the count of samples in that bucket.
     pub fn buckets(&self) -> Vec<(f64, u64)> {
-        self.bounds
-            .iter()
-            .cloned()
-            .zip(self.buckets.iter().cloned())
-            .collect()
+        self.bounds.iter().cloned().zip(self.buckets.iter().cloned()).collect()
     }
 
     /// Records a single sample.

--- a/metrics-util/src/recency.rs
+++ b/metrics-util/src/recency.rs
@@ -63,10 +63,7 @@ pub struct Generational<T> {
 impl<T> Generational<T> {
     /// Creates a new `Generational<T>`.
     fn new(inner: T) -> Generational<T> {
-        Generational {
-            inner,
-            gen: Arc::new(AtomicUsize::new(0)),
-        }
+        Generational { inner, gen: Arc::new(AtomicUsize::new(0)) }
     }
 
     /// Gets a reference to the inner value.
@@ -188,11 +185,7 @@ impl Recency {
     /// Refer to the documentation for [`MetricKindMask`](crate::MetricKindMask) for more
     /// information on defining a metric kind mask.
     pub fn new(clock: Clock, mask: MetricKindMask, idle_timeout: Option<Duration>) -> Recency {
-        Recency {
-            mask,
-            inner: Mutex::new((clock, HashMap::new())),
-            idle_timeout,
-        }
+        Recency { mask, inner: Mutex::new((clock, HashMap::new())), idle_timeout }
     }
 
     /// Checks if the given counter should be stored, based on its known recency.
@@ -241,13 +234,9 @@ impl Recency {
         gen: Generation,
         registry: &Registry<GenerationalPrimitives>,
     ) -> bool {
-        self.should_store(
-            key,
-            gen,
-            registry,
-            MetricKind::Histogram,
-            |registry, key| registry.delete_histogram(key),
-        )
+        self.should_store(key, gen, registry, MetricKind::Histogram, |registry, key| {
+            registry.delete_histogram(key)
+        })
     }
 
     fn should_store<F>(

--- a/metrics-util/src/registry.rs
+++ b/metrics-util/src/registry.rs
@@ -82,26 +82,14 @@ where
     pub fn new() -> Self {
         let shard_count = std::cmp::max(1, num_cpus::get()).next_power_of_two();
         let shard_mask = shard_count - 1;
-        let counters = repeat(())
-            .take(shard_count)
-            .map(|_| RwLock::new(RegistryHashMap::default()))
-            .collect();
-        let gauges = repeat(())
-            .take(shard_count)
-            .map(|_| RwLock::new(RegistryHashMap::default()))
-            .collect();
-        let histograms = repeat(())
-            .take(shard_count)
-            .map(|_| RwLock::new(RegistryHashMap::default()))
-            .collect();
+        let counters =
+            repeat(()).take(shard_count).map(|_| RwLock::new(RegistryHashMap::default())).collect();
+        let gauges =
+            repeat(()).take(shard_count).map(|_| RwLock::new(RegistryHashMap::default())).collect();
+        let histograms =
+            repeat(()).take(shard_count).map(|_| RwLock::new(RegistryHashMap::default())).collect();
 
-        Self {
-            counters,
-            gauges,
-            histograms,
-            shard_mask,
-            _primitives: PhantomData,
-        }
+        Self { counters, gauges, histograms, shard_mask, _primitives: PhantomData }
     }
 
     #[inline]
@@ -142,10 +130,7 @@ where
         // `self.shard_mask` is `self.histograms.len() - 1`, thus we can never have a result from
         // the masking operation that results in a value which is not in bounds of our subshards
         // vector.
-        let shard = unsafe {
-            self.histograms
-                .get_unchecked(hash as usize & self.shard_mask)
-        };
+        let shard = unsafe { self.histograms.get_unchecked(hash as usize & self.shard_mask) };
 
         (hash, shard)
     }
@@ -274,9 +259,7 @@ where
     pub fn delete_counter(&self, key: &Key) -> bool {
         let (hash, shard) = self.get_hash_and_shard_for_counter(key);
         let mut shard_write = shard.write();
-        let entry = shard_write
-            .raw_entry_mut()
-            .from_key_hashed_nocheck(hash, key);
+        let entry = shard_write.raw_entry_mut().from_key_hashed_nocheck(hash, key);
         if let RawEntryMut::Occupied(entry) = entry {
             let _ = entry.remove_entry();
             return true;
@@ -291,9 +274,7 @@ where
     pub fn delete_gauge(&self, key: &Key) -> bool {
         let (hash, shard) = self.get_hash_and_shard_for_gauge(key);
         let mut shard_write = shard.write();
-        let entry = shard_write
-            .raw_entry_mut()
-            .from_key_hashed_nocheck(hash, key);
+        let entry = shard_write.raw_entry_mut().from_key_hashed_nocheck(hash, key);
         if let RawEntryMut::Occupied(entry) = entry {
             let _ = entry.remove_entry();
             return true;
@@ -308,9 +289,7 @@ where
     pub fn delete_histogram(&self, key: &Key) -> bool {
         let (hash, shard) = self.get_hash_and_shard_for_histogram(key);
         let mut shard_write = shard.write();
-        let entry = shard_write
-            .raw_entry_mut()
-            .from_key_hashed_nocheck(hash, key);
+        let entry = shard_write.raw_entry_mut().from_key_hashed_nocheck(hash, key);
         if let RawEntryMut::Occupied(entry) = entry {
             let _ = entry.remove_entry();
             return true;
@@ -434,10 +413,8 @@ mod tests {
         let initial_entries = registry.get_counter_handles();
         assert_eq!(initial_entries.len(), 1);
 
-        let initial_entry: (Key, Arc<AtomicU64>) = initial_entries
-            .into_iter()
-            .next()
-            .expect("failed to get first entry");
+        let initial_entry: (Key, Arc<AtomicU64>) =
+            initial_entries.into_iter().next().expect("failed to get first entry");
 
         let (ikey, ivalue) = initial_entry;
         assert_eq!(ikey, key);
@@ -448,10 +425,8 @@ mod tests {
         let updated_entries = registry.get_counter_handles();
         assert_eq!(updated_entries.len(), 1);
 
-        let updated_entry: (Key, Arc<AtomicU64>) = updated_entries
-            .into_iter()
-            .next()
-            .expect("failed to get updated entry");
+        let updated_entry: (Key, Arc<AtomicU64>) =
+            updated_entries.into_iter().next().expect("failed to get updated entry");
 
         let (ukey, uvalue) = updated_entry;
         assert_eq!(ukey, key);

--- a/metrics-util/src/summary.rs
+++ b/metrics-util/src/summary.rs
@@ -138,19 +138,14 @@ impl Summary {
         if rank < ncount {
             // Quantile lands in the negative side.
             let nq = 1.0 - (rank as f64 / ncount as f64);
-            self.negative
-                .quantile(nq)
-                .expect("quantile should be valid at this point")
-                .map(|v| -v)
+            self.negative.quantile(nq).expect("quantile should be valid at this point").map(|v| -v)
         } else if rank >= ncount && rank < (ncount + zcount) {
             // Quantile lands in the zero band.
             Some(0.0)
         } else {
             // Quantile lands in the positive side.
             let pq = (rank - (ncount + zcount)) as f64 / pcount as f64;
-            self.positive
-                .quantile(pq)
-                .expect("quantile should be valid at this point")
+            self.positive.quantile(pq).expect("quantile should be valid at this point")
         }
     }
 
@@ -229,15 +224,9 @@ mod tests {
         assert_eq!(summary.count(), 3);
         assert_relative_eq!(summary.min(), -420.42);
         assert_relative_eq!(summary.max(), 420.42);
-        assert_abs_diff_eq!(
-            summary.quantile(0.4999999999).expect("value should exist"),
-            -420.42
-        );
+        assert_abs_diff_eq!(summary.quantile(0.4999999999).expect("value should exist"), -420.42);
         assert_abs_diff_eq!(summary.quantile(0.5).expect("value should exist"), 42.42);
-        assert_abs_diff_eq!(
-            summary.quantile(0.9999999999).expect("value should exist"),
-            42.42
-        );
+        assert_abs_diff_eq!(summary.quantile(0.9999999999).expect("value should exist"), 42.42);
     }
 
     #[test]
@@ -265,13 +254,8 @@ mod tests {
             let aval_raw = true_histogram
                 .quantile_axis_mut(Axis(0), n64(*quantile), &Linear)
                 .expect("quantile should be in range");
-            let aval = aval_raw
-                .get(())
-                .expect("quantile value should be present")
-                .into_inner();
-            let sval = summary
-                .quantile(*quantile)
-                .expect("quantile value should be present");
+            let aval = aval_raw.get(()).expect("quantile value should be present").into_inner();
+            let sval = summary.quantile(*quantile).expect("quantile value should be present");
 
             // Multiply the true value by α, and double it to account from the -α/α swing.
             let distance = (aval * alpha) * 2.0;
@@ -307,13 +291,8 @@ mod tests {
             let aval_raw = true_histogram
                 .quantile_axis_mut(Axis(0), n64(*quantile), &Linear)
                 .expect("quantile should be in range");
-            let aval = aval_raw
-                .get(())
-                .expect("quantile value should be present")
-                .into_inner();
-            let sval = summary
-                .quantile(*quantile)
-                .expect("quantile value should be present");
+            let aval = aval_raw.get(()).expect("quantile value should be present").into_inner();
+            let sval = summary.quantile(*quantile).expect("quantile value should be present");
 
             // Multiply the true value by α, and quadruple it to account from the -α/α swing,
             // but also to account for the values sitting at the edge case quantiles.

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - A new macro, `absolute_counter!`, for setting the value of a counter to an absolute value.
+- A new wrapper type, `KeyName`, which encapsulates creating the name portion of a `Key`.  Existing
+  methods for building a `Key`, as well as implicit conversion trait implementations, allow this to
+  be a no-op.
 
 ### Changed
 - Switched to metric handles through the `Recorder` API.
@@ -18,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Unit` is now `Copy`.
 - Removed the half-baked attempt to allow turning off `std` usage, as `metrics` is not meaningfully
   usable (at the moment) without libstd support.
+- When describing a metric via the `describe_*` macros, the description is no longer optional.
 
 ## [0.17.1] - 2021-12-16
 

--- a/metrics/benches/macros.rs
+++ b/metrics/benches/macros.rs
@@ -3,15 +3,15 @@ extern crate criterion;
 
 use criterion::Criterion;
 
-use metrics::{counter, Counter, Gauge, Histogram, Key, Recorder, Unit};
+use metrics::{counter, Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit};
 use rand::{thread_rng, Rng};
 
 #[derive(Default)]
 struct TestRecorder;
 impl Recorder for TestRecorder {
-    fn describe_counter(&self, _: &Key, _: Option<Unit>, _: Option<&'static str>) {}
-    fn describe_gauge(&self, _: &Key, _: Option<Unit>, _: Option<&'static str>) {}
-    fn describe_histogram(&self, _: &Key, _: Option<Unit>, _: Option<&'static str>) {}
+    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: &'static str) {}
+    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: &'static str) {}
+    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: &'static str) {}
     fn register_counter(&self, _: &Key) -> Counter {
         Counter::noop()
     }

--- a/metrics/examples/basic.rs
+++ b/metrics/examples/basic.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use metrics::{
     absolute_counter, counter, decrement_gauge, describe_counter, describe_gauge,
     describe_histogram, gauge, histogram, increment_counter, increment_gauge, register_counter,
-    register_gauge, register_histogram,
+    register_gauge, register_histogram, KeyName,
 };
 use metrics::{Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, Recorder, Unit};
 
@@ -50,24 +50,30 @@ impl HistogramFn for PrintHandle {
 struct PrintRecorder;
 
 impl Recorder for PrintRecorder {
-    fn describe_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
         println!(
             "(counter) registered key {} with unit {:?} and description {:?}",
-            key, unit, description
+            key_name.as_str(),
+            unit,
+            description
         );
     }
 
-    fn describe_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
         println!(
             "(gauge) registered key {} with unit {:?} and description {:?}",
-            key, unit, description
+            key_name.as_str(),
+            unit,
+            description
         );
     }
 
-    fn describe_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>) {
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
         println!(
             "(histogram) registered key {} with unit {:?} and description {:?}",
-            key, unit, description
+            key_name.as_str(),
+            unit,
+            description
         );
     }
 
@@ -98,15 +104,19 @@ fn main() {
 
     // Go through describing the metrics:
     describe_counter!("requests_processed", "number of requests processed");
-    describe_counter!("bytes_sent", Unit::Bytes);
-    describe_gauge!("connection_count", common_labels);
+    describe_counter!("bytes_sent", Unit::Bytes, "total number of bytes sent");
+    describe_gauge!("connection_count", "current number of client connections");
     describe_histogram!(
         "svc.execution_time",
         Unit::Milliseconds,
         "execution time of request handler"
     );
-    describe_gauge!("unused_gauge", "service" => "backend");
-    describe_histogram!("unused_histogram", Unit::Seconds, "unused histo", "service" => "middleware");
+    describe_gauge!("unused_gauge", "some gauge we'll never use in this program");
+    describe_histogram!(
+        "unused_histogram",
+        Unit::Seconds,
+        "some histogram we'll also never use in this program"
+    );
 
     // And registering them:
     let counter1 = register_counter!("test_counter");

--- a/metrics/examples/sizes.rs
+++ b/metrics/examples/sizes.rs
@@ -5,14 +5,8 @@ use std::borrow::Cow;
 fn main() {
     println!("Key: {} bytes", std::mem::size_of::<Key>());
     println!("Label: {} bytes", std::mem::size_of::<Label>());
-    println!(
-        "Cow<'static, [Label]>: {} bytes",
-        std::mem::size_of::<Cow<'static, [Label]>>()
-    );
-    println!(
-        "Vec<SharedString>: {} bytes",
-        std::mem::size_of::<Vec<SharedString>>()
-    );
+    println!("Cow<'static, [Label]>: {} bytes", std::mem::size_of::<Cow<'static, [Label]>>());
+    println!("Vec<SharedString>: {} bytes", std::mem::size_of::<Vec<SharedString>>());
     println!(
         "[Option<SharedString>; 2]: {} bytes",
         std::mem::size_of::<[Option<SharedString>; 2]>()

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -199,10 +199,7 @@ impl Unit {
 
     /// Whether or not this unit relates to the measurement of time.
     pub fn is_time_based(&self) -> bool {
-        matches!(
-            self,
-            Unit::Seconds | Unit::Milliseconds | Unit::Microseconds | Unit::Nanoseconds
-        )
+        matches!(self, Unit::Seconds | Unit::Milliseconds | Unit::Microseconds | Unit::Nanoseconds)
     }
 
     /// Whether or not this unit relates to the measurement of data.

--- a/metrics/src/cow.rs
+++ b/metrics/src/cow.rs
@@ -29,11 +29,7 @@ where
     pub fn owned(val: T::Owned) -> Self {
         let (ptr, meta) = T::owned_into_parts(val);
 
-        Cow {
-            ptr,
-            meta,
-            marker: PhantomData,
-        }
+        Cow { ptr, meta, marker: PhantomData }
     }
 }
 
@@ -45,11 +41,7 @@ where
     pub fn borrowed(val: &'a T) -> Self {
         let (ptr, meta) = T::ref_into_parts(val);
 
-        Cow {
-            ptr,
-            meta,
-            marker: PhantomData,
-        }
+        Cow { ptr, meta, marker: PhantomData }
     }
 
     #[inline]

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -106,7 +106,7 @@
 //! ### Examples
 //!
 //! ```rust
-//! use metrics::{histogram, counter};
+//! use metrics::{counter, histogram};
 //!
 //! # use std::time::Instant;
 //! # pub fn run_query(_: &str) -> u64 { 42 }
@@ -282,9 +282,9 @@ pub use self::recorder::*;
 /// Counters represent a single monotonic value, which means the value can only be incremented, not
 /// decremented, and always starts out with an initial value of zero.
 ///
-/// Metrics can be described with an optional unit and description.  Whether or not the installed
-/// recorder does anything with the description is implementation defined.  Labels can also be
-/// specified when describing a metric.
+/// Metrics can be described with a free-form string, and optionally, a unit can be provided to
+/// describe the value and/or rate of the metric measurements.  Whether or not the installed
+/// recorder does anything with the description, or optional unit, is implementation defined.
 ///
 /// Metric names are shown below using string literals, but they can also be owned `String` values,
 /// which includes using macros such as `format!` directly at the callsite. String literals are
@@ -296,37 +296,17 @@ pub use self::recorder::*;
 /// # use metrics::Unit;
 /// # fn main() {
 /// // A basic counter:
-/// describe_counter!("some_metric_name");
+/// describe_counter!("some_metric_name", "my favorite counter");
 ///
 /// // Providing a unit for a counter:
-/// describe_counter!("some_metric_name", Unit::Bytes);
-///
-/// // Providing a description for a counter:
-/// describe_counter!("some_metric_name", "total number of bytes");
-///
-/// // Specifying labels:
-/// describe_counter!("some_metric_name", "service" => "http");
-///
-/// // We can combine the units, description, and labels arbitrarily:
-/// describe_counter!("some_metric_name", Unit::Bytes, "total number of bytes");
-/// describe_counter!("some_metric_name", Unit::Bytes, "service" => "http");
-/// describe_counter!("some_metric_name", "total number of bytes", "service" => "http");
-///
-/// // And all combined:
-/// describe_counter!("some_metric_name", Unit::Bytes, "number of woopsy daisies", "service" => "http");
-///
-/// // We can also pass labels by giving a vector or slice of key/value pairs.  In this scenario,
-/// // a unit or description can still be passed in their respective positions:
-/// let dynamic_val = "woo";
-/// let labels = [("dynamic_key", format!("{}!", dynamic_val))];
-/// describe_counter!("some_metric_name", &labels);
+/// describe_counter!("some_metric_name", Unit::Bytes, "my favorite counter");
 ///
 /// // As mentioned in the documentation, metric names also can be owned strings, including ones
 /// // generated at the callsite via things like `format!`:
 /// let name = String::from("some_owned_metric_name");
-/// describe_counter!(name);
+/// describe_counter!(name, "my favorite counter");
 ///
-/// describe_counter!(format!("{}_via_format", "name"));
+/// describe_counter!(format!("{}_via_format", "name"), "my favorite counter");
 /// # }
 /// ```
 pub use metrics_macros::describe_counter;
@@ -336,9 +316,9 @@ pub use metrics_macros::describe_counter;
 /// Gauges represent a single value that can go up or down over time, and always starts out with an
 /// initial value of zero.
 ///
-/// Metrics can be described with an optional unit and description.  Whether or not the installed
-/// recorder does anything with the description is implementation defined.  Labels can also be
-/// specified when describing a metric.
+/// Metrics can be described with a free-form string, and optionally, a unit can be provided to
+/// describe the value and/or rate of the metric measurements.  Whether or not the installed
+/// recorder does anything with the description, or optional unit, is implementation defined.
 ///
 /// Metric names are shown below using string literals, but they can also be owned `String` values,
 /// which includes using macros such as `format!` directly at the callsite. String literals are
@@ -350,37 +330,17 @@ pub use metrics_macros::describe_counter;
 /// # use metrics::Unit;
 /// # fn main() {
 /// // A basic gauge:
-/// describe_gauge!("some_metric_name");
+/// describe_gauge!("some_metric_name", "my favorite gauge");
 ///
 /// // Providing a unit for a gauge:
-/// describe_gauge!("some_metric_name", Unit::Bytes);
-///
-/// // Providing a description for a gauge:
-/// describe_gauge!("some_metric_name", "total number of bytes");
-///
-/// // Specifying labels:
-/// describe_gauge!("some_metric_name", "service" => "http");
-///
-/// // We can combine the units, description, and labels arbitrarily:
-/// describe_gauge!("some_metric_name", Unit::Bytes, "total number of bytes");
-/// describe_gauge!("some_metric_name", Unit::Bytes, "service" => "http");
-/// describe_gauge!("some_metric_name", "total number of bytes", "service" => "http");
-///
-/// // And all combined:
-/// describe_gauge!("some_metric_name", Unit::Bytes, "total number of bytes", "service" => "http");
-///
-/// // We can also pass labels by giving a vector or slice of key/value pairs.  In this scenario,
-/// // a unit or description can still be passed in their respective positions:
-/// let dynamic_val = "woo";
-/// let labels = [("dynamic_key", format!("{}!", dynamic_val))];
-/// describe_gauge!("some_metric_name", &labels);
+/// describe_gauge!("some_metric_name", Unit::Bytes, "my favorite gauge");
 ///
 /// // As mentioned in the documentation, metric names also can be owned strings, including ones
 /// // generated at the callsite via things like `format!`:
 /// let name = String::from("some_owned_metric_name");
-/// describe_gauge!(name);
+/// describe_gauge!(name, "my favorite gauge");
 ///
-/// describe_gauge!(format!("{}_via_format", "name"));
+/// describe_gauge!(format!("{}_via_format", "name"), "my favorite gauge");
 /// # }
 /// ```
 pub use metrics_macros::describe_gauge;
@@ -390,9 +350,9 @@ pub use metrics_macros::describe_gauge;
 /// Histograms measure the distribution of values for a given set of measurements, and start with no
 /// initial values.
 ///
-/// Metrics can be described with an optional unit and description.  Whether or not the installed
-/// recorder does anything with the description is implementation defined.  Labels can also be
-/// specified when describing a metric.
+/// Metrics can be described with a free-form string, and optionally, a unit can be provided to
+/// describe the value and/or rate of the metric measurements.  Whether or not the installed
+/// recorder does anything with the description, or optional unit, is implementation defined.
 ///
 /// Metric names are shown below using string literals, but they can also be owned `String` values,
 /// which includes using macros such as `format!` directly at the callsite. String literals are
@@ -404,37 +364,17 @@ pub use metrics_macros::describe_gauge;
 /// # use metrics::Unit;
 /// # fn main() {
 /// // A basic histogram:
-/// describe_histogram!("some_metric_name");
+/// describe_histogram!("some_metric_name", "my favorite histogram");
 ///
 /// // Providing a unit for a histogram:
-/// describe_histogram!("some_metric_name", Unit::Nanoseconds);
-///
-/// // Providing a description for a histogram:
-/// describe_histogram!("some_metric_name", "request handler duration");
-///
-/// // Specifying labels:
-/// describe_histogram!("some_metric_name", "service" => "http");
-///
-/// // We can combine the units, description, and labels arbitrarily:
-/// describe_histogram!("some_metric_name", Unit::Nanoseconds, "request handler duration");
-/// describe_histogram!("some_metric_name", Unit::Nanoseconds, "service" => "http");
-/// describe_histogram!("some_metric_name", "request handler duration", "service" => "http");
-///
-/// // And all combined:
-/// describe_histogram!("some_metric_name", Unit::Nanoseconds, "request handler duration", "service" => "http");
-///
-/// // We can also pass labels by giving a vector or slice of key/value pairs.  In this scenario,
-/// // a unit or description can still be passed in their respective positions:
-/// let dynamic_val = "woo";
-/// let labels = [("dynamic_key", format!("{}!", dynamic_val))];
-/// describe_histogram!("some_metric_name", &labels);
+/// describe_histogram!("some_metric_name", Unit::Bytes, "my favorite histogram");
 ///
 /// // As mentioned in the documentation, metric names also can be owned strings, including ones
 /// // generated at the callsite via things like `format!`:
 /// let name = String::from("some_owned_metric_name");
-/// describe_histogram!(name);
+/// describe_histogram!(name, "my favorite histogram");
 ///
-/// describe_histogram!(format!("{}_via_format", "name"));
+/// describe_histogram!(format!("{}_via_format", "name"), "my favorite histogram");
 /// # }
 /// ```
 pub use metrics_macros::describe_histogram;

--- a/metrics/src/recorder.rs
+++ b/metrics/src/recorder.rs
@@ -1,4 +1,4 @@
-use crate::{Counter, Gauge, Histogram, Key, Unit};
+use crate::{Counter, Gauge, Histogram, Key, KeyName, Unit};
 use core::fmt;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -23,7 +23,7 @@ pub trait Recorder {
     /// not a metric can be reregistered to provide a unit/description, if one was already passed
     /// or not, as well as how units/descriptions are used by the underlying recorder, is an
     /// implementation detail.
-    fn describe_counter(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>);
+    fn describe_counter(&self, key: KeyName, unit: Option<Unit>, description: &'static str);
 
     /// Describes a gauge.
     ///
@@ -31,7 +31,7 @@ pub trait Recorder {
     /// not a metric can be reregistered to provide a unit/description, if one was already passed
     /// or not, as well as how units/descriptions are used by the underlying recorder, is an
     /// implementation detail.
-    fn describe_gauge(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>);
+    fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, description: &'static str);
 
     /// Describes a histogram.
     ///
@@ -39,7 +39,7 @@ pub trait Recorder {
     /// not a metric can be reregistered to provide a unit/description, if one was already passed
     /// or not, as well as how units/descriptions are used by the underlying recorder, is an
     /// implementation detail.
-    fn describe_histogram(&self, key: &Key, unit: Option<Unit>, description: Option<&'static str>);
+    fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, description: &'static str);
 
     /// Registers a counter.
     fn register_counter(&self, key: &Key) -> Counter;
@@ -58,21 +58,9 @@ pub trait Recorder {
 pub struct NoopRecorder;
 
 impl Recorder for NoopRecorder {
-    fn describe_counter(
-        &self,
-        _key: &Key,
-        _unit: Option<Unit>,
-        _description: Option<&'static str>,
-    ) {
-    }
-    fn describe_gauge(&self, _key: &Key, _unit: Option<Unit>, _description: Option<&'static str>) {}
-    fn describe_histogram(
-        &self,
-        _key: &Key,
-        _unit: Option<Unit>,
-        _description: Option<&'static str>,
-    ) {
-    }
+    fn describe_counter(&self, _key: KeyName, _unit: Option<Unit>, _description: &'static str) {}
+    fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: &'static str) {}
+    fn describe_histogram(&self, _key: KeyName, _unit: Option<Unit>, _description: &'static str) {}
     fn register_counter(&self, _key: &Key) -> Counter {
         Counter::noop()
     }

--- a/metrics/tests/macros/01_basic.rs
+++ b/metrics/tests/macros/01_basic.rs
@@ -1,28 +1,64 @@
-use metrics::counter;
+use metrics::{counter, describe_counter, register_counter, Unit};
 
+#[allow(dead_code)]
 fn literal_key() {
+    describe_counter!("abcdef", "a counter");
+    describe_counter!("abcdef", Unit::Nanoseconds, "a counter");
+    let _ = register_counter!("abcdef");
     counter!("abcdef", 1);
 }
 
+#[allow(dead_code)]
 fn literal_key_literal_labels() {
+    describe_counter!("abcdef", "a counter");
+    describe_counter!("abcdef", Unit::Nanoseconds, "a counter");
+    let _ = register_counter!("abcdef", "uvw" => "xyz");
     counter!("abcdef", 1, "uvw" => "xyz");
 }
 
+#[allow(dead_code)]
 fn nonliteral_key() {
     let some_u16 = 0u16;
+    describe_counter!(format!("response_status_{}", some_u16), "a counter");
+    describe_counter!(format!("response_status_{}", some_u16), Unit::Nanoseconds, "a counter");
+    let _ = register_counter!(format!("response_status_{}", some_u16));
     counter!(format!("response_status_{}", some_u16), 1);
 }
 
+#[allow(dead_code)]
 fn nonliteral_key_literal_labels() {
     let some_u16 = 0u16;
+    describe_counter!(format!("response_status_{}", some_u16), "a counter");
+    describe_counter!(format!("response_status_{}", some_u16), Unit::Nanoseconds, "a counter");
+    let _ = register_counter!(format!("response_status_{}", some_u16), "uvw" => "xyz");
     counter!(format!("response_status_{}", some_u16), 1, "uvw" => "xyz");
 }
 
+#[allow(dead_code)]
 fn nonliteral_key_nonliteral_labels() {
     let some_u16 = 0u16;
     let dynamic_val = "xyz";
     let labels = [("uvw", format!("{}!", dynamic_val))];
+    describe_counter!(format!("response_status_{}", some_u16), "a counter");
+    describe_counter!(format!("response_status_{}", some_u16), Unit::Nanoseconds, "a counter");
+    let _ = register_counter!(format!("response_status_{}", some_u16), &labels);
     counter!(format!("response_status_{}", some_u16), 12, &labels);
+}
+
+#[allow(dead_code)]
+fn const_key() {
+    const KEY: &str = "abcdef";
+    describe_counter!(KEY, "a counter");
+    describe_counter!(KEY, Unit::Nanoseconds, "a counter");
+    let _ = register_counter!(KEY);
+    counter!(KEY, 17);
+}
+
+#[allow(dead_code)]
+fn const_description() {
+    const DESC: &str = "a counter";
+    describe_counter!("abcdef", DESC);
+    describe_counter!("abcdef", Unit::Nanoseconds, DESC);
 }
 
 fn main() {}

--- a/metrics/tests/macros/02_trailing_comma.rs
+++ b/metrics/tests/macros/02_trailing_comma.rs
@@ -1,5 +1,6 @@
 use metrics::counter;
 
+#[allow(dead_code)]
 fn no_trailing_comma() {
     counter!("qwe", 1);
     counter!(
@@ -9,6 +10,7 @@ fn no_trailing_comma() {
     counter!("qwe", 1, vec![]);
 }
 
+#[allow(dead_code)]
 fn with_trailing_comma() {
     counter!("qwe", 1,);
     counter!(

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+use_small_heuristics = "Max"


### PR DESCRIPTION
This PR is meant to address #244, but deals with a more wide-sweeping change to make metric description more succinct in practice.

As part of the work in #239 to support metric handles, we renamed the previous `register_*` macros to `describe_*`, to reflect a way to simply describe a metric, without registering it in the backend.  Metadata only, essentially.

Now that those macros exist, the concept of using them to register a metric no longer exists, and so having an optional description doesn't make much sense.  As such, the macros now require a description to be passed, and we've tweaked the methods on `Recorder` to reflect this.  Units are still optional.

Additionally, we no longer support passing a full metric key (name + labels) as, again, these macros no longer need to support registering a specific metric in the backend, and defining a description for a specific name/labels combination is not something that comes up in practice.

Closes #244.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>