### PR TITLE
Make `Registry` generic over both key and storage.

### DIFF
--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -6,7 +6,7 @@ use metrics::{
     gauge, histogram, increment_counter, register_counter, register_gauge, register_histogram,
     Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit,
 };
-use metrics_util::registry::{Registry, AtomicStorage};
+use metrics_util::registry::{AtomicStorage, Registry};
 use quanta::{Clock, Instant as QuantaInstant};
 use std::{
     env,
@@ -22,7 +22,7 @@ use std::{
 const LOOP_SAMPLE: u64 = 1000;
 
 pub struct Controller {
-    registry: Arc<Registry<AtomicStorage>>,
+    registry: Arc<Registry<Key, AtomicStorage>>,
 }
 
 impl Controller {
@@ -41,7 +41,7 @@ impl Controller {
 ///
 /// Simulates typical recorder implementations by utilizing `Registry`, clearing histogram buckets, etc.
 pub struct BenchmarkingRecorder {
-    registry: Arc<Registry<AtomicStorage>>,
+    registry: Arc<Registry<Key, AtomicStorage>>,
 }
 
 impl BenchmarkingRecorder {

--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -6,7 +6,7 @@ use metrics::{
     gauge, histogram, increment_counter, register_counter, register_gauge, register_histogram,
     Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit,
 };
-use metrics_util::{Registry, StandardPrimitives};
+use metrics_util::registry::{Registry, AtomicStorage};
 use quanta::{Clock, Instant as QuantaInstant};
 use std::{
     env,
@@ -22,7 +22,7 @@ use std::{
 const LOOP_SAMPLE: u64 = 1000;
 
 pub struct Controller {
-    registry: Arc<Registry<StandardPrimitives>>,
+    registry: Arc<Registry<AtomicStorage>>,
 }
 
 impl Controller {
@@ -41,7 +41,7 @@ impl Controller {
 ///
 /// Simulates typical recorder implementations by utilizing `Registry`, clearing histogram buckets, etc.
 pub struct BenchmarkingRecorder {
-    registry: Arc<Registry<StandardPrimitives>>,
+    registry: Arc<Registry<AtomicStorage>>,
 }
 
 impl BenchmarkingRecorder {

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -38,7 +38,7 @@ use tokio::runtime;
 #[cfg(feature = "push-gateway")]
 use tracing::error;
 
-use metrics_util::{parse_quantiles, recency::Recency, MetricKindMask, Quantile, Registry};
+use metrics_util::{parse_quantiles, MetricKindMask, Quantile, registry::{Recency, Registry}};
 
 use crate::common::Matcher;
 use crate::distribution::DistributionBuilder;

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -38,7 +38,11 @@ use tokio::runtime;
 #[cfg(feature = "push-gateway")]
 use tracing::error;
 
-use metrics_util::{parse_quantiles, MetricKindMask, Quantile, registry::{Recency, Registry}};
+use metrics_util::{
+    parse_quantiles,
+    registry::{Recency, Registry},
+    MetricKindMask, Quantile,
+};
 
 use crate::common::Matcher;
 use crate::distribution::DistributionBuilder;

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -13,8 +13,8 @@ use crate::common::{
 use crate::distribution::{Distribution, DistributionBuilder};
 
 pub(crate) struct Inner {
-    pub registry: Registry<GenerationalAtomicStorage>,
-    pub recency: Recency,
+    pub registry: Registry<Key, GenerationalAtomicStorage>,
+    pub recency: Recency<Key>,
     pub distributions: RwLock<HashMap<String, IndexMap<Vec<String>, Distribution>>>,
     pub distribution_builder: DistributionBuilder,
     pub descriptions: RwLock<HashMap<String, &'static str>>,

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit};
-use metrics_util::recency::{GenerationalPrimitives, Recency};
-use metrics_util::Registry;
+use metrics_util::registry::{GenerationalAtomicStorage, Recency, Registry};
 use parking_lot::RwLock;
 
 use crate::common::{
@@ -14,7 +13,7 @@ use crate::common::{
 use crate::distribution::{Distribution, DistributionBuilder};
 
 pub(crate) struct Inner {
-    pub registry: Registry<GenerationalPrimitives>,
+    pub registry: Registry<GenerationalAtomicStorage>,
     pub recency: Recency,
     pub distributions: RwLock<HashMap<String, IndexMap<Vec<String>, Distribution>>>,
     pub distribution_builder: DistributionBuilder,

--- a/metrics-util/CHANGELOG.md
+++ b/metrics-util/CHANGELOG.md
@@ -8,8 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-## [0.11.0] - 2022-01-14
+### Changed
 
+- Renamed `Primitives` to `Storage`, and publicly exposed it so that users can implement their own
+  storage strategies.
+- Renamed `StandardPrimitives` and `GenerationalPrimitives` to `AtomicStorage` and
+  `GenerationalAtomicStorage`, respectively.
+- Created a new top-level module, `registry`, that encompasses `Registry` and all `Registry`-related
+  and dependent types.
+
+## [0.11.0] - 2022-01-14
 ### Changed
 - Updated various dependencies in order to properly scope dependencies to only the necessary feature
   flags, and thus optimize build times and reduce transitive dependencies.

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -1,18 +1,18 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use metrics::{Key, Label};
-use metrics_util::{Registry, StandardPrimitives};
+use metrics_util::registry::{Registry, AtomicStorage};
 
 fn registry_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("registry");
     group.bench_function("cached op (basic)", |b| {
-        let registry = Registry::<StandardPrimitives>::new();
+        let registry = Registry::<AtomicStorage>::new();
         static KEY_NAME: &'static str = "simple_key";
         static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
 
         b.iter(|| registry.get_or_create_counter(&KEY_DATA, |_| ()))
     });
     group.bench_function("cached op (labels)", |b| {
-        let registry = Registry::<StandardPrimitives>::new();
+        let registry = Registry::<AtomicStorage>::new();
         static KEY_NAME: &'static str = "simple_key";
         static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
         static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
@@ -21,7 +21,7 @@ fn registry_benchmark(c: &mut Criterion) {
     });
     group.bench_function("uncached op (basic)", |b| {
         b.iter_batched_ref(
-            || Registry::<StandardPrimitives>::new(),
+            || Registry::<AtomicStorage>::new(),
             |registry| {
                 let key = "simple_key".into();
                 registry.get_or_create_counter(&key, |_| ())
@@ -31,7 +31,7 @@ fn registry_benchmark(c: &mut Criterion) {
     });
     group.bench_function("uncached op (labels)", |b| {
         b.iter_batched_ref(
-            || Registry::<StandardPrimitives>::new(),
+            || Registry::<AtomicStorage>::new(),
             |registry| {
                 let labels = vec![Label::new("type", "http")];
                 let key = ("simple_key", labels).into();
@@ -43,7 +43,7 @@ fn registry_benchmark(c: &mut Criterion) {
     group.bench_function("creation overhead", |b| {
         b.iter_batched(
             || (),
-            |_| Registry::<StandardPrimitives>::new(),
+            |_| Registry::<AtomicStorage>::new(),
             BatchSize::NumIterations(1),
         )
     });

--- a/metrics-util/benches/registry.rs
+++ b/metrics-util/benches/registry.rs
@@ -1,18 +1,18 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use metrics::{Key, Label};
-use metrics_util::registry::{Registry, AtomicStorage};
+use metrics_util::registry::Registry;
 
 fn registry_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("registry");
     group.bench_function("cached op (basic)", |b| {
-        let registry = Registry::<AtomicStorage>::new();
+        let registry = Registry::atomic();
         static KEY_NAME: &'static str = "simple_key";
         static KEY_DATA: Key = Key::from_static_name(&KEY_NAME);
 
         b.iter(|| registry.get_or_create_counter(&KEY_DATA, |_| ()))
     });
     group.bench_function("cached op (labels)", |b| {
-        let registry = Registry::<AtomicStorage>::new();
+        let registry = Registry::atomic();
         static KEY_NAME: &'static str = "simple_key";
         static KEY_LABELS: [Label; 1] = [Label::from_static_parts("type", "http")];
         static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
@@ -21,7 +21,7 @@ fn registry_benchmark(c: &mut Criterion) {
     });
     group.bench_function("uncached op (basic)", |b| {
         b.iter_batched_ref(
-            || Registry::<AtomicStorage>::new(),
+            || Registry::atomic(),
             |registry| {
                 let key = "simple_key".into();
                 registry.get_or_create_counter(&key, |_| ())
@@ -31,7 +31,7 @@ fn registry_benchmark(c: &mut Criterion) {
     });
     group.bench_function("uncached op (labels)", |b| {
         b.iter_batched_ref(
-            || Registry::<AtomicStorage>::new(),
+            || Registry::atomic(),
             |registry| {
                 let labels = vec![Label::new("type", "http")];
                 let key = ("simple_key", labels).into();
@@ -41,11 +41,7 @@ fn registry_benchmark(c: &mut Criterion) {
         )
     });
     group.bench_function("creation overhead", |b| {
-        b.iter_batched(
-            || (),
-            |_| Registry::<AtomicStorage>::new(),
-            BatchSize::NumIterations(1),
-        )
+        b.iter_batched(|| (), |_| Registry::atomic(), BatchSize::NumIterations(1))
     });
     group.bench_function("const key overhead (basic)", |b| {
         b.iter(|| {

--- a/metrics-util/src/common.rs
+++ b/metrics-util/src/common.rs
@@ -10,15 +10,28 @@ use metrics::{Key, KeyHasher};
 /// `Hash` trait, `Hashable` exposes an interface that forces objects to hash themselves entirely,
 /// providing only the resulting 8-byte hash.
 ///
-/// For all implementations of `Hashable`, you _must_ utilize `metrics::KeyHasher`.  Usage of
-/// another hasher will lead to inconsistency in places where `Hashable` is used, specifically
-/// `Registry`.  You can wrap items in `DefaultHashable` to ensure they utilize the correct hasher.
+/// As a key may sometimes need to be rehashed, we need to ensure that the same hashing algorithm
+/// used to pre-generate the hash for this value is used when rehashing it.  All implementors must
+/// define the hashing algorithm used by specifying the `Hasher` associated type.
+///
+/// A default implementation, `DefaultHashable`, is provided that utilizes the same hashing
+/// algorithm that `metrics::Key` uses, which is high-performance.  This type can be used to satisfy
+/// `Hashable` so long as the type itself is already `Hash`.
 pub trait Hashable: Hash {
+    /// The hasher implementation used internally.
+    type Hasher: Hasher + Default;
+
     /// Generate the hash of this object.
-    fn hashable(&self) -> u64;
+    fn hashable(&self) -> u64 {
+        let mut hasher = Self::Hasher::default();
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
 }
 
 impl Hashable for Key {
+    type Hasher = KeyHasher;
+
     fn hashable(&self) -> u64 {
         self.get_hash()
     }
@@ -28,6 +41,8 @@ impl Hashable for Key {
 pub(crate) struct DefaultHashable<H: Hash>(pub H);
 
 impl<H: Hash> Hashable for DefaultHashable<H> {
+    type Hasher = KeyHasher;
+
     fn hashable(&self) -> u64 {
         let mut hasher = KeyHasher::default();
         self.hash(&mut hasher);

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, fmt::Debug};
 
+use crate::registry::AtomicStorage;
 use crate::{kind::MetricKind, registry::Registry, CompositeKey};
 
 use indexmap::IndexMap;
@@ -51,7 +52,7 @@ pub enum DebugValue {
 
 /// Captures point-in-time snapshots of `DebuggingRecorder`.
 pub struct Snapshotter {
-    registry: Arc<Registry>,
+    registry: Arc<Registry<Key, AtomicStorage>>,
     seen: Arc<Mutex<IndexMap<CompositeKey, ()>>>,
     metadata: Arc<Mutex<IndexMap<CompositeKeyName, (Option<Unit>, &'static str)>>>,
 }
@@ -107,7 +108,7 @@ impl Snapshotter {
 /// Callers can easily take snapshots of the metrics at any given time and get access
 /// to the raw values.
 pub struct DebuggingRecorder {
-    registry: Arc<Registry>,
+    registry: Arc<Registry<Key, AtomicStorage>>,
     seen: Arc<Mutex<IndexMap<CompositeKey, ()>>>,
     metadata: Arc<Mutex<IndexMap<CompositeKeyName, (Option<Unit>, &'static str)>>>,
 }

--- a/metrics-util/src/lib.rs
+++ b/metrics-util/src/lib.rs
@@ -19,9 +19,7 @@ mod quantile;
 pub use quantile::{parse_quantiles, Quantile};
 
 #[cfg(feature = "registry")]
-mod registry;
-#[cfg(feature = "registry")]
-pub use registry::{Registry, StandardPrimitives};
+pub mod registry;
 
 mod common;
 pub use common::*;
@@ -41,9 +39,6 @@ mod summary;
 pub use summary::Summary;
 
 pub mod layers;
-
-#[cfg(feature = "recency")]
-pub mod recency;
 
 #[cfg(test)]
 mod test_util;

--- a/metrics-util/src/registry/mod.rs
+++ b/metrics-util/src/registry/mod.rs
@@ -1,0 +1,13 @@
+//! High-performance metrics storage.
+
+mod storage;
+pub use storage::{Storage, AtomicStorage};
+
+#[cfg(feature = "recency")]
+mod recency;
+
+#[cfg(feature = "recency")]
+pub use recency::{Generation, GenerationalAtomicStorage, Recency};
+
+mod registry;
+pub use registry::Registry;

--- a/metrics-util/src/registry/mod.rs
+++ b/metrics-util/src/registry/mod.rs
@@ -1,7 +1,7 @@
 //! High-performance metrics storage.
 
 mod storage;
-pub use storage::{Storage, AtomicStorage};
+pub use storage::{AtomicStorage, Storage};
 
 #[cfg(feature = "recency")]
 mod recency;

--- a/metrics-util/src/registry/storage.rs
+++ b/metrics-util/src/registry/storage.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use atomic_shim::AtomicU64;
+use metrics::{CounterFn, GaugeFn, HistogramFn};
+
+use crate::AtomicBucket;
+
+/// Defines the underlying storage for metrics as well as how to create them.
+pub trait Storage {
+	/// The type used for counters.
+    type Counter: CounterFn + Clone;
+
+	/// The type used for gauges.
+    type Gauge: GaugeFn + Clone;
+
+	/// The type used for histograms.
+    type Histogram: HistogramFn + Clone;
+
+	/// Creates an empty counter.
+    fn counter() -> Self::Counter;
+
+	/// Creates an empty gauge.
+    fn gauge() -> Self::Gauge;
+
+	/// Creates an empty histogram.
+    fn histogram() -> Self::Histogram;
+}
+
+/// Atomic metric storage.
+/// 
+/// Utilizes atomics for storing the value(s) of a given metric.  Shared access to the actual atomic
+/// is handling via `Arc`.
+pub struct AtomicStorage;
+
+impl Storage for AtomicStorage {
+    type Counter = Arc<AtomicU64>;
+    type Gauge = Arc<AtomicU64>;
+    type Histogram = Arc<AtomicBucket<f64>>;
+
+    fn counter() -> Self::Counter {
+        Arc::new(AtomicU64::new(0))
+    }
+
+    fn gauge() -> Self::Gauge {
+        Arc::new(AtomicU64::new(0))
+    }
+
+    fn histogram() -> Self::Histogram {
+        Arc::new(AtomicBucket::new())
+    }
+}

--- a/metrics-util/src/registry/storage.rs
+++ b/metrics-util/src/registry/storage.rs
@@ -7,27 +7,27 @@ use crate::AtomicBucket;
 
 /// Defines the underlying storage for metrics as well as how to create them.
 pub trait Storage {
-	/// The type used for counters.
+    /// The type used for counters.
     type Counter: CounterFn + Clone;
 
-	/// The type used for gauges.
+    /// The type used for gauges.
     type Gauge: GaugeFn + Clone;
 
-	/// The type used for histograms.
+    /// The type used for histograms.
     type Histogram: HistogramFn + Clone;
 
-	/// Creates an empty counter.
+    /// Creates an empty counter.
     fn counter() -> Self::Counter;
 
-	/// Creates an empty gauge.
+    /// Creates an empty gauge.
     fn gauge() -> Self::Gauge;
 
-	/// Creates an empty histogram.
+    /// Creates an empty histogram.
     fn histogram() -> Self::Histogram;
 }
 
 /// Atomic metric storage.
-/// 
+///
 /// Utilizes atomics for storing the value(s) of a given metric.  Shared access to the actual atomic
 /// is handling via `Arc`.
 pub struct AtomicStorage;


### PR DESCRIPTION
It was brought up in #271 that the latest `metrics` release had degraded the experience of using `Registry` due in part to the refactoring we did which hard-coded not only the key type but the primitives used.

This was somewhat intentional, given our need to need to unifying hash for pre-hashed vs re-hashing of keys, but I had never explicitly intended to hide `Primitives` and prevent external implementations. This PR fixes both of those issues.

Firstly, we've made the key type generic by augmenting `Hashable` such that it has to specify (as an associated type) the hasher it uses for pre-hashing itself.  External implementations can choose to rely on `metrics::KeyHasher` if the choose, but now they have an option to utilize a different hasher as well.

Secondly, we've renamed `Primitives` to `Storage`, and made the trait public.  This will allow users to implement their own storage regime when using `Registry` in case they have special requirements.

Fixes #272.
Fixes #274.