### PR TITLE
Fix `metrics::Cow` provenance issue

### DIFF
--- a/metrics/src/cow.rs
+++ b/metrics/src/cow.rs
@@ -330,7 +330,9 @@ unsafe impl Cowable for str {
 
     #[inline]
     fn owned_into_parts(owned: String) -> (NonNull<u8>, Metadata) {
-        let mut owned = ManuallyDrop::new(owned);
+        // We need to go through Vec here to get provenance for the entire allocation
+        // instead of just the initialized parts.
+        let mut owned = ManuallyDrop::new(owned.into_bytes());
         let ptr = unsafe { NonNull::new_unchecked(owned.as_mut_ptr()) };
         let metadata = Metadata::from_owned(owned.len(), owned.capacity());
         (ptr, metadata)


### PR DESCRIPTION
Calling `.as_mut_ptr` on a `String` actually goes through `&mut str`, which shrinks the provenance of the pointer to only contain the initialized bytes. This caused issues when a reconstructed `String` tried to write to the uninitialized part of it. The fix is to go through `Vec::<u8>::as_mut_ptr`, which gives provenance for the entire allocation.

Also PRed upstream [beef#47](https://github.com/maciejhirsz/beef/pull/47)