### PR TITLE
Change description to be `SharedString`

### DIFF
--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -4,7 +4,7 @@ use hdrhistogram::Histogram as HdrHistogram;
 use log::{error, info};
 use metrics::{
     gauge, histogram, increment_counter, register_counter, register_gauge, register_histogram,
-    Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit,
+    Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit,
 };
 use metrics_util::registry::{AtomicStorage, Registry};
 use quanta::{Clock, Instant as QuantaInstant};
@@ -62,11 +62,11 @@ impl BenchmarkingRecorder {
 }
 
 impl Recorder for BenchmarkingRecorder {
-    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: &'static str) {}
+    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
 
-    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: &'static str) {}
+    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
 
-    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: &'static str) {}
+    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
 
     fn register_counter(&self, key: &Key) -> Counter {
         self.registry.get_or_create_counter(key, |c| Counter::from_arc(c.clone()))

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -982,7 +982,7 @@ mod tests {
         let key_name = KeyName::from("yee_haw:lets go");
         let key = Key::from_name(key_name.clone())
             .with_extra_labels(vec![Label::new("øhno", "\"yeet\nies\\\"")]);
-        recorder.describe_counter(key_name, None, "\"Simplë stuff.\nRëally.\"");
+        recorder.describe_counter(key_name, None, "\"Simplë stuff.\nRëally.\"".into());
         let counter1 = recorder.register_counter(&key);
         counter1.increment(1);
 

--- a/metrics-exporter-tcp/src/lib.rs
+++ b/metrics-exporter-tcp/src/lib.rs
@@ -63,7 +63,7 @@ use bytes::Bytes;
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
 use metrics::{
     Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Recorder,
-    SetRecorderError, Unit,
+    SetRecorderError, SharedString, Unit,
 };
 use mio::{
     net::{TcpListener, TcpStream},
@@ -93,7 +93,7 @@ enum MetricOperation {
 }
 
 enum Event {
-    Metadata(KeyName, MetricType, Option<Unit>, &'static str),
+    Metadata(KeyName, MetricType, Option<Unit>, SharedString),
     Metric(Key, MetricOperation),
 }
 
@@ -152,7 +152,7 @@ impl State {
         key_name: KeyName,
         metric_type: MetricType,
         unit: Option<Unit>,
-        description: &'static str,
+        description: SharedString,
     ) {
         let _ = self.tx.try_send(Event::Metadata(key_name, metric_type, unit, description));
         self.wake();
@@ -303,15 +303,15 @@ impl Default for TcpBuilder {
 }
 
 impl Recorder for TcpRecorder {
-    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.state.register_metric(key_name, MetricType::Counter, unit, description);
     }
 
-    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.state.register_metric(key_name, MetricType::Gauge, unit, description);
     }
 
-    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.state.register_metric(key_name, MetricType::Histogram, unit, description);
     }
 
@@ -501,12 +501,13 @@ fn run_transport(
 
 #[allow(clippy::mutable_key_type)]
 fn generate_metadata_messages(
-    metadata: &HashMap<KeyName, (MetricType, Option<Unit>, Option<&'static str>)>,
+    metadata: &HashMap<KeyName, (MetricType, Option<Unit>, Option<SharedString>)>,
 ) -> VecDeque<Bytes> {
     let mut bufs = VecDeque::new();
     for (key_name, (metric_type, unit, desc)) in metadata.iter() {
-        let msg = convert_metadata_to_protobuf_encoded(key_name, *metric_type, *unit, *desc)
-            .expect("failed to encode metadata buffer");
+        let msg =
+            convert_metadata_to_protobuf_encoded(key_name, *metric_type, *unit, desc.as_ref())
+                .expect("failed to encode metadata buffer");
         bufs.push_back(msg);
     }
     bufs
@@ -562,14 +563,14 @@ fn convert_metadata_to_protobuf_encoded(
     key_name: &KeyName,
     metric_type: MetricType,
     unit: Option<Unit>,
-    desc: Option<&'static str>,
+    desc: Option<&SharedString>,
 ) -> Result<Bytes, EncodeError> {
     let name = key_name.as_str().to_string();
     let metadata = proto::Metadata {
         name,
         metric_type: metric_type.into(),
         unit: unit.map(|u| proto::metadata::Unit::UnitValue(u.as_str().to_owned())),
-        description: desc.map(|d| proto::metadata::Description::DescriptionValue(d.to_owned())),
+        description: desc.map(|d| proto::metadata::Description::DescriptionValue(d.to_string())),
     };
     let event = proto::Event { event: Some(proto::event::Event::Metadata(metadata)) };
 

--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -215,7 +215,7 @@ fn get_describe_code(
         {
             // Only do this work if there's a recorder installed.
             if let Some(recorder) = metrics::try_recorder() {
-                recorder.#describe_ident(#name.into(), #unit, #description);
+                recorder.#describe_ident(#name.into(), #unit, #description.into());
             }
         }
     }

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -16,7 +16,7 @@ fn test_get_describe_code() {
     let expected = concat!(
         "{ ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . describe_mytype (\"mykeyname\" . into () , None , \"a counter\") ; ",
+        "recorder . describe_mytype (\"mykeyname\" . into () , None , \"a counter\" . into ()) ; ",
         "} ",
         "}",
     );
@@ -38,7 +38,7 @@ fn test_get_describe_code_with_qualified_unit() {
     let expected = concat!(
         "{ ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . describe_mytype (\"mykeyname\" . into () , Some (metrics :: Unit :: Nanoseconds) , \"a counter\") ; ",
+        "recorder . describe_mytype (\"mykeyname\" . into () , Some (metrics :: Unit :: Nanoseconds) , \"a counter\" . into ()) ; ",
         "} ",
         "}",
     );
@@ -60,7 +60,7 @@ fn test_get_describe_code_with_relative_unit() {
     let expected = concat!(
         "{ ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . describe_mytype (\"mykeyname\" . into () , Some (Unit :: Nanoseconds) , \"a counter\") ; ",
+        "recorder . describe_mytype (\"mykeyname\" . into () , Some (Unit :: Nanoseconds) , \"a counter\" . into ()) ; ",
         "} ",
         "}",
     );
@@ -77,7 +77,7 @@ fn test_get_describe_code_with_constants() {
     let expected = concat!(
         "{ ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . describe_mytype (KEY_NAME . into () , None , COUNTER_DESC) ; ",
+        "recorder . describe_mytype (KEY_NAME . into () , None , COUNTER_DESC . into ()) ; ",
         "} ",
         "}",
     );
@@ -99,7 +99,7 @@ fn test_get_describe_code_with_constants_and_with_qualified_unit() {
     let expected = concat!(
         "{ ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . describe_mytype (KEY_NAME . into () , Some (metrics :: Unit :: Nanoseconds) , COUNTER_DESC) ; ",
+        "recorder . describe_mytype (KEY_NAME . into () , Some (metrics :: Unit :: Nanoseconds) , COUNTER_DESC . into ()) ; ",
         "} ",
         "}",
     );
@@ -121,7 +121,7 @@ fn test_get_describe_code_with_constants_and_with_relative_unit() {
     let expected = concat!(
         "{ ",
         "if let Some (recorder) = metrics :: try_recorder () { ",
-        "recorder . describe_mytype (KEY_NAME . into () , Some (Unit :: Nanoseconds) , COUNTER_DESC) ; ",
+        "recorder . describe_mytype (KEY_NAME . into () , Some (Unit :: Nanoseconds) , COUNTER_DESC . into ()) ; ",
         "} ",
         "}",
     );

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -95,7 +95,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Label, Recorder, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Label, Recorder, SharedString, Unit};
 use metrics_util::layers::Layer;
 
 pub mod label_filter;
@@ -203,15 +203,15 @@ where
     R: Recorder,
     F: LabelFilter,
 {
-    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.inner.describe_counter(key_name, unit, description)
     }
 
-    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.inner.describe_gauge(key_name, unit, description)
     }
 
-    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.inner.describe_histogram(key_name, unit, description)
     }
 

--- a/metrics-util/src/layers/fanout.rs
+++ b/metrics-util/src/layers/fanout.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use metrics::{
-    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Recorder, Unit,
+    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Recorder,
+    SharedString, Unit,
 };
 
 struct FanoutCounter {
@@ -100,21 +101,21 @@ pub struct Fanout {
 }
 
 impl Recorder for Fanout {
-    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         for recorder in &self.recorders {
-            recorder.describe_counter(key_name.clone(), unit, description);
+            recorder.describe_counter(key_name.clone(), unit, description.clone());
         }
     }
 
-    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         for recorder in &self.recorders {
-            recorder.describe_gauge(key_name.clone(), unit, description);
+            recorder.describe_gauge(key_name.clone(), unit, description.clone());
         }
     }
 
-    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         for recorder in &self.recorders {
-            recorder.describe_histogram(key_name.clone(), unit, description);
+            recorder.describe_histogram(key_name.clone(), unit, description.clone());
         }
     }
 
@@ -175,13 +176,17 @@ mod tests {
             RecorderOperation::DescribeCounter(
                 "counter_key".into(),
                 Some(Unit::Count),
-                "counter desc",
+                "counter desc".into(),
             ),
-            RecorderOperation::DescribeGauge("gauge_key".into(), Some(Unit::Bytes), "gauge desc"),
+            RecorderOperation::DescribeGauge(
+                "gauge_key".into(),
+                Some(Unit::Bytes),
+                "gauge desc".into(),
+            ),
             RecorderOperation::DescribeHistogram(
                 "histogram_key".into(),
                 Some(Unit::Nanoseconds),
-                "histogram desc",
+                "histogram desc".into(),
             ),
             RecorderOperation::RegisterCounter("counter_key".into(), Counter::noop()),
             RecorderOperation::RegisterGauge("gauge_key".into(), Gauge::noop()),

--- a/metrics-util/src/layers/filter.rs
+++ b/metrics-util/src/layers/filter.rs
@@ -1,6 +1,6 @@
 use crate::layers::Layer;
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
 
 /// Filters and discards metrics matching certain name patterns.
 ///
@@ -17,21 +17,21 @@ impl<R> Filter<R> {
 }
 
 impl<R: Recorder> Recorder for Filter<R> {
-    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         if self.should_filter(key_name.as_str()) {
             return;
         }
         self.inner.describe_counter(key_name, unit, description)
     }
 
-    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         if self.should_filter(key_name.as_str()) {
             return;
         }
         self.inner.describe_gauge(key_name, unit, description)
     }
 
-    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         if self.should_filter(key_name.as_str()) {
             return;
         }
@@ -159,27 +159,27 @@ mod tests {
             RecorderOperation::DescribeCounter(
                 "tokio.loops".into(),
                 Some(Unit::Count),
-                "counter desc",
+                "counter desc".into(),
             ),
             RecorderOperation::DescribeGauge(
                 "hyper.bytes_read".into(),
                 Some(Unit::Bytes),
-                "gauge desc",
+                "gauge desc".into(),
             ),
             RecorderOperation::DescribeHistogram(
                 "hyper.response_latency".into(),
                 Some(Unit::Nanoseconds),
-                "histogram desc",
+                "histogram desc".into(),
             ),
             RecorderOperation::DescribeCounter(
                 "tokio.spurious_wakeups".into(),
                 Some(Unit::Count),
-                "counter desc",
+                "counter desc".into(),
             ),
             RecorderOperation::DescribeGauge(
                 "bb8.pooled_conns".into(),
                 Some(Unit::Count),
-                "gauge desc",
+                "gauge desc".into(),
             ),
             RecorderOperation::RegisterCounter("tokio.loops".into(), Counter::noop()),
             RecorderOperation::RegisterGauge("hyper.bytes_read".into(), Gauge::noop()),
@@ -195,12 +195,12 @@ mod tests {
             RecorderOperation::DescribeGauge(
                 "hyper.bytes_read".into(),
                 Some(Unit::Bytes),
-                "gauge desc",
+                "gauge desc".into(),
             ),
             RecorderOperation::DescribeHistogram(
                 "hyper.response_latency".into(),
                 Some(Unit::Nanoseconds),
-                "histogram desc",
+                "histogram desc".into(),
             ),
             RecorderOperation::RegisterGauge("hyper.bytes_read".into(), Gauge::noop()),
             RecorderOperation::RegisterHistogram(
@@ -224,27 +224,27 @@ mod tests {
             RecorderOperation::DescribeCounter(
                 "tokiO.loops".into(),
                 Some(Unit::Count),
-                "counter desc",
+                "counter desc".into(),
             ),
             RecorderOperation::DescribeGauge(
                 "hyper.bytes_read".into(),
                 Some(Unit::Bytes),
-                "gauge desc",
+                "gauge desc".into(),
             ),
             RecorderOperation::DescribeHistogram(
                 "hyper.response_latency".into(),
                 Some(Unit::Nanoseconds),
-                "histogram desc",
+                "histogram desc".into(),
             ),
             RecorderOperation::DescribeCounter(
                 "Tokio.spurious_wakeups".into(),
                 Some(Unit::Count),
-                "counter desc",
+                "counter desc".into(),
             ),
             RecorderOperation::DescribeGauge(
                 "bB8.pooled_conns".into(),
                 Some(Unit::Count),
-                "gauge desc",
+                "gauge desc".into(),
             ),
             RecorderOperation::RegisterCounter("tokiO.loops".into(), Counter::noop()),
             RecorderOperation::RegisterGauge("hyper.bytes_read".into(), Gauge::noop()),
@@ -260,12 +260,12 @@ mod tests {
             RecorderOperation::DescribeGauge(
                 "hyper.bytes_read".into(),
                 Some(Unit::Bytes),
-                "gauge desc",
+                "gauge desc".into(),
             ),
             RecorderOperation::DescribeHistogram(
                 "hyper.response_latency".into(),
                 Some(Unit::Nanoseconds),
-                "histogram desc",
+                "histogram desc".into(),
             ),
             RecorderOperation::RegisterGauge("hyper.bytes_read".into(), Gauge::noop()),
             RecorderOperation::RegisterHistogram(

--- a/metrics-util/src/layers/mod.rs
+++ b/metrics-util/src/layers/mod.rs
@@ -8,7 +8,7 @@
 //! Here's an example of a layer that filters out all metrics that start with a specific string:
 //!
 //! ```rust
-//! # use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit};
+//! # use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
 //! # use metrics::NoopRecorder as BasicRecorder;
 //! # use metrics_util::layers::{Layer, Stack, PrefixLayer};
 //! // A simple layer that denies any metrics that have "stairway" or "heaven" in their name.
@@ -26,7 +26,7 @@
 //!         &self,
 //!         key_name: KeyName,
 //!         unit: Option<Unit>,
-//!         description: &'static str,
+//!         description: SharedString,
 //!     ) {
 //!         if self.is_invalid_key(key_name.as_str()) {
 //!             return;
@@ -34,7 +34,7 @@
 //!         self.0.describe_counter(key_name, unit, description)
 //!     }
 //!
-//!     fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+//!     fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
 //!         if self.is_invalid_key(key_name.as_str()) {
 //!             return;
 //!         }
@@ -45,7 +45,7 @@
 //!         &self,
 //!         key_name: KeyName,
 //!         unit: Option<Unit>,
-//!         description: &'static str,
+//!         description: SharedString,
 //!     ) {
 //!         if self.is_invalid_key(key_name.as_str()) {
 //!             return;
@@ -111,7 +111,7 @@
 //!     .expect("failed to install stack");
 //! # }
 //! ```
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
 
 use metrics::SetRecorderError;
 
@@ -167,15 +167,15 @@ impl<R: Recorder + 'static> Stack<R> {
 }
 
 impl<R: Recorder> Recorder for Stack<R> {
-    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.inner.describe_counter(key_name, unit, description);
     }
 
-    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.inner.describe_gauge(key_name, unit, description);
     }
 
-    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.inner.describe_histogram(key_name, unit, description);
     }
 

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -30,17 +30,17 @@ impl<R> Prefix<R> {
 }
 
 impl<R: Recorder> Recorder for Prefix<R> {
-    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         let new_key_name = self.prefix_key_name(key_name);
         self.inner.describe_counter(new_key_name, unit, description)
     }
 
-    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         let new_key_name = self.prefix_key_name(key_name);
         self.inner.describe_gauge(new_key_name, unit, description)
     }
 
-    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         let new_key_name = self.prefix_key_name(key_name);
         self.inner.describe_histogram(new_key_name, unit, description)
     }
@@ -94,13 +94,17 @@ mod tests {
             RecorderOperation::DescribeCounter(
                 "counter_key".into(),
                 Some(Unit::Count),
-                "counter desc",
+                "counter desc".into(),
             ),
-            RecorderOperation::DescribeGauge("gauge_key".into(), Some(Unit::Bytes), "gauge desc"),
+            RecorderOperation::DescribeGauge(
+                "gauge_key".into(),
+                Some(Unit::Bytes),
+                "gauge desc".into(),
+            ),
             RecorderOperation::DescribeHistogram(
                 "histogram_key".into(),
                 Some(Unit::Nanoseconds),
-                "histogram desc",
+                "histogram desc".into(),
             ),
             RecorderOperation::RegisterCounter("counter_key".into(), Counter::noop()),
             RecorderOperation::RegisterGauge("gauge_key".into(), Gauge::noop()),
@@ -111,17 +115,17 @@ mod tests {
             RecorderOperation::DescribeCounter(
                 "testing.counter_key".into(),
                 Some(Unit::Count),
-                "counter desc",
+                "counter desc".into(),
             ),
             RecorderOperation::DescribeGauge(
                 "testing.gauge_key".into(),
                 Some(Unit::Bytes),
-                "gauge desc",
+                "gauge desc".into(),
             ),
             RecorderOperation::DescribeHistogram(
                 "testing.histogram_key".into(),
                 Some(Unit::Nanoseconds),
-                "histogram desc",
+                "histogram desc".into(),
             ),
             RecorderOperation::RegisterCounter("testing.counter_key".into(), Counter::noop()),
             RecorderOperation::RegisterGauge("testing.gauge_key".into(), Gauge::noop()),

--- a/metrics-util/src/layers/router.rs
+++ b/metrics-util/src/layers/router.rs
@@ -1,4 +1,4 @@
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
 use radix_trie::{Trie, TrieCommon};
 
 use crate::{MetricKind, MetricKindMask};
@@ -39,17 +39,17 @@ impl Router {
 }
 
 impl Recorder for Router {
-    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         let target = self.route(MetricKind::Counter, key_name.as_str(), &self.counter_routes);
         target.describe_counter(key_name, unit, description)
     }
 
-    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         let target = self.route(MetricKind::Gauge, key_name.as_str(), &self.gauge_routes);
         target.describe_gauge(key_name, unit, description)
     }
 
-    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         let target = self.route(MetricKind::Histogram, key_name.as_str(), &self.histogram_routes);
         target.describe_histogram(key_name, unit, description)
     }
@@ -166,16 +166,16 @@ mod tests {
 
     use super::RouterBuilder;
     use crate::MetricKindMask;
-    use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit};
+    use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
 
     mock! {
         pub TestRecorder {
         }
 
         impl Recorder for TestRecorder {
-            fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str);
-            fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str);
-            fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str);
+            fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString);
+            fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString);
+            fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString);
             fn register_counter(&self, key: &Key) -> Counter;
             fn register_gauge(&self, key: &Key) -> Gauge;
             fn register_histogram(&self, key: &Key) -> Histogram;

--- a/metrics-util/src/test_util.rs
+++ b/metrics-util/src/test_util.rs
@@ -1,4 +1,4 @@
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
 use mockall::{
     mock,
     predicate::{self, eq},
@@ -7,9 +7,9 @@ use mockall::{
 
 #[derive(Clone)]
 pub enum RecorderOperation {
-    DescribeCounter(KeyName, Option<Unit>, &'static str),
-    DescribeGauge(KeyName, Option<Unit>, &'static str),
-    DescribeHistogram(KeyName, Option<Unit>, &'static str),
+    DescribeCounter(KeyName, Option<Unit>, SharedString),
+    DescribeGauge(KeyName, Option<Unit>, SharedString),
+    DescribeHistogram(KeyName, Option<Unit>, SharedString),
     RegisterCounter(Key, Counter),
     RegisterGauge(Key, Gauge),
     RegisterHistogram(Key, Histogram),
@@ -68,9 +68,9 @@ mock! {
     pub BasicRecorder {}
 
     impl Recorder for BasicRecorder {
-        fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str);
-        fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str);
-        fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str);
+        fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString);
+        fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString);
+        fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString);
         fn register_counter(&self, key: &Key) -> Counter;
         fn register_gauge(&self, key: &Key) -> Gauge;
         fn register_histogram(&self, key: &Key) -> Histogram;
@@ -94,7 +94,7 @@ pub fn expect_describe_counter(
     mock: &mut MockBasicRecorder,
     key_name: KeyName,
     unit: Option<Unit>,
-    description: &'static str,
+    description: SharedString,
 ) {
     mock.expect_describe_counter()
         .times(1)
@@ -106,7 +106,7 @@ pub fn expect_describe_gauge(
     mock: &mut MockBasicRecorder,
     key_name: KeyName,
     unit: Option<Unit>,
-    description: &'static str,
+    description: SharedString,
 ) {
     mock.expect_describe_gauge()
         .times(1)
@@ -118,7 +118,7 @@ pub fn expect_describe_histogram(
     mock: &mut MockBasicRecorder,
     key_name: KeyName,
     unit: Option<Unit>,
-    description: &'static str,
+    description: SharedString,
 ) {
     mock.expect_describe_histogram()
         .times(1)

--- a/metrics/benches/macros.rs
+++ b/metrics/benches/macros.rs
@@ -3,15 +3,15 @@ extern crate criterion;
 
 use criterion::Criterion;
 
-use metrics::{counter, Counter, Gauge, Histogram, Key, KeyName, Recorder, Unit};
+use metrics::{counter, Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
 use rand::{thread_rng, Rng};
 
 #[derive(Default)]
 struct TestRecorder;
 impl Recorder for TestRecorder {
-    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: &'static str) {}
-    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: &'static str) {}
-    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: &'static str) {}
+    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
     fn register_counter(&self, _: &Key) -> Counter {
         Counter::noop()
     }

--- a/metrics/examples/basic.rs
+++ b/metrics/examples/basic.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use metrics::{
     absolute_counter, counter, decrement_gauge, describe_counter, describe_gauge,
     describe_histogram, gauge, histogram, increment_counter, increment_gauge, register_counter,
-    register_gauge, register_histogram, KeyName,
+    register_gauge, register_histogram, KeyName, SharedString,
 };
 use metrics::{Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, Recorder, Unit};
 
@@ -50,7 +50,7 @@ impl HistogramFn for PrintHandle {
 struct PrintRecorder;
 
 impl Recorder for PrintRecorder {
-    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         println!(
             "(counter) registered key {} with unit {:?} and description {:?}",
             key_name.as_str(),
@@ -59,7 +59,7 @@ impl Recorder for PrintRecorder {
         );
     }
 
-    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         println!(
             "(gauge) registered key {} with unit {:?} and description {:?}",
             key_name.as_str(),
@@ -68,7 +68,7 @@ impl Recorder for PrintRecorder {
         );
     }
 
-    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: &'static str) {
+    fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         println!(
             "(histogram) registered key {} with unit {:?} and description {:?}",
             key_name.as_str(),

--- a/metrics/src/recorder.rs
+++ b/metrics/src/recorder.rs
@@ -1,5 +1,5 @@
 use self::cell::RecorderOnceCell;
-use crate::{Counter, Gauge, Histogram, Key, KeyName, Unit};
+use crate::{Counter, Gauge, Histogram, Key, KeyName, SharedString, Unit};
 use core::fmt;
 
 mod cell {
@@ -116,7 +116,7 @@ pub trait Recorder {
     /// not a metric can be reregistered to provide a unit/description, if one was already passed
     /// or not, as well as how units/descriptions are used by the underlying recorder, is an
     /// implementation detail.
-    fn describe_counter(&self, key: KeyName, unit: Option<Unit>, description: &'static str);
+    fn describe_counter(&self, key: KeyName, unit: Option<Unit>, description: SharedString);
 
     /// Describes a gauge.
     ///
@@ -124,7 +124,7 @@ pub trait Recorder {
     /// not a metric can be reregistered to provide a unit/description, if one was already passed
     /// or not, as well as how units/descriptions are used by the underlying recorder, is an
     /// implementation detail.
-    fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, description: &'static str);
+    fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, description: SharedString);
 
     /// Describes a histogram.
     ///
@@ -132,7 +132,7 @@ pub trait Recorder {
     /// not a metric can be reregistered to provide a unit/description, if one was already passed
     /// or not, as well as how units/descriptions are used by the underlying recorder, is an
     /// implementation detail.
-    fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, description: &'static str);
+    fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, description: SharedString);
 
     /// Registers a counter.
     fn register_counter(&self, key: &Key) -> Counter;
@@ -151,9 +151,9 @@ pub trait Recorder {
 pub struct NoopRecorder;
 
 impl Recorder for NoopRecorder {
-    fn describe_counter(&self, _key: KeyName, _unit: Option<Unit>, _description: &'static str) {}
-    fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: &'static str) {}
-    fn describe_histogram(&self, _key: KeyName, _unit: Option<Unit>, _description: &'static str) {}
+    fn describe_counter(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+    fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+    fn describe_histogram(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
     fn register_counter(&self, _key: &Key) -> Counter {
         Counter::noop()
     }


### PR DESCRIPTION
This makes it possible to describe metrics using both `&'static str` as well as from an owned string.

Solves #310 