### PR TITLE
Use `portable-atomic` only for 32-bit architectures

### DIFF
--- a/metrics-benchmark/Cargo.toml
+++ b/metrics-benchmark/Cargo.toml
@@ -12,6 +12,5 @@ pretty_env_logger = "0.4"
 getopts = "0.2"
 hdrhistogram = { version = "7.2", default-features = false }
 quanta = "0.10.0"
-portable-atomic = "0.3"
 metrics = { version = "^0.20", path = "../metrics" }
 metrics-util = { version = "^0.14", path = "../metrics-util" }

--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -3,10 +3,9 @@ use hdrhistogram::Histogram as HdrHistogram;
 use log::{error, info};
 use metrics::{
     gauge, histogram, increment_counter, register_counter, register_gauge, register_histogram,
-    Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit,
+    AtomicU64, Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit,
 };
 use metrics_util::registry::{AtomicStorage, Registry};
-use portable_atomic::AtomicU64;
 use quanta::{Clock, Instant as QuantaInstant};
 use std::{
     env,

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -29,7 +29,6 @@ parking_lot = { version = "0.12", default-features = false }
 thiserror = { version = "1", default-features = false }
 quanta = { version = "0.10.0", default-features = false }
 indexmap = { version = "1", default-features = false }
-portable-atomic = "0.3"
 
 # Optional
 hyper = { version = "0.14", default-features = false, features = ["tcp", "http1"], optional = true }

--- a/metrics-exporter-prometheus/src/registry.rs
+++ b/metrics-exporter-prometheus/src/registry.rs
@@ -1,7 +1,6 @@
-use portable_atomic::AtomicU64;
 use std::sync::Arc;
 
-use metrics::HistogramFn;
+use metrics::{AtomicU64, HistogramFn};
 use metrics_util::registry::GenerationalStorage;
 use metrics_util::AtomicBucket;
 use quanta::Instant;

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -50,7 +50,6 @@ required-features = ["handles"]
 metrics = { version = "^0.20", path = "../metrics" }
 crossbeam-epoch = { version = "0.9.2", default-features = false, optional = true, features = ["alloc", "std"] }
 crossbeam-utils = { version = "0.8", default-features = false, optional = true }
-portable-atomic = { version = "0.3", optional = true }
 aho-corasick = { version = "0.7", default-features = false, optional = true, features = ["std"] }
 indexmap = { version = "1", default-features = false, optional = true }
 parking_lot = { version = "0.12", default-features = false, optional = true }
@@ -90,4 +89,4 @@ layer-filter = ["aho-corasick"]
 layer-router = ["radix_trie"]
 summary = ["sketches-ddsketch"]
 recency = ["parking_lot", "registry", "quanta"]
-registry = ["portable-atomic", "crossbeam-epoch", "crossbeam-utils", "handles", "hashbrown", "num_cpus", "parking_lot"]
+registry = ["crossbeam-epoch", "crossbeam-utils", "handles", "hashbrown", "num_cpus", "parking_lot"]

--- a/metrics-util/src/registry/mod.rs
+++ b/metrics-util/src/registry/mod.rs
@@ -393,8 +393,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use metrics::{CounterFn, Key};
-    use portable_atomic::AtomicU64;
+    use metrics::{AtomicU64, CounterFn, Key};
 
     use super::Registry;
     use std::sync::{atomic::Ordering, Arc};

--- a/metrics-util/src/registry/storage.rs
+++ b/metrics-util/src/registry/storage.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use metrics::{CounterFn, GaugeFn, HistogramFn};
-use portable_atomic::AtomicU64;
+use metrics::{AtomicU64, CounterFn, GaugeFn, HistogramFn};
 
 use crate::AtomicBucket;
 

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+
+### Changed
+
+- Only use `portable_atomic::AtomicU64` for 32-bit platforms, for 64-bit platforms use std.
+
+### Added
+
+- Re-export `AtomicU64` so one have an easy and convenient way to get the used atomic counter type regardless if one 32-bit or 64-bit architectures and without depending on external crates when using this crate.
+
+### Removed
+
+- Removed the `std-atomics` Cargo feature as it is not longer needed
 
 ## [0.20.1] - 2022-07-22
 
@@ -43,11 +56,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.18.1] - 2022-03-10
 
 ### Added
+
 - Slices of string key/value tuples can now be passed as the labels expression in macros. ([#277](https://github.com/metrics-rs/metrics/pull/277))
 
 ## [0.18.0] - 2022-01-14
 
 ### Added
+
 - A new macro, `absolute_counter!`, for setting the value of a counter to an absolute value.
 - A new wrapper type, `KeyName`, which encapsulates creating the name portion of a `Key`.  Existing
   methods for building a `Key`, as well as implicit conversion trait implementations, allow this to
@@ -57,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   traits, even `&'static str` constants will cause allocations when used for emitting a metric.
 
 ### Changed
+
 - Switched to metric handles through the `Recorder` API.
   ([#240](https://github.com/metrics-rs/metrics/pull/240)).  Due to the size of this change, the
   details are further documented and discussed in [RELEASES.md](RELEASES.md).
@@ -64,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When describing a metric via the `describe_*` macros, the description is no longer optional.
 
 ### Removed
+
 - Removed the `std` feature flag, as `metrics` depends too heavily on `std`-based types and as such
   was not meaningfully usaable when the `std` feature flag was disabled.  This will be revisited in
   the future.
@@ -71,59 +88,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.1] - 2021-12-16
 
 ### Changed
+
 - Removed unnecessary `proc-macro-hack` dependency.
 
 ## [0.17.0] - 2021-07-13
 
 ### Changed
+
 - Switched from `t1ha` to `ahash` for the key hasher.
 
 ## [0.16.0] - 2021-05-18
 
 ### Removed
+
 - `NameParts` has been removed to simplify metric names, again relying on a single string which is
   still backed by copy-on-write storage.
 
 ## [0.15.1] - 2021-05-03
+
 ### Changed
+
 - Nothing.  Fixed an issue with using the wrong dependency version during a mass release of
   workspace crates.
 
 ## [0.15.0] - 2021-05-03
+
 ### Changed
+
 - Switched from `Key` to `&Key` in `Recorder`.
 - Refactored `KeyData` into `Key`.
 
 ### Added
+
 - Metric keys are now pre-hashed/memoized where possible, which provides a massive speedup to
   hashing operations over time.
+
 ## [0.14.2] - 2021-02-13
+
 ### Added
+
 - Implemented `Ord`/`PartialOrd` for various key-related types.
 
 ## [0.14.1] - 2021-02-02
+
 ### Added
+
 - Minor documentation test updates for better coverage of owned strings used as metric names.
 
 ## [0.14.0] - 2021-02-02
+
 ### Changed
+
 - Added support for owned strings as metric names. [#170](https://github.com/metrics-rs/metrics/pull/170)
 
 ## [0.13.1] - 2021-01-23
+
 ### Added
+
 - Added conversion from `std::borrow::Cow<'static, str>` for `SharedString`.
 
 ## [0.13.0] - 2021-01-22
+
 ### Added
+
 - New macros for registration: `register_counter!`, `register_gauge!`, `register_histogram!`.
 - New macros for emission: `histogram!`, `increment_counter!`, `increment_gauge!`,
   `decrement_gauge!`.
 - Added unit support to describe the unit of a given metric.
 
 ### Removed
+
 - Dropped the `timing!` and `value!` macros in favor of `histogram!`.
 
 ### Changed
+
 - All macros are now procedural macros instead of declarative macros.
 - Gauges are now `f64` instead of `i64`.
 - Histograms are now `f64` instead of `u64`.
@@ -132,19 +170,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Significant overhaul of generated callsites via macros.
 
 ## [0.12.1] - 2019-11-21
+
 ### Changed
+
 - Cost for macros dropped to almost zero when no recorder is installed. ([#55](https://github.com/metrics-rs/metrics/pull/55))
 
 ## [0.12.0] - 2019-10-18
+
 ### Changed
+
 - Improved documentation. (#44, #45, #46)
 - Renamed `Recorder::record_counter` to `increment_counter` and `Recorder::record_gauge` to `update_gauge`. ([#47](https://github.com/metrics-rs/metrics/pull/47))
 
 ## [0.11.1] - 2019-08-09
+
 ### Changed
+
 - Fixed a bug with macros calling inner macros without a fully qualified name.
 
 ## [0.11.0] - 2019-07-29
+
 ### Added
+
 - Life begins at 0.11.0 for this crate, after being renamed from `metrics-facade` to `metrics` to
   reflect the duality of `metrics` to the `log` crate. (#27)

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -26,12 +26,13 @@ name = "macros"
 harness = false
 
 [features]
-default = ["std-atomics"]
-std-atomics = []
+default = []
 
 [dependencies]
 metrics-macros = { version = "^0.6", path = "../metrics-macros" }
 ahash = { version = "0.7", default-features = false }
+
+[target.'cfg(target_pointer_width = "32")'.dependencies]
 portable-atomic = "0.3"
 
 [dev-dependencies]

--- a/metrics/src/handles.rs
+++ b/metrics/src/handles.rs
@@ -1,4 +1,4 @@
-use portable_atomic::AtomicU64;
+use crate::AtomicU64;
 use std::sync::{atomic::Ordering, Arc};
 
 use crate::IntoF64;
@@ -155,52 +155,6 @@ impl CounterFn for AtomicU64 {
 }
 
 impl GaugeFn for AtomicU64 {
-    fn increment(&self, value: f64) {
-        loop {
-            let result = self.fetch_update(Ordering::AcqRel, Ordering::Relaxed, |curr| {
-                let input = f64::from_bits(curr);
-                let output = input + value;
-                Some(output.to_bits())
-            });
-
-            if result.is_ok() {
-                break;
-            }
-        }
-    }
-
-    fn decrement(&self, value: f64) {
-        loop {
-            let result = self.fetch_update(Ordering::AcqRel, Ordering::Relaxed, |curr| {
-                let input = f64::from_bits(curr);
-                let output = input - value;
-                Some(output.to_bits())
-            });
-
-            if result.is_ok() {
-                break;
-            }
-        }
-    }
-
-    fn set(&self, value: f64) {
-        let _ = self.swap(value.to_bits(), Ordering::AcqRel);
-    }
-}
-
-#[cfg(feature = "std-atomics")]
-impl CounterFn for std::sync::atomic::AtomicU64 {
-    fn increment(&self, value: u64) {
-        let _ = self.fetch_add(value, Ordering::Release);
-    }
-
-    fn absolute(&self, value: u64) {
-        let _ = self.fetch_max(value, Ordering::AcqRel);
-    }
-}
-
-#[cfg(feature = "std-atomics")]
-impl GaugeFn for std::sync::atomic::AtomicU64 {
     fn increment(&self, value: f64) {
         loop {
             let result = self.fetch_update(Ordering::AcqRel, Ordering::Relaxed, |curr| {

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -1,7 +1,7 @@
+use crate::AtomicU64;
 use crate::{cow::Cow, IntoLabels, KeyHasher, Label, SharedString};
 use alloc::{string::String, vec::Vec};
 use core::{fmt, hash::Hash, slice::Iter};
-use portable_atomic::AtomicU64;
 use std::{
     cmp,
     hash::Hasher,

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -799,3 +799,8 @@ pub use metrics_macros::decrement_gauge;
 /// # }
 /// ```
 pub use metrics_macros::histogram;
+
+#[cfg(target_pointer_width = "32")]
+pub use portable_atomic::AtomicU64;
+#[cfg(target_pointer_width = "64")]
+pub use std::sync::atomic::AtomicU64;


### PR DESCRIPTION
A new take on how to use the atomics without bringing in the `portable-atomic` crate for 64-bit architectures where one can use just `std`.  

Believe this approach could satisfy the requirements, and be easier to use for everyone, but I'm not super familiar with this crate so may have missed something also.

Resolves #346
Resolves #323

### Changed

- Only use `portable_atomic::AtomicU64` for 32-bit platforms, for 64-bit platforms use std.

### Added

- Re-export `AtomicU64` so one have an easy and convenient way to get the used atomic counter type regardless if one 32-bit or 64-bit architectures and without depending on external crates when using this crate.

### Removed

- Removed the `std-atomics` Cargo feature as it is not longer needed