### PR TITLE
metrics-exporter-prometheus: fix recent metrics being removed by idle timeout logic

### DIFF
--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -914,10 +914,7 @@ mod tests {
 
         counter1.increment(1);
 
-        let expected_after = concat!(
-            "# TYPE basic_counter counter\n",
-            "basic_counter 43\n\n",
-        );
+        let expected_after = concat!("# TYPE basic_counter counter\n", "basic_counter 43\n\n",);
 
         mock.increment(Duration::from_secs(2));
         let rendered = handle.render();

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -242,15 +242,15 @@ impl Recorder for PrometheusRecorder {
     }
 
     fn register_counter(&self, key: &Key) -> Counter {
-        self.inner.registry.get_or_create_counter(key, |c| c.get_inner().clone().into())
+        self.inner.registry.get_or_create_counter(key, |c| c.clone().into())
     }
 
     fn register_gauge(&self, key: &Key) -> Gauge {
-        self.inner.registry.get_or_create_gauge(key, |c| c.get_inner().clone().into())
+        self.inner.registry.get_or_create_gauge(key, |c| c.clone().into())
     }
 
     fn register_histogram(&self, key: &Key) -> Histogram {
-        self.inner.registry.get_or_create_histogram(key, |c| c.get_inner().clone().into())
+        self.inner.registry.get_or_create_histogram(key, |c| c.clone().into())
     }
 }
 

--- a/metrics-util/src/recency.rs
+++ b/metrics-util/src/recency.rs
@@ -33,7 +33,7 @@ use crate::registry::Primitives;
 use crate::StandardPrimitives;
 use crate::{kind::MetricKindMask, MetricKind, Registry};
 
-use metrics::{CounterFn, GaugeFn, HistogramFn, Key, Counter, Gauge, Histogram};
+use metrics::{Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key};
 use parking_lot::Mutex;
 use quanta::{Clock, Instant};
 

--- a/metrics-util/src/recency.rs
+++ b/metrics-util/src/recency.rs
@@ -33,7 +33,7 @@ use crate::registry::Primitives;
 use crate::StandardPrimitives;
 use crate::{kind::MetricKindMask, MetricKind, Registry};
 
-use metrics::{CounterFn, GaugeFn, HistogramFn, Key};
+use metrics::{CounterFn, GaugeFn, HistogramFn, Key, Counter, Gauge, Histogram};
 use parking_lot::Mutex;
 use quanta::{Clock, Instant};
 
@@ -41,7 +41,7 @@ use quanta::{Clock, Instant};
 ///
 /// Generations are opaque and are not meant to be used directly, but meant to be used as a
 /// comparison amongst each other in terms of ordering.
-#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Generation(usize);
 
 /// Generation tracking for a metric.
@@ -123,6 +123,33 @@ where
 {
     fn record(&self, value: f64) {
         self.with_increment(|h| h.record(value))
+    }
+}
+
+impl<T> From<Generational<T>> for Counter
+where
+    T: CounterFn + Send + Sync + 'static,
+{
+    fn from(inner: Generational<T>) -> Self {
+        Counter::from_arc(Arc::new(inner))
+    }
+}
+
+impl<T> From<Generational<T>> for Gauge
+where
+    T: GaugeFn + Send + Sync + 'static,
+{
+    fn from(inner: Generational<T>) -> Self {
+        Gauge::from_arc(Arc::new(inner))
+    }
+}
+
+impl<T> From<Generational<T>> for Histogram
+where
+    T: HistogramFn + Send + Sync + 'static,
+{
+    fn from(inner: Generational<T>) -> Self {
+        Histogram::from_arc(Arc::new(inner))
     }
 }
 


### PR DESCRIPTION
In #240, we switched over to a new trait, `Primitive`, in order to drive the behavior of `Registry`.  We use this in the Prometheus exporter to apply generational semantics to metric updates, which powers recency and idle timeout behavior.

When we wrote the code, we inadvertently created metric handles which wrapped the inner atomic itself, instead of wrapping the `Generational<T>` wrapper.  Without proxying updates through `Generational`, we never update the generation.  This leads to idle timeout logic being broken.  Woops.

The actual change to fix it is simple: clone the `Generational<T>`, not the `T`.  We've also added a test that asserts that recent metrics live past the idle timeout based off their initial creation time.

Fixes #263.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>