### PR TITLE
allow for slices to be converted into labels

### DIFF
--- a/metrics/src/label.rs
+++ b/metrics/src/label.rs
@@ -75,12 +75,29 @@ impl IntoLabels for Iter<'_, Label> {
     }
 }
 
-impl<T, L> IntoLabels for &T
+impl<T: ?Sized, L> IntoLabels for &T
 where
     Self: IntoIterator<Item = L>,
     L: Into<Label>,
 {
     fn into_labels(self) -> Vec<Label> {
         self.into_iter().map(|l| l.into()).collect()
+    }
+}
+
+#[cfg(test)]
+mod label_tests {
+    use super::*;
+
+    #[test]
+    fn slice_labels() {
+        let labels = [("x", "a"), ("y", "b")];
+
+        fn from_slice_to_labels(labels: &[(&'static str, &'static str)]) -> Vec<Label> {
+            labels.into_labels()
+        }
+
+        let expected = vec![Label::new("x", "a"), Label::new("y", "b")];
+        assert_eq!(from_slice_to_labels(&labels), expected);
     }
 }


### PR DESCRIPTION
This PR removes the (implicit) sized requirement of one of the `IntoLabels` implementations to allow `&[(&'static str, &'static str)]` to be converted into `Vec<Label>`

A pattern I've been using often is that I have a static array of labels somewhere on the top of a module. i.e.,:

```rust
// note the explicit "1" for the size of the array here. 
const LABELS: [(&'static str, &'static str); 1] = [("source", "this-module")];

fn do_a_thing_for_this_module() {
    /* does a thing specific to this module */
    metrics::increment_counter!("a-thing-ocurred", &LABELS);
}
```

This works great when the `LABELS` const is being used directly as that variable is sized (to an array of 1 element).

However, I recently started refactoring some of my code and I had a function that looks like:

```rust
fn do_a_thing_anywhere(labels: &[(&'static str, &'static str)]) {
    /*does a thing that could be called from any module so it might need different labels */
    metrics::increment_counter!("a-thing-ocurred", &labels);
}
```

This does not compile however because there is an implicit `Sized` requirement in the `impl<T> IntoLabels for &T` block. While there are things that I could do get around this requirement in my code (e.g., make the function be generic over `IntoLabels`, or force it to be a reference to an array of a specific size) the `Sized` requirement felt like it was more of an oopsie rather than an intentional design choice. This PR removes this implicit bound and adds a test to verify it compiles and works as expected. I couldn't find where to put label specific tests so I put it on the same module I made the change in, I hope that's okay. 