### PR TITLE
Impl From<std::borrow::Cow> for KeyName

### DIFF
--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -35,6 +35,12 @@ impl From<String> for KeyName {
         KeyName(SharedString::from(name))
     }
 }
+
+impl From<std::borrow::Cow<'static, str>> for KeyName {
+    fn from(name: std::borrow::Cow<'static, str>) -> Self {
+        KeyName(SharedString::from(name))
+    }
+}
 /// A metric identifier.
 ///
 /// A key represents both the name and labels of a metric.


### PR DESCRIPTION
This adds conversion from std::borrow::Cow<'static, str> to KeyName.

This is for [issue 377](https://github.com/metrics-rs/metrics/issues/377)