### PR TITLE
Add RollingSummary to prevent summary saturation

### DIFF
--- a/metrics-exporter-prometheus/src/distribution.rs
+++ b/metrics-exporter-prometheus/src/distribution.rs
@@ -1,4 +1,8 @@
+use std::num::NonZeroU32;
+use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
+
+use quanta::Instant;
 
 use crate::common::Matcher;
 
@@ -18,7 +22,7 @@ pub enum Distribution {
     /// Computes and exposes value quantiles directly to Prometheus i.e. 50% of
     /// requests were faster than 200ms, and 99% of requests were faster than
     /// 1000ms, etc.
-    Summary(Summary, Arc<Vec<Quantile>>, f64),
+    Summary(RollingSummary, Arc<Vec<Quantile>>, f64),
 }
 
 impl Distribution {
@@ -30,17 +34,19 @@ impl Distribution {
 
     /// Creates a summary distribution.
     pub fn new_summary(quantiles: Arc<Vec<Quantile>>) -> Distribution {
-        let summary = Summary::with_defaults();
+        let summary = RollingSummary::default();
         Distribution::Summary(summary, quantiles, 0.0)
     }
 
     /// Records the given `samples` in the current distribution.
-    pub fn record_samples(&mut self, samples: &[f64]) {
+    pub fn record_samples(&mut self, samples: &[(f64, Instant)]) {
         match self {
-            Distribution::Histogram(hist) => hist.record_many(samples),
+            Distribution::Histogram(hist) => {
+                hist.record_many(samples.iter().map(|(sample, _ts)| sample));
+            }
             Distribution::Summary(hist, _, sum) => {
-                for sample in samples {
-                    hist.add(*sample);
+                for (sample, ts) in samples {
+                    hist.add(*sample, *ts);
                     *sum += *sample;
                 }
             }
@@ -106,5 +112,302 @@ impl DistributionBuilder {
         }
 
         "summary"
+    }
+}
+
+#[derive(Clone)]
+struct Bucket {
+    begin: Instant,
+    summary: Summary,
+}
+
+/// A RollingSummary manages a list of [Summary] so that old results can be expired.
+#[derive(Clone)]
+pub struct RollingSummary {
+    // Buckets are ordered with the latest buckets first.  The buckets are kept in alignment based
+    // on the instant of the first added bucket and the bucket_duration.  There may be gaps in the
+    // bucket list.
+    buckets: Vec<Bucket>,
+    // Maximum number of buckets to track.
+    max_buckets: usize,
+    // Duration of values stored per bucket.
+    bucket_duration: Duration,
+    // This is the maximum duration a bucket will be kept.
+    max_bucket_duration: Duration,
+    // Total samples since creation of this summary.  This is separate from the Summary since it is
+    // never reset.
+    count: usize,
+}
+
+impl Default for RollingSummary {
+    fn default() -> Self {
+        RollingSummary::new(NonZeroU32::new(3).unwrap(), Duration::from_secs(20))
+    }
+}
+
+impl RollingSummary {
+    /// Create a new RollingSummary with the given number of `buckets` and `bucket-duration`.
+    ///
+    /// The summary will store quantiles over `buckets * bucket_duration` seconds.
+    pub fn new(buckets: std::num::NonZeroU32, bucket_duration: Duration) -> RollingSummary {
+        assert!(!bucket_duration.is_zero());
+        let max_bucket_duration = bucket_duration * buckets.get();
+        let max_buckets = buckets.get() as usize;
+
+        RollingSummary {
+            buckets: Vec::with_capacity(max_buckets),
+            max_buckets,
+            bucket_duration,
+            max_bucket_duration,
+            count: 0,
+        }
+    }
+
+    /// Add a sample `value` to the RollingSummary at the time `now`.
+    ///
+    /// Any values that expire at the `value_ts` are removed from the RollingSummary.
+    pub fn add(&mut self, value: f64, now: Instant) {
+        // The count is incremented even if this value is too old to be saved in any bucket.
+        self.count += 1;
+
+        // If we can find a bucket that this value belongs in, then we can just add it in and be
+        // done.
+        for bucket in &mut self.buckets {
+            let end = bucket.begin + self.bucket_duration;
+
+            // If this value belongs in a future bucket...
+            if now > bucket.begin + self.bucket_duration {
+                break;
+            }
+
+            if now >= bucket.begin && now < end {
+                bucket.summary.add(value);
+                return;
+            }
+        }
+
+        // Remove any expired buckets.
+        if let Some(cutoff) = now.checked_sub(self.max_bucket_duration) {
+            self.buckets.retain(|b| b.begin > cutoff);
+        }
+
+        if self.buckets.is_empty() {
+            let mut summary = Summary::with_defaults();
+            summary.add(value);
+            self.buckets.push(Bucket { begin: now, summary });
+            return;
+        }
+
+        // Take the first bucket time as a reference.  Other buckets will be created at an offset
+        // of this time.  We know this time is close to the value_ts, if it were much older the
+        // bucket would have been removed.
+        let reftime = self.buckets[0].begin;
+
+        let mut summary = Summary::with_defaults();
+        summary.add(value);
+
+        // If the value is newer than the first bucket then count upwards to the new bucket time.
+        let mut begin;
+        if now > reftime {
+            begin = reftime + self.bucket_duration;
+            let mut end = begin + self.bucket_duration;
+            while now < begin || now >= end {
+                begin += self.bucket_duration;
+                end += self.bucket_duration;
+            }
+
+            self.buckets.truncate(self.max_buckets - 1);
+            self.buckets.insert(0, Bucket { begin, summary });
+        } else {
+            begin = reftime - self.bucket_duration;
+            while now < begin {
+                begin -= self.bucket_duration;
+            }
+
+            self.buckets.truncate(self.max_buckets - 1);
+            self.buckets.push(Bucket { begin, summary });
+            self.buckets.sort_unstable_by(|a, b| b.begin.cmp(&a.begin));
+        }
+    }
+
+    /// Return a merged Summary of all items that are valid at `now`.
+    ///
+    /// # Warning
+    ///
+    /// The snapshot `Summary::count()` contains the total number of values considered in the
+    /// Snapshot, which is not the full count of the RollingSummary.  Use `RollingSummary::count()`
+    /// instead.
+    pub fn snapshot(&self, now: Instant) -> Summary {
+        let cutoff = now.checked_sub(self.max_bucket_duration);
+        let mut acc = Summary::with_defaults();
+        self.buckets
+            .iter()
+            .filter(|b| if let Some(cutoff) = cutoff { b.begin > cutoff } else { true })
+            .map(|b| &b.summary)
+            .fold(&mut acc, |acc, item| {
+                acc.merge(item).expect("merge can only fail if summary config inconsistent");
+                acc
+            });
+        acc
+    }
+
+    /// Whether or not this summary is empty.
+    pub fn is_empty(&self) -> bool {
+        self.count() == 0
+    }
+
+    /// Gets the totoal number of samples this summary has seen so far.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    #[cfg(test)]
+    fn buckets(&self) -> &Vec<Bucket> {
+        &self.buckets
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use quanta::Clock;
+
+    #[test]
+    fn new_rolling_summary() {
+        let summary = RollingSummary::default();
+
+        assert_eq!(0, summary.buckets().len());
+        assert_eq!(0, summary.count());
+        assert!(summary.is_empty());
+    }
+
+    #[test]
+    fn empty_snapshot() {
+        let (clock, _mock) = Clock::mock();
+        let summary = RollingSummary::default();
+        let snapshot = summary.snapshot(clock.now());
+
+        assert_eq!(0, snapshot.count());
+        assert_eq!(f64::INFINITY, snapshot.min());
+        assert_eq!(f64::NEG_INFINITY, snapshot.max());
+        assert_eq!(None, snapshot.quantile(0.5));
+    }
+
+    #[test]
+    fn snapshot() {
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(3600));
+
+        let mut summary = RollingSummary::default();
+        summary.add(42.0, clock.now());
+        mock.increment(Duration::from_secs(20));
+        summary.add(42.0, clock.now());
+        mock.increment(Duration::from_secs(20));
+        summary.add(42.0, clock.now());
+
+        let snapshot = summary.snapshot(clock.now());
+
+        assert_eq!(42.0, snapshot.min());
+        assert_eq!(42.0, snapshot.max());
+        assert_eq!(Some(42.0), snapshot.quantile(0.5));
+    }
+
+    #[test]
+    fn add_first_value() {
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(3600));
+
+        let mut summary = RollingSummary::default();
+        summary.add(42.0, clock.now());
+
+        assert_eq!(1, summary.buckets().len());
+        assert_eq!(1, summary.count());
+        assert!(!summary.is_empty());
+    }
+
+    #[test]
+    fn add_new_head() {
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(3600));
+
+        let mut summary = RollingSummary::default();
+        summary.add(42.0, clock.now());
+        mock.increment(Duration::from_secs(20));
+        summary.add(42.0, clock.now());
+
+        assert_eq!(2, summary.buckets().len());
+    }
+
+    #[test]
+    fn truncate_old_buckets() {
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(3600));
+
+        let mut summary = RollingSummary::default();
+        summary.add(42.0, clock.now());
+
+        for _ in 0..3 {
+            mock.increment(Duration::from_secs(20));
+            summary.add(42.0, clock.now());
+        }
+
+        assert_eq!(3, summary.buckets().len());
+    }
+
+    #[test]
+    fn add_to_tail() {
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(3600));
+
+        let mut summary = RollingSummary::default();
+        summary.add(42.0, clock.now());
+        let mut expected = Vec::new();
+        expected.push(clock.now());
+        mock.decrement(Duration::from_secs(20));
+        summary.add(42.0, clock.now());
+        expected.push(clock.now());
+
+        let actual: Vec<Instant> = summary.buckets().iter().map(|b| b.begin).collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn add_to_tail_with_gap() {
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(3600));
+
+        let mut summary = RollingSummary::default();
+        summary.add(42.0, clock.now());
+        let mut expected = Vec::new();
+        expected.push(clock.now());
+        mock.decrement(Duration::from_secs(40));
+        summary.add(42.0, clock.now());
+        expected.push(clock.now());
+
+        let actual: Vec<Instant> = summary.buckets().iter().map(|b| b.begin).collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn add_to_middle_gap() {
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(3600));
+
+        let mut expected = Vec::new();
+        expected.resize(3, Instant::now());
+
+        let mut summary = RollingSummary::default();
+        summary.add(42.0, clock.now());
+        expected[0] = clock.now();
+        mock.decrement(Duration::from_secs(40));
+        summary.add(42.0, clock.now());
+        expected[2] = clock.now();
+        mock.increment(Duration::from_secs(20));
+        summary.add(42.0, clock.now());
+        expected[1] = clock.now();
+
+        let actual: Vec<Instant> = summary.buckets().iter().map(|b| b.begin).collect();
+        assert_eq!(expected, actual);
     }
 }

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -109,7 +109,7 @@ impl Snapshotter {
                 }),
                 MetricKind::Histogram => histograms.get(ck.key()).map(|h| {
                     let mut values = Vec::new();
-                    h.clear_with(|xs| values.extend(xs.iter().map(|f| OrderedFloat::from(*f))));
+                    h.clear_with(|xs| values.extend(xs.iter().map(|(f, _)| OrderedFloat::from(*f))));
                     DebugValue::Histogram(values)
                 }),
             };
@@ -159,7 +159,7 @@ impl Snapshotter {
                         MetricKind::Histogram => histograms.get(ck.key()).map(|h| {
                             let mut values = Vec::new();
                             h.clear_with(|xs| {
-                                values.extend(xs.iter().map(|f| OrderedFloat::from(*f)))
+                                values.extend(xs.iter().map(|(f, _)| OrderedFloat::from(*f)))
                             });
                             DebugValue::Histogram(values)
                         }),

--- a/metrics-util/src/handles.rs
+++ b/metrics-util/src/handles.rs
@@ -1,8 +1,10 @@
 use crate::AtomicBucket;
 use metrics::HistogramFn;
+use quanta::Instant;
 
-impl HistogramFn for AtomicBucket<f64> {
+impl HistogramFn for AtomicBucket<(f64, Instant)> {
     fn record(&self, value: f64) {
-        self.push(value);
+        let now = Instant::now();
+        self.push((value, now));
     }
 }

--- a/metrics-util/src/registry/storage.rs
+++ b/metrics-util/src/registry/storage.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use atomic_shim::AtomicU64;
 use metrics::{CounterFn, GaugeFn, HistogramFn};
+use quanta::Instant;
 
 use crate::AtomicBucket;
 
@@ -35,7 +36,7 @@ pub struct AtomicStorage;
 impl<K> Storage<K> for AtomicStorage {
     type Counter = Arc<AtomicU64>;
     type Gauge = Arc<AtomicU64>;
-    type Histogram = Arc<AtomicBucket<f64>>;
+    type Histogram = Arc<AtomicBucket<(f64, Instant)>>;
 
     fn counter(&self, _: &K) -> Self::Counter {
         Arc::new(AtomicU64::new(0))


### PR DESCRIPTION
This PR attempts to address the issue described in #269 where Prometheus
Summaries become saturated.  I added a RollingSummary type that manages a list
of Summary so that old values can be retired.

There is a breaking change in `AtomicStorage`:
```diff
- type Histogram = Arc<AtomicBucket<f64>>;
+ type Histogram = Arc<AtomicBucket<(f64, Instant)>>;
```

I tested using a program that produces a test pattern, every two minutes it
switches between uniform random values between 0-100 and 100-200.

I also graph the summary `rate(sum[1m]) / rate(count[1m])` for comparison to
the 50th quantile.

Before this patch:

![2022-06-09-163831_1347x637_scrot](https://user-images.githubusercontent.com/1048079/172962420-af2dcb64-927d-4957-8899-ae4c9aebcdda.png)

With this patch:

![2022-06-09-160026_1345x635_scrot](https://user-images.githubusercontent.com/1048079/172962379-5eb8c305-ed80-49d8-a887-435265da96ea.png)
