### PR TITLE
metrics-tracing-context: add Allowlist label filter

### DIFF
--- a/metrics-tracing-context/src/label_filter.rs
+++ b/metrics-tracing-context/src/label_filter.rs
@@ -1,5 +1,7 @@
 //! Label filtering.
 
+use std::collections::HashSet;
+
 use metrics::Label;
 
 /// [`LabelFilter`] trait encapsulates the ability to filter labels, i.e.
@@ -16,5 +18,26 @@ pub struct IncludeAll;
 impl LabelFilter for IncludeAll {
     fn should_include_label(&self, _label: &Label) -> bool {
         true
+    }
+}
+
+/// A [`LabelFilter`] that allows an allowed list of label names.
+#[derive(Debug, Clone)]
+pub struct Allowlist {
+    /// The set of allowed label names.
+    label_names: HashSet<String>,
+}
+
+impl Allowlist {
+    /// Create a [`Allowlist`] filter with the provide label names.
+    pub fn new(label_names: &[&str]) -> Allowlist {
+        let set: HashSet<String> = label_names.iter().map(|l| l.to_string()).collect();
+        Allowlist { label_names: set }
+    }
+}
+
+impl LabelFilter for Allowlist {
+    fn should_include_label(&self, label: &Label) -> bool {
+        self.label_names.contains(label.key())
     }
 }

--- a/metrics-tracing-context/src/label_filter.rs
+++ b/metrics-tracing-context/src/label_filter.rs
@@ -35,15 +35,7 @@ impl Allowlist {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        Self {
-            label_names: allowed
-                .into_iter()
-                .map(|s| s.as_ref().to_string())
-                .collect(),
-        }
-    }
-        let set: HashSet<String> = label_names.iter().map(|l| l.to_string()).collect();
-        Allowlist { label_names: set }
+        Self { label_names: allowed.into_iter().map(|s| s.as_ref().to_string()).collect() }
     }
 }
 

--- a/metrics-tracing-context/src/label_filter.rs
+++ b/metrics-tracing-context/src/label_filter.rs
@@ -21,7 +21,7 @@ impl LabelFilter for IncludeAll {
     }
 }
 
-/// A [`LabelFilter`] that allows an allowed list of label names.
+/// A [`LabelFilter`] that only allows labels contained in a predefined list.
 #[derive(Debug, Clone)]
 pub struct Allowlist {
     /// The set of allowed label names.
@@ -29,8 +29,19 @@ pub struct Allowlist {
 }
 
 impl Allowlist {
-    /// Create a [`Allowlist`] filter with the provide label names.
-    pub fn new(label_names: &[&str]) -> Allowlist {
+    /// Create a [`Allowlist`] filter with the provided label names.
+    pub fn new<I, S>(allowed: I) -> Allowlist
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self {
+            label_names: allowed
+                .into_iter()
+                .map(|s| s.as_ref().to_string())
+                .collect(),
+        }
+    }
         let set: HashSet<String> = label_names.iter().map(|l| l.to_string()).collect();
         Allowlist { label_names: set }
     }

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -126,9 +126,13 @@ impl TracingContextLayer<label_filter::IncludeAll> {
 }
 
 impl TracingContextLayer<label_filter::Allowlist> {
-    /// Creates a new [`TracingContextLayer`] with an allowed list of label
-    /// names.
-    pub fn allowlist(label_names: &[&str]) -> Self {
+    /// Creates a new [`TracingContextLayer`] that only allows labels contained
+    /// in a predefined list.
+    pub fn only_allow<I, S>(allowed: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
         Self { label_filter: label_filter::Allowlist::new(label_names) }
     }
 }

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -125,6 +125,14 @@ impl TracingContextLayer<label_filter::IncludeAll> {
     }
 }
 
+impl TracingContextLayer<label_filter::Allowlist> {
+    /// Creates a new [`TracingContextLayer`] with an allowed list of label
+    /// names.
+    pub fn allowlist(label_names: &[&str]) -> Self {
+        Self { label_filter: label_filter::Allowlist::new(label_names) }
+    }
+}
+
 impl<R, F> Layer<R> for TracingContextLayer<F>
 where
     F: Clone,

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -133,7 +133,7 @@ impl TracingContextLayer<label_filter::Allowlist> {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        Self { label_filter: label_filter::Allowlist::new(label_names) }
+        Self { label_filter: label_filter::Allowlist::new(allowed) }
     }
 }
 

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -351,7 +351,7 @@ fn test_label_filtering() {
 
 #[test]
 fn test_label_allowlist() {
-    let (_guard, snapshotter) = setup(TracingContextLayer::allowlist(&["env", "service"]));
+    let (_guard, snapshotter) = setup(TracingContextLayer::only_allow(&["env", "service"]));
 
     let user = "ferris";
     let email = "ferris@rust-lang.org";

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -22,6 +22,10 @@ static EMAIL_USER: &'static [Label] = &[
     Label::from_static_parts("user.email", "ferris@rust-lang.org"),
     Label::from_static_parts("user", "ferris"),
 ];
+static SVC_ENV: &'static [Label] = &[
+    Label::from_static_parts("service", "login_service"),
+    Label::from_static_parts("env", "test"),
+];
 static SVC_USER_EMAIL: &'static [Label] = &[
     Label::from_static_parts("service", "login_service"),
     Label::from_static_parts("user", "ferris"),
@@ -338,6 +342,37 @@ fn test_label_filtering() {
                 MetricKind::Counter,
                 Key::from_static_parts(LOGIN_ATTEMPTS, EMAIL_USER)
             ),
+            None,
+            None,
+            DebugValue::Counter(1),
+        )]
+    )
+}
+
+#[test]
+fn test_label_allowlist() {
+    let (_guard, snapshotter) = setup(TracingContextLayer::allowlist(&["env", "service"]));
+
+    let user = "ferris";
+    let email = "ferris@rust-lang.org";
+    let span = span!(
+        Level::TRACE,
+        "login",
+        user,
+        user.email_span = email,
+        service = "login_service",
+        env = "test"
+    );
+    let _guard = span.enter();
+
+    counter!("login_attempts", 1);
+
+    let snapshot = snapshotter.snapshot().into_vec();
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            CompositeKey::new(MetricKind::Counter, Key::from_static_parts(LOGIN_ATTEMPTS, SVC_ENV)),
             None,
             None,
             DebugValue::Counter(1),


### PR DESCRIPTION
In many metrics system (for example, Datadog) sending all tags will be cost prohibitive if not impossible. Since filtering metrics tags to a small set of allowed tags is a common requirement, add a `LabelFilter` to support this easily.

**Note:** I'm fairly new with Rust, please let me know if there are better ways to implement this.