### PR TITLE
Add openmetrics exemplar support

### DIFF
--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -51,6 +51,10 @@ required-features = ["push-gateway"]
 name = "prometheus_server"
 required-features = ["http-listener"]
 
+[[example]]
+name = "exemplars"
+required-features = ["http-listener"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/metrics-exporter-prometheus/examples/exemplars.rs
+++ b/metrics-exporter-prometheus/examples/exemplars.rs
@@ -1,0 +1,100 @@
+use std::thread;
+use std::time::Duration;
+
+use metrics::{
+    decrement_gauge, describe_counter, describe_histogram, gauge, histogram, increment_counter,
+    increment_gauge, Key, Label,
+};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusRecorder};
+use metrics_util::MetricKindMask;
+
+use quanta::Clock;
+use rand::{thread_rng, Rng};
+
+fn main() {
+    tracing_subscriber::fmt::init();
+
+    let builder = PrometheusBuilder::new();
+    builder
+        .idle_timeout(
+            MetricKindMask::COUNTER | MetricKindMask::HISTOGRAM,
+            Some(Duration::from_secs(10)),
+        )
+        .set_buckets(&[0.01, 0.1, 0.2, 0.5, 1., 2.])
+        .unwrap()
+        .install()
+        .expect("failed to install Prometheus recorder");
+
+    // We register these metrics, which gives us a chance to specify a description for them.  The
+    // Prometheus exporter records this description and adds it as HELP text when the endpoint is
+    // scraped.
+    //
+    // Registering metrics ahead of using them is not required, but is the only way to specify the
+    // description of a metric.
+    describe_counter!("tcp_server_loops", "The iterations of the TCP server event loop so far.");
+    describe_histogram!(
+        "tcp_server_loop_delta_secs",
+        "The time taken for iterations of the TCP server event loop."
+    );
+
+    let clock = Clock::new();
+    let mut last = None;
+
+    increment_counter!("idle_metric");
+    gauge!("testing", 42.0);
+
+    // Loop over and over, pretending to do some work.
+    loop {
+        let with_exemplar = thread_rng().gen_bool(0.75);
+        if with_exemplar {
+            let labels = vec![Label::new("system", "foo")];
+            let metric_key = Key::from_parts("tcp_server_loops", labels);
+            let recorder = metrics::recorder()
+                .downcast_ref::<PrometheusRecorder>()
+                .expect("Couldn't downcast to prometheus recorder");
+            let handler = recorder.register_counter_with_exemplar(&metric_key);
+            handler.increment_with_exemplar(1, vec![Label::new("trace_id", "xyasfj234234")]);
+        } else {
+            increment_counter!("tcp_server_loops", "system" => "foo");
+        }
+
+        if let Some(t) = last {
+            let delta: Duration = clock.now() - t;
+            if with_exemplar {
+                let labels = vec![Label::new("system", "foo")];
+                let metric_key = Key::from_parts("tcp_server_loops", labels);
+                let recorder = metrics::recorder()
+                    .downcast_ref::<PrometheusRecorder>()
+                    .expect("Couldn't downcast to prometheus recorder");
+                let distribution = recorder.get_distribution(metric_key.name());
+                let handler = recorder.register_histogram_with_exemplar(&metric_key);
+                handler.record_with_exemplar(
+                    distribution,
+                    metrics::__into_f64(delta),
+                    vec![Label::new("trace_id", "xyasfj234234")],
+                );
+            } else {
+                histogram!("tcp_server_loop_delta_secs", delta, "system" => "foo");
+            }
+        }
+
+        let increment_gauge = thread_rng().gen_bool(0.75);
+        if increment_gauge {
+            increment_gauge!("lucky_iterations", 1.0);
+        } else {
+            decrement_gauge!("lucky_iterations", 1.0);
+        }
+
+        last = Some(clock.now());
+
+        let render = thread_rng().gen_bool(0.1);
+        if render {
+            let recorder = metrics::recorder()
+                .downcast_ref::<PrometheusRecorder>()
+                .expect("Couldn't downcast to prometheus recorder");
+            println!("{}", recorder.handle().render());
+        }
+
+        thread::sleep(Duration::from_millis(750));
+    }
+}

--- a/metrics-exporter-prometheus/src/common.rs
+++ b/metrics-exporter-prometheus/src/common.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::distribution::Distribution;
 
 use crate::formatting::sanitize_metric_name;
+use crate::registry::Exemplar;
 use indexmap::IndexMap;
 use metrics::SetRecorderError;
 use thiserror::Error;
@@ -77,7 +78,8 @@ pub enum BuildError {
 }
 
 pub struct Snapshot {
-    pub counters: HashMap<String, HashMap<Vec<String>, u64>>,
-    pub gauges: HashMap<String, HashMap<Vec<String>, f64>>,
-    pub distributions: HashMap<String, IndexMap<Vec<String>, Distribution>>,
+    pub counters: HashMap<String, HashMap<Vec<String>, (u64, Option<Exemplar<u64>>)>>,
+    pub gauges: HashMap<String, HashMap<Vec<String>, (f64, Option<Exemplar<f64>>)>>,
+    pub distributions:
+        HashMap<String, IndexMap<Vec<String>, (Distribution, HashMap<usize, Exemplar<f64>>)>>,
 }

--- a/metrics-exporter-prometheus/src/lib.rs
+++ b/metrics-exporter-prometheus/src/lib.rs
@@ -115,3 +115,7 @@ mod recorder;
 mod registry;
 
 pub use self::recorder::{PrometheusHandle, PrometheusRecorder};
+
+pub use self::registry::Counter;
+pub use self::registry::Gauge;
+pub use self::registry::Histogram;

--- a/metrics-exporter-prometheus/src/registry.rs
+++ b/metrics-exporter-prometheus/src/registry.rs
@@ -1,31 +1,64 @@
+use parking_lot::RwLock;
 use portable_atomic::AtomicU64;
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::SystemTime;
 
-use metrics::HistogramFn;
-use metrics_util::registry::GenerationalStorage;
+use metrics::{CounterFn, GaugeFn, HistogramFn, Key, Label};
+use metrics_util::registry::{Generational, GenerationalStorage};
 use metrics_util::AtomicBucket;
 use quanta::Instant;
+
+use crate::Distribution;
 
 pub type GenerationalAtomicStorage = GenerationalStorage<AtomicStorage>;
 
 /// Atomic metric storage for the prometheus exporter.
 pub struct AtomicStorage;
 
-impl<K> metrics_util::registry::Storage<K> for AtomicStorage {
-    type Counter = Arc<AtomicU64>;
-    type Gauge = Arc<AtomicU64>;
-    type Histogram = Arc<AtomicBucketInstant<f64>>;
+#[derive(Clone)]
+pub struct Exemplar<T> {
+    pub value: T,
+    pub timestamp: SystemTime,
+    pub labels: Vec<Label>, // TODO this needs to be validated to its max len, 128 utf-8 characters, excluding ,="
+}
 
-    fn counter(&self, _: &K) -> Self::Counter {
-        Arc::new(AtomicU64::new(0))
+pub type CounterInner = (AtomicU64, RwLock<Option<Exemplar<u64>>>);
+pub type GaugeInner = (AtomicU64, RwLock<Option<Exemplar<f64>>>);
+pub type HistogramInner = (AtomicBucketInstant<f64>, RwLock<HashMap<usize, Exemplar<f64>>>);
+
+/// A counter with exemplar.clone
+pub struct Counter {
+    inner: Arc<CounterInner>,
+}
+/// A gauge with exemplar.
+pub struct Gauge {
+    inner: Arc<GaugeInner>,
+}
+/// A histogram with exemplar.
+pub struct Histogram {
+    inner: Arc<HistogramInner>,
+    name: String,
+}
+
+impl metrics_util::registry::Storage<Key> for AtomicStorage {
+    type Counter = Arc<Counter>;
+    type Gauge = Arc<Gauge>;
+    type Histogram = Arc<Histogram>;
+
+    fn counter(&self, _: &Key) -> Self::Counter {
+        Arc::new(Counter { inner: Arc::new((AtomicU64::new(0), RwLock::new(None))) })
     }
 
-    fn gauge(&self, _: &K) -> Self::Gauge {
-        Arc::new(AtomicU64::new(0))
+    fn gauge(&self, _: &Key) -> Self::Gauge {
+        Arc::new(Gauge { inner: Arc::new((AtomicU64::new(0), RwLock::new(None))) })
     }
 
-    fn histogram(&self, _: &K) -> Self::Histogram {
-        Arc::new(AtomicBucketInstant::new())
+    fn histogram(&self, key: &Key) -> Self::Histogram {
+        Arc::new(Histogram {
+            inner: Arc::new((AtomicBucketInstant::new(), RwLock::new(HashMap::new()))),
+            name: key.name().to_owned(),
+        })
     }
 }
 
@@ -47,9 +80,120 @@ impl<T> AtomicBucketInstant<T> {
     }
 }
 
-impl HistogramFn for AtomicBucketInstant<f64> {
+impl HistogramFn for Histogram {
     fn record(&self, value: f64) {
         let now = Instant::now();
-        self.inner.push((value, now));
+        self.inner.0.inner.push((value, now));
+    }
+}
+
+impl CounterFn for Counter {
+    fn increment(&self, value: u64) {
+        CounterFn::increment(&self.inner.0, value);
+    }
+
+    fn absolute(&self, value: u64) {
+        CounterFn::absolute(&self.inner.0, value);
+    }
+}
+
+impl GaugeFn for Gauge {
+    fn increment(&self, value: f64) {
+        GaugeFn::increment(&self.inner.0, value);
+    }
+
+    fn decrement(&self, value: f64) {
+        GaugeFn::decrement(&self.inner.0, value);
+    }
+
+    fn set(&self, value: f64) {
+        GaugeFn::set(&self.inner.0, value);
+    }
+}
+
+impl Counter {
+    /// Increment the counter by `value` and sets an exemplar.
+    pub fn increment_with_exemplar(&self, value: u64, exemplar_labels: Vec<Label>) {
+        CounterFn::increment(&self.inner.0, value);
+        self.inner.1.write().replace(Exemplar {
+            value,
+            timestamp: SystemTime::now(),
+            labels: exemplar_labels,
+        });
+    }
+
+    /// Gets a reference to the inner value.
+    pub fn get_inner(&self) -> &CounterInner {
+        &self.inner
+    }
+}
+
+impl Gauge {
+    /// Increment the gauge by `value` and sets an exemplar.
+    pub fn increment_with_exemplar(&self, value: f64, exemplar_labels: Vec<Label>) {
+        GaugeFn::increment(&self.inner.0, value);
+        self.inner.1.write().replace(Exemplar {
+            value,
+            timestamp: SystemTime::now(),
+            labels: exemplar_labels,
+        });
+    }
+    /// Decrement the gauge by `value` and sets an exemplar.
+    pub fn decrement_with_exemplar(&self, value: f64, exemplar_labels: Vec<Label>) {
+        GaugeFn::decrement(&self.inner.0, value);
+        self.inner.1.write().replace(Exemplar {
+            value,
+            timestamp: SystemTime::now(),
+            labels: exemplar_labels,
+        });
+    }
+
+    /// Gets a reference to the inner value.
+    pub fn get_inner(&self) -> &GaugeInner {
+        &self.inner
+    }
+}
+
+impl Histogram {
+    /// Record `value` in histogram and sets an exemplar.
+    pub fn record_with_exemplar(
+        &self,
+        distribution: Distribution,
+        value: f64,
+        exemplar_labels: Vec<Label>,
+    ) {
+        HistogramFn::record(self, value);
+
+        let bucket_idx = match distribution {
+            Distribution::Histogram(histogram) => histogram.bucket_index(value),
+            Distribution::Summary(_, _, _) => 0, // TODO(fredr): needs fix, look into how this should work for quantiles
+        };
+
+        self.get_inner().1.write().insert(
+            bucket_idx,
+            Exemplar { value, timestamp: SystemTime::now(), labels: exemplar_labels },
+        );
+    }
+
+    /// Gets a reference to the inner value.
+    pub fn get_inner(&self) -> &HistogramInner {
+        &self.inner
+    }
+}
+
+impl From<Generational<Arc<Counter>>> for Counter {
+    fn from(inner: Generational<Arc<Counter>>) -> Self {
+        Self { inner: inner.get_inner().inner.clone() }
+    }
+}
+impl From<Generational<Arc<Gauge>>> for Gauge {
+    fn from(inner: Generational<Arc<Gauge>>) -> Self {
+        Self { inner: inner.get_inner().inner.clone() }
+    }
+}
+impl From<Generational<Arc<Histogram>>> for Histogram {
+    fn from(inner: Generational<Arc<Histogram>>) -> Self {
+        let inner = inner.get_inner().clone();
+        Self { inner: inner.inner.clone(), name: inner.name.clone() }
     }
 }

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -200,8 +200,8 @@ where
 
 impl<R, F> Recorder for TracingContext<R, F>
 where
-    R: Recorder,
-    F: LabelFilter,
+    R: Recorder + 'static,
+    F: LabelFilter + 'static,
 {
     fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.inner.describe_counter(key_name, unit, description)

--- a/metrics-util/src/histogram.rs
+++ b/metrics-util/src/histogram.rs
@@ -60,6 +60,16 @@ impl Histogram {
         }
     }
 
+    /// Find the upper bucket for sample
+    pub fn bucket_index(&self, sample: f64) -> usize {
+        self.bounds
+            .iter()
+            .enumerate()
+            .find(|(_, bucket)| **bucket >= sample)
+            .map(|(idx, _)| idx)
+            .unwrap_or_else(|| self.bounds.len()) // TODO(fredr): is this inf+? or how does that work?
+    }
+
     /// Records multiple samples.
     pub fn record_many<'a, S>(&mut self, samples: S)
     where

--- a/metrics-util/src/layers/filter.rs
+++ b/metrics-util/src/layers/filter.rs
@@ -16,7 +16,7 @@ impl<R> Filter<R> {
     }
 }
 
-impl<R: Recorder> Recorder for Filter<R> {
+impl<R: Recorder + 'static> Recorder for Filter<R> {
     fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         if self.should_filter(key_name.as_str()) {
             return;

--- a/metrics-util/src/layers/mod.rs
+++ b/metrics-util/src/layers/mod.rs
@@ -21,7 +21,7 @@
 //!     }
 //! }
 //!
-//! impl<R: Recorder> Recorder for StairwayDeny<R> {
+//! impl<R: Recorder + 'static> Recorder for StairwayDeny<R> {
 //!     fn describe_counter(
 //!         &self,
 //!         key_name: KeyName,
@@ -166,7 +166,7 @@ impl<R: Recorder + 'static> Stack<R> {
     }
 }
 
-impl<R: Recorder> Recorder for Stack<R> {
+impl<R: Recorder + 'static> Recorder for Stack<R> {
     fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         self.inner.describe_counter(key_name, unit, description);
     }

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -29,7 +29,7 @@ impl<R> Prefix<R> {
     }
 }
 
-impl<R: Recorder> Recorder for Prefix<R> {
+impl<R: Recorder + 'static> Recorder for Prefix<R> {
     fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString) {
         let new_key_name = self.prefix_key_name(key_name);
         self.inner.describe_counter(new_key_name, unit, description)


### PR DESCRIPTION
This is a work in progress implementation for #175 

Opening this as a draft to have a discussion to see if this is a valid approach to go forward with, or if there is a different path that is cleaner/better.

I've tried to keep all changes to the prometheus exporter, as this is a prometheus-specific feature, but have had to add downcasting to the recorder, so that a handle to the specific recorder can be fetched. But maybe there is some more generic api that can be used. I'm not very familiar with other metrics systems, but maybe it is common to add additional data to observations?

There is an example of how to increase a counter and record a sample in a histogram with exemplars. This is extra problematic for histograms, as we need to know what bucket to assign the exemplar with.

I'm also thinking about what would be a good macro api for this. Since an exemplar is just an other set of labels, we can't just add it as an other parameter.

e.g. with the following its hard to know what labels should be metric labels and which should be exemplar labels 
```
counter_with_exemplar!("my_counter", "some_label" => "value", "trace_id" => "123");
```
We could probably say that exemplar labels are always expressions, so something like would probably be possible (I haven't written any macros, but I'm guessing this is possilbe)
```
counter_with_exemplar!("my_counter", vec![Label::from_parts("trace_id", "123")], "some_label" => "value");
counter_with_exemplar!("my_counter_without_labels", vec![Label::from_parts("trace_id", "123")]);
```
It might be confusing still, as it is easy to mix the different labels up.

Also, where would these macros live? I don't think we can add them to metrics-macros (behind a feature), since that would be a cyclic dependency if it needed to depend on the PrometheusRecorder.
