### PR TITLE
metrics-macros: allow constants for label keys

### DIFF
--- a/metrics-macros/CHANGELOG.md
+++ b/metrics-macros/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - When describing a metric, a constant can now be used for the description itself.
+- Label keys can now be general expressions i.e. constants or variables.  Due to limitations in
+  how procedural macros work, and the facilities available in stable Rust for const traits, even
+  `&'static str` constants will cause allocations when used for emitting a metric.
 
 ### Changed
 - Correctly scoped the required features of various dependencies to reduce build times/transitive dependencies.

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -469,6 +469,28 @@ fn test_get_register_and_op_code_op_owned_name_existing_labels() {
 }
 
 #[test]
+fn test_get_register_and_op_code_op_owned_name_constant_key_labels() {
+    let stream = get_register_and_op_code(
+        "mytype",
+        parse_quote! { String::from("owned") },
+        Some(Labels::Inline(vec![(parse_quote! { LABEL_KEY }, parse_quote! { "some_val" })])),
+        Some(("myop", quote! { 1 })),
+    );
+
+    let expected = concat!(
+        "{ ",
+        "if let Some (recorder) = metrics :: try_recorder () { ",
+        "let key = metrics :: Key :: from_parts (String :: from (\"owned\") , vec ! [metrics :: Label :: new (LABEL_KEY , \"some_val\")]) ; ",
+        "let handle = recorder . register_mytype (& key) ; ",
+        "handle . myop (1) ; ",
+        "} ",
+        "}",
+    );
+
+    assert_eq!(stream.to_string(), expected);
+}
+
+#[test]
 fn test_labels_to_quoted_existing_labels() {
     let labels = Labels::Existing(Expr::Path(parse_quote! { mylabels }));
     let stream = labels_to_quoted(&labels);

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -13,15 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A new wrapper type, `KeyName`, which encapsulates creating the name portion of a `Key`.  Existing
   methods for building a `Key`, as well as implicit conversion trait implementations, allow this to
   be a no-op.
+- Label keys in macros can now be general expressions i.e. constants or variables.  Due to
+  limitations in how procedural macros work, and the facilities available in stable Rust for const
+  traits, even `&'static str` constants will cause allocations when used for emitting a metric.
 
 ### Changed
 - Switched to metric handles through the `Recorder` API.
   ([#240](https://github.com/metrics-rs/metrics/pull/240)).  Due to the size of this change, the
   details are further documented and discussed in [RELEASES.md](RELEASES.md).
 - `Unit` is now `Copy`.
-- Removed the half-baked attempt to allow turning off `std` usage, as `metrics` is not meaningfully
-  usable (at the moment) without libstd support.
 - When describing a metric via the `describe_*` macros, the description is no longer optional.
+
+### Removed
+- Removed the `std` feature flag, as `metrics` depends too heavily on `std`-based types and as such
+  was not meaningfully usaable when the `std` feature flag was disabled.  This will be revisited in
+  the future.
 
 ## [0.17.1] - 2021-12-16
 

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -399,9 +399,14 @@ pub use metrics_macros::describe_histogram;
 /// let counter = register_counter!("some_metric_name");
 /// counter.increment(1);
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// let counter = register_counter!("some_metric_name", "service" => "http");
 /// counter.absolute(42);
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// let counter = register_counter!("some_metric_name", SERVICE_LABEL => SERVICE_HTTP);
+/// counter.increment(123);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs.  In this scenario,
 /// // a unit or description can still be passed in their respective positions:
@@ -439,9 +444,14 @@ pub use metrics_macros::register_counter;
 /// let gauge = register_gauge!("some_metric_name");
 /// gauge.increment(1.0);
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// let gauge = register_gauge!("some_metric_name", "service" => "http");
 /// gauge.decrement(42.0);
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// let gauge = register_gauge!("some_metric_name", SERVICE_LABEL => SERVICE_HTTP);
+/// gauge.increment(3.14);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs.  In this scenario,
 /// // a unit or description can still be passed in their respective positions:
@@ -480,8 +490,12 @@ pub use metrics_macros::register_gauge;
 /// let histogram = register_histogram!("some_metric_name");
 /// histogram.record(1.0);
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// let histogram = register_histogram!("some_metric_name", "service" => "http");
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// let histogram = register_histogram!("some_metric_name", SERVICE_LABEL => SERVICE_HTTP);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs.  In this scenario,
 /// // a unit or description can still be passed in their respective positions:
@@ -515,8 +529,12 @@ pub use metrics_macros::register_histogram;
 /// // A basic counter:
 /// counter!("some_metric_name", 12);
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// counter!("some_metric_name", 12, "service" => "http");
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// counter!("some_metric_name", 12, SERVICE_LABEL => SERVICE_HTTP);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs:
 /// let dynamic_val = "woo";
@@ -549,8 +567,12 @@ pub use metrics_macros::counter;
 /// // A basic increment:
 /// increment_counter!("some_metric_name");
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// increment_counter!("some_metric_name", "service" => "http");
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// increment_counter!("some_metric_name", SERVICE_LABEL => SERVICE_HTTP);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs:
 /// let dynamic_val = "woo";
@@ -590,8 +612,12 @@ pub use metrics_macros::increment_counter;
 /// // A basic counter:
 /// absolute_counter!("some_metric_name", 12);
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// absolute_counter!("some_metric_name", 13, "service" => "http");
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// absolute_counter!("some_metric_name", 13, SERVICE_LABEL => SERVICE_HTTP);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs:
 /// let dynamic_val = "woo";
@@ -624,8 +650,12 @@ pub use metrics_macros::absolute_counter;
 /// // A basic gauge:
 /// gauge!("some_metric_name", 42.2222);
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// gauge!("some_metric_name", 66.6666, "service" => "http");
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// gauge!("some_metric_name", 66.6666, SERVICE_LABEL => SERVICE_HTTP);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs:
 /// let dynamic_val = "woo";
@@ -658,8 +688,12 @@ pub use metrics_macros::gauge;
 /// // A basic gauge:
 /// increment_gauge!("some_metric_name", 42.2222);
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// increment_gauge!("some_metric_name", 66.6666, "service" => "http");
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// increment_gauge!("some_metric_name", 66.6666, SERVICE_LABEL => SERVICE_HTTP);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs:
 /// let dynamic_val = "woo";
@@ -692,8 +726,12 @@ pub use metrics_macros::increment_gauge;
 /// // A basic gauge:
 /// decrement_gauge!("some_metric_name", 42.2222);
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// decrement_gauge!("some_metric_name", 66.6666, "service" => "http");
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// decrement_gauge!("some_metric_name", 66.6666, SERVICE_LABEL => SERVICE_HTTP);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs:
 /// let dynamic_val = "woo";
@@ -740,8 +778,12 @@ pub use metrics_macros::decrement_gauge;
 /// let d = Duration::from_millis(17);
 /// histogram!("some_metric_name", d);
 ///
-/// // Specifying labels:
+/// // Specifying labels inline, including using constants for either the key or value:
 /// histogram!("some_metric_name", 38.0, "service" => "http");
+///
+/// const SERVICE_LABEL: &'static str = "service";
+/// const SERVICE_HTTP: &'static str = "http";
+/// histogram!("some_metric_name", 38.0, SERVICE_LABEL => SERVICE_HTTP);
 ///
 /// // We can also pass labels by giving a vector or slice of key/value pairs:
 /// let dynamic_val = "woo";


### PR DESCRIPTION
This PR allows constants to be used for label keys, which allows users to deduplicate common label keys, as well allows centralization of those constants to allow for easier refactoring, etc.

Closes #97.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>