### PR TITLE
Add PrometheusHandle::compact

### DIFF
--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -276,4 +276,9 @@ impl PrometheusHandle {
     pub fn render(&self) -> String {
         self.inner.render()
     }
+
+    /// Clear the idle metrics and compact histogram measurements to save the memory.
+    pub fn compact(&self) {
+        let _ = self.inner.get_recent_metrics();
+    }
 }


### PR DESCRIPTION
#245 

Expose get_recent_metrics() so users don't have to call render() to save the memory.
