### PR TITLE
Document CI enforced msrv in readme and rust-version fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ As well, there are also some community-maintained exporters and other integratio
 * [`metrics-exporter-newrelic`][metrics-exporter-newrelic]: A `metrics`-compatible exporter for sending metrics to New Relic.
 * [`opinionated_metrics`][opinionated-metrics]: Opinionated interface to emitting metrics for CLi/server applications, based on `metrics`.
 
+## MSRV
+
+Minimum Supported Rust version is **1.56.1**
+It is enforced in CI.
+
 # contributing
 
 To those of you who have already contributed to `metrics` in some way, shape, or form: **a big, and continued, "thank you!"** ❤️

--- a/README.md
+++ b/README.md
@@ -66,8 +66,14 @@ As well, there are also some community-maintained exporters and other integratio
 
 ## MSRV
 
-Minimum Supported Rust version is **1.56.1**
+Minimum Supported Rust version is **1.56.1**.
 It is enforced in CI.
+
+### policy for bumping MSRV
+
+* The last 4 stable releases must always be supported
+* Goal is to try and support older versions where possible (not opting in to newer versions just to use a new helper method on standard library types, etc)
+* Do not bump the MSRV for newer versions of dependencies in core crates (metrics and metrics-util)
 
 # contributing
 

--- a/metrics-benchmark/Cargo.toml
+++ b/metrics-benchmark/Cargo.toml
@@ -3,6 +3,7 @@ name = "metrics-benchmark"
 version = "0.1.1-alpha.5"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
+rust-version = "1.56.1"
 publish = false
 
 [dependencies]

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -3,6 +3,7 @@ name = "metrics-exporter-prometheus"
 version = "0.10.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
+rust-version = "1.56.1"
 
 license = "MIT"
 

--- a/metrics-exporter-tcp/Cargo.toml
+++ b/metrics-exporter-tcp/Cargo.toml
@@ -3,6 +3,7 @@ name = "metrics-exporter-tcp"
 version = "0.6.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
+rust-version = "1.56.1"
 
 license = "MIT"
 

--- a/metrics-macros/Cargo.toml
+++ b/metrics-macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "metrics-macros"
 version = "0.5.1"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
+rust-version = "1.56.1"
 
 license = "MIT"
 

--- a/metrics-observer/Cargo.toml
+++ b/metrics-observer/Cargo.toml
@@ -3,6 +3,7 @@ name = "metrics-observer"
 version = "0.1.1-alpha.2"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
+rust-version = "1.56.1"
 publish = false
 
 license = "MIT"

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -3,6 +3,7 @@ name = "metrics-tracing-context"
 version = "0.11.0"
 authors = ["MOZGIII <mike-n@narod.ru>"]
 edition = "2018"
+rust-version = "1.56.1"
 
 license = "MIT"
 

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -3,6 +3,7 @@ name = "metrics-util"
 version = "0.13.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
+rust-version = "1.56.1"
 
 license = "MIT"
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -3,6 +3,7 @@ name = "metrics"
 version = "0.19.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
+rust-version = "1.56.1"
 
 license = "MIT"
 

--- a/tooling/metrics-histogram-fidelity/Cargo.toml
+++ b/tooling/metrics-histogram-fidelity/Cargo.toml
@@ -3,6 +3,7 @@ name = "metrics-histogram-fidelity"
 version = "0.1.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
+rust-version = "1.56.1"
 
 [workspace]
 


### PR DESCRIPTION
closes https://github.com/metrics-rs/metrics/issues/287

If there is a policy of when the MSRV can be bumped I would love to document that in the readme.