### PR TITLE
metrics-exporter-prometheus: properly sanitize metric names

### DIFF
--- a/metrics-exporter-prometheus/src/formatting.rs
+++ b/metrics-exporter-prometheus/src/formatting.rs
@@ -226,7 +226,13 @@ mod tests {
 
     #[test]
     fn test_sanitize_metric_name_known_cases() {
-        let cases = &[("*", "_"), ("\"", "_"), ("foo_bar", "foo_bar"), ("1foobar", "_foobar")];
+        let cases = &[
+            ("*", "_"),
+            ("\"", "_"),
+            ("foo_bar", "foo_bar"),
+            ("foo1_bar", "foo1_bar"),
+            ("1foobar", "_foobar"),
+        ];
 
         for (input, expected) in cases {
             let result = sanitize_metric_name(input);

--- a/metrics-exporter-prometheus/src/formatting.rs
+++ b/metrics-exporter-prometheus/src/formatting.rs
@@ -110,8 +110,17 @@ pub fn write_metric_line<T, T2>(
 /// [data model]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
 pub fn sanitize_metric_name(name: &str) -> String {
     // The first character must be [a-zA-Z_:], and all subsequent characters must be [a-zA-Z0-9_:].
-    name.replacen(invalid_metric_name_start_character, "_", 1)
-        .replace(invalid_metric_name_character, "_")
+    let mut out = String::with_capacity(name.len());
+    let mut is_invalid: fn(char) -> bool = invalid_metric_name_start_character;
+    for c in name.chars() {
+        if is_invalid(c) {
+            out.push('_');
+        } else {
+            out.push(c);
+        }
+        is_invalid = invalid_metric_name_character;
+    }
+    return out;
 }
 
 /// Sanitizes a label key to be valid under the Prometheus [data model].

--- a/metrics-exporter-prometheus/src/formatting.rs
+++ b/metrics-exporter-prometheus/src/formatting.rs
@@ -120,7 +120,7 @@ pub fn sanitize_metric_name(name: &str) -> String {
         }
         is_invalid = invalid_metric_name_character;
     }
-    return out;
+    out
 }
 
 /// Sanitizes a label key to be valid under the Prometheus [data model].


### PR DESCRIPTION
Closes #289 

#289 describes a case when a valid metric name is sanitized (i.e., changed) when it need not be. I added a test to exercise this case and modified the `sanitize_metrics_name` function to pass this test. In terms of approach, I changed from using methods on strings to using a pre-constructed lookup table. The helper functions that were previously used to implement `sanitize_metrics_name` have been moved in the `test` module to act as oracles in the property tests.