### PR TITLE
Properly track the latest generation in `Recency` for an already-seen metric .

### DIFF
--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -922,6 +922,47 @@ mod tests {
     }
 
     #[test]
+    fn test_idle_timeout_catches_delayed_idle() {
+        let (clock, mock) = Clock::mock();
+
+        let recorder = PrometheusBuilder::new()
+            .idle_timeout(MetricKindMask::ALL, Some(Duration::from_secs(10)))
+            .build_with_clock(clock);
+
+        let key = Key::from_name("basic_counter");
+        let counter1 = recorder.register_counter(&key);
+        counter1.increment(42);
+
+        // First render, which starts tracking the counter in the recency state.
+        let handle = recorder.handle();
+        let rendered = handle.render();
+        let expected = concat!("# TYPE basic_counter counter\n", "basic_counter 42\n\n",);
+
+        assert_eq!(rendered, expected);
+
+        // Now go forward by 9 seconds, which is close but still right unfer the idle timeout.
+        mock.increment(Duration::from_secs(9));
+        let rendered = handle.render();
+        assert_eq!(rendered, expected);
+
+        // Now increment the counter and advance time by two seconds: this pushes it over the idle
+        // timeout threshold, but it should not be removed since it has been updated.
+        counter1.increment(1);
+
+        let expected_after = concat!("# TYPE basic_counter counter\n", "basic_counter 43\n\n",);
+
+        mock.increment(Duration::from_secs(2));
+        let rendered = handle.render();
+        assert_eq!(rendered, expected_after);
+
+        // Now advance by 11 seconds, right past the idle timeout threshold.  We've made no further
+        // updates to the counter so it should be properly removed this time.
+        mock.increment(Duration::from_secs(11));
+        let rendered = handle.render();
+        assert_eq!(rendered, "");
+    }
+
+    #[test]
     pub fn test_global_labels() {
         let recorder = PrometheusBuilder::new()
             .add_global_label("foo", "foo")

--- a/metrics-util/CHANGELOG.md
+++ b/metrics-util/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+- `Recency` incorrectly failed to keep track of the latest generation when a previously-observed
+  metric had changed generations since the first time it was observed.
+
 ## [0.11.0] - 2022-01-14
 
 ### Changed

--- a/metrics-util/src/recency.rs
+++ b/metrics-util/src/recency.rs
@@ -298,6 +298,7 @@ impl Recency {
                     } else {
                         // Value has changed, so mark it such.
                         *last_update = now;
+                        *last_gen = gen;
                     }
                 } else {
                     entries.insert(key.clone(), (gen, now));


### PR DESCRIPTION
This fixes an a particularly embarrassing bug with `Recency`, and by extension the idle timeout support in `metrics-exporter-prometheus`, where if a metric was seen twice, such that it has changed between the two observations, then it would effectively be locked such that it was never removed.