### PR TITLE
metrics-exporter-prometheus: histograms are now correctly removed when idle timeout is exceeded

### DIFF
--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -23,13 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   messages for understanding when something went wrong.
 - Most builder methods are now fallible to help avoid runtime panics for invalid data given when
   building, and to better surface this upfront to users.
+- Rendered output for histograms is now stable, based on the order in which a given key
+  (name/labels) was recorded.
 
 ### Fixed
 - Label keys and values, as well as metric descriptions, are now correctly sanitized according to
   the Prometheus [data model](https://prometheus.io/docs/concepts/data_model/) and [exposition
   format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md).
   ([#248](https://github.com/metrics-rs/metrics/issues/248))
-- Metric descriptions are correctly mapped to metrics whose names have been modified during sanitization.
+- Metric descriptions are correctly mapped to metrics whose names have been modified during
+  sanitization.
+- Histograms are now correctly removed when they exceed the idle timeout.
 
 ## [0.7.0] - 2021-12-16
 

--- a/metrics-exporter-prometheus/src/common.rs
+++ b/metrics-exporter-prometheus/src/common.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::distribution::Distribution;
 
+use indexmap::IndexMap;
 use metrics::SetRecorderError;
 use thiserror::Error;
 
@@ -77,7 +78,7 @@ pub enum BuildError {
 pub struct Snapshot {
     pub counters: HashMap<String, HashMap<Vec<String>, u64>>,
     pub gauges: HashMap<String, HashMap<Vec<String>, f64>>,
-    pub distributions: HashMap<String, HashMap<Vec<String>, Distribution>>,
+    pub distributions: HashMap<String, IndexMap<Vec<String>, Distribution>>,
 }
 
 #[inline]


### PR DESCRIPTION
An issue was reported in #228 where histograms did not appear to be removed after they exceeded the configured idle timeout.

There were two bugs, one in the version the user reproduced the issue with and one in the current version of the code:
- used wrong method to check for/delete idle histograms (current version)
- did not remove aggregated distributions for histograms that were reported as inactive (both versions)

Primarily, the issue centered around the fact that the exporter aggregated histograms (distributions) internally every time something wants to render the metrics.  This provided bounded memory usage over time for a given metric, as well as tracking aggregated histograms/summaries in the way that Prometheus expects.

However, even though we would correctly delete a histogram from the registry when we detected that it had been idle too long, we did not delete the internally aggregated version that the exporter also held... and since rendering works off of the internally aggregated data, it essentially ended up as the histogram continuing to be rendered/reported.

Fixes #228.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>