### PR TITLE
Removes the std-atomic feature

### DIFF
--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -25,10 +25,6 @@ bench = false
 name = "macros"
 harness = false
 
-[features]
-default = ["std-atomics"]
-std-atomics = []
-
 [dependencies]
 metrics-macros = { version = "^0.6", path = "../metrics-macros" }
 ahash = { version = "0.7", default-features = false }

--- a/metrics/src/handles.rs
+++ b/metrics/src/handles.rs
@@ -188,52 +188,6 @@ impl GaugeFn for AtomicU64 {
     }
 }
 
-#[cfg(feature = "std-atomics")]
-impl CounterFn for std::sync::atomic::AtomicU64 {
-    fn increment(&self, value: u64) {
-        let _ = self.fetch_add(value, Ordering::Release);
-    }
-
-    fn absolute(&self, value: u64) {
-        let _ = self.fetch_max(value, Ordering::AcqRel);
-    }
-}
-
-#[cfg(feature = "std-atomics")]
-impl GaugeFn for std::sync::atomic::AtomicU64 {
-    fn increment(&self, value: f64) {
-        loop {
-            let result = self.fetch_update(Ordering::AcqRel, Ordering::Relaxed, |curr| {
-                let input = f64::from_bits(curr);
-                let output = input + value;
-                Some(output.to_bits())
-            });
-
-            if result.is_ok() {
-                break;
-            }
-        }
-    }
-
-    fn decrement(&self, value: f64) {
-        loop {
-            let result = self.fetch_update(Ordering::AcqRel, Ordering::Relaxed, |curr| {
-                let input = f64::from_bits(curr);
-                let output = input - value;
-                Some(output.to_bits())
-            });
-
-            if result.is_ok() {
-                break;
-            }
-        }
-    }
-
-    fn set(&self, value: f64) {
-        let _ = self.swap(value.to_bits(), Ordering::AcqRel);
-    }
-}
-
 impl<T> CounterFn for Arc<T>
 where
     T: CounterFn,


### PR DESCRIPTION
The std-atomic feature is not required as the portable atomics library will fall back to native atomics when there are available.

Additionally, having a std-atomics feature as a default prevents the other metrics libraries such as metrics-util, from being used on 32 bit archs.

Fixes https://github.com/metrics-rs/metrics/issues/323