### PR TITLE
Add metadata to metrics

### DIFF
--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -3,7 +3,7 @@ use hdrhistogram::Histogram as HdrHistogram;
 use log::{error, info};
 use metrics::{
     gauge, histogram, increment_counter, register_counter, register_gauge, register_histogram,
-    Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit,
+    Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit,
 };
 use metrics_util::registry::{AtomicStorage, Registry};
 use portable_atomic::AtomicU64;
@@ -68,15 +68,15 @@ impl Recorder for BenchmarkingRecorder {
 
     fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
         self.registry.get_or_create_counter(key, |c| Counter::from_arc(c.clone()))
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
         self.registry.get_or_create_gauge(key, |g| Gauge::from_arc(g.clone()))
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
         self.registry.get_or_create_histogram(key, |h| Histogram::from_arc(h.clone()))
     }
 }

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -579,13 +579,21 @@ mod tests {
 
     use super::{Matcher, PrometheusBuilder};
 
+    static METADATA: metrics::Metadata = metrics::Metadata::new(
+        module_path!(),
+        metrics::Level::INFO,
+        Some(module_path!()),
+        Some(file!()),
+        Some(line!()),
+    );
+
     #[test]
     fn test_render() {
         let recorder =
             PrometheusBuilder::new().set_quantiles(&[0.0, 1.0]).unwrap().build_recorder();
 
         let key = Key::from_name("basic_counter");
-        let counter1 = recorder.register_counter(&key);
+        let counter1 = recorder.register_counter(&key, &METADATA);
         counter1.increment(42);
 
         let handle = recorder.handle();
@@ -596,7 +604,7 @@ mod tests {
 
         let labels = vec![Label::new("wutang", "forever")];
         let key = Key::from_parts("basic_gauge", labels);
-        let gauge1 = recorder.register_gauge(&key);
+        let gauge1 = recorder.register_gauge(&key, &METADATA);
         gauge1.set(-3.14);
         let rendered = handle.render();
         let expected_gauge = format!(
@@ -607,7 +615,7 @@ mod tests {
         assert_eq!(rendered, expected_gauge);
 
         let key = Key::from_name("basic_histogram");
-        let histogram1 = recorder.register_histogram(&key);
+        let histogram1 = recorder.register_histogram(&key, &METADATA);
         histogram1.record(12.0);
         let rendered = handle.render();
 
@@ -649,19 +657,19 @@ mod tests {
             .build_recorder();
 
         let full_key = Key::from_name("metrics.testing_foo");
-        let full_key_histo = recorder.register_histogram(&full_key);
+        let full_key_histo = recorder.register_histogram(&full_key, &METADATA);
         full_key_histo.record(FULL_VALUES[0]);
 
         let prefix_key = Key::from_name("metrics.testing_bar");
-        let prefix_key_histo = recorder.register_histogram(&prefix_key);
+        let prefix_key_histo = recorder.register_histogram(&prefix_key, &METADATA);
         prefix_key_histo.record(PREFIX_VALUES[1]);
 
         let suffix_key = Key::from_name("metrics_testin_foo");
-        let suffix_key_histo = recorder.register_histogram(&suffix_key);
+        let suffix_key_histo = recorder.register_histogram(&suffix_key, &METADATA);
         suffix_key_histo.record(SUFFIX_VALUES[2]);
 
         let default_key = Key::from_name("metrics.wee");
-        let default_key_histo = recorder.register_histogram(&default_key);
+        let default_key_histo = recorder.register_histogram(&default_key, &METADATA);
         default_key_histo.record(DEFAULT_VALUES[2] + 1.0);
 
         let full_data = concat!(
@@ -724,15 +732,15 @@ mod tests {
             .build_with_clock(clock);
 
         let key = Key::from_name("basic_counter");
-        let counter1 = recorder.register_counter(&key);
+        let counter1 = recorder.register_counter(&key, &METADATA);
         counter1.increment(42);
 
         let key = Key::from_name("basic_gauge");
-        let gauge1 = recorder.register_gauge(&key);
+        let gauge1 = recorder.register_gauge(&key, &METADATA);
         gauge1.set(-3.14);
 
         let key = Key::from_name("basic_histogram");
-        let histo1 = recorder.register_histogram(&key);
+        let histo1 = recorder.register_histogram(&key, &METADATA);
         histo1.record(1.0);
 
         let handle = recorder.handle();
@@ -774,15 +782,15 @@ mod tests {
             .build_with_clock(clock);
 
         let key = Key::from_name("basic_counter");
-        let counter1 = recorder.register_counter(&key);
+        let counter1 = recorder.register_counter(&key, &METADATA);
         counter1.increment(42);
 
         let key = Key::from_name("basic_gauge");
-        let gauge1 = recorder.register_gauge(&key);
+        let gauge1 = recorder.register_gauge(&key, &METADATA);
         gauge1.set(-3.14);
 
         let key = Key::from_name("basic_histogram");
-        let histo1 = recorder.register_histogram(&key);
+        let histo1 = recorder.register_histogram(&key, &METADATA);
         histo1.record(1.0);
 
         let handle = recorder.handle();
@@ -823,15 +831,15 @@ mod tests {
             .build_with_clock(clock);
 
         let key = Key::from_name("basic_counter");
-        let counter1 = recorder.register_counter(&key);
+        let counter1 = recorder.register_counter(&key, &METADATA);
         counter1.increment(42);
 
         let key = Key::from_name("basic_gauge");
-        let gauge1 = recorder.register_gauge(&key);
+        let gauge1 = recorder.register_gauge(&key, &METADATA);
         gauge1.set(-3.14);
 
         let key = Key::from_name("basic_histogram");
-        let histo1 = recorder.register_histogram(&key);
+        let histo1 = recorder.register_histogram(&key, &METADATA);
         histo1.record(1.0);
 
         let handle = recorder.handle();
@@ -855,7 +863,7 @@ mod tests {
         assert_eq!(rendered, expected);
 
         let key = Key::from_parts("basic_histogram", vec![Label::new("type", "special")]);
-        let histo2 = recorder.register_histogram(&key);
+        let histo2 = recorder.register_histogram(&key, &METADATA);
         histo2.record(2.0);
 
         let expected_second = concat!(
@@ -898,11 +906,11 @@ mod tests {
             .build_with_clock(clock);
 
         let key = Key::from_name("basic_counter");
-        let counter1 = recorder.register_counter(&key);
+        let counter1 = recorder.register_counter(&key, &METADATA);
         counter1.increment(42);
 
         let key = Key::from_name("basic_gauge");
-        let gauge1 = recorder.register_gauge(&key);
+        let gauge1 = recorder.register_gauge(&key, &METADATA);
         gauge1.set(-3.14);
 
         let handle = recorder.handle();
@@ -947,7 +955,7 @@ mod tests {
             .build_with_clock(clock);
 
         let key = Key::from_name("basic_counter");
-        let counter1 = recorder.register_counter(&key);
+        let counter1 = recorder.register_counter(&key, &METADATA);
         counter1.increment(42);
 
         // First render, which starts tracking the counter in the recency state.
@@ -986,7 +994,7 @@ mod tests {
             .add_global_label("foo", "bar")
             .build_recorder();
         let key = Key::from_name("basic_counter");
-        let counter1 = recorder.register_counter(&key);
+        let counter1 = recorder.register_counter(&key, &METADATA);
         counter1.increment(42);
 
         let handle = recorder.handle();
@@ -1002,7 +1010,7 @@ mod tests {
 
         let key =
             Key::from_name("overridden").with_extra_labels(vec![Label::new("foo", "overridden")]);
-        let counter1 = recorder.register_counter(&key);
+        let counter1 = recorder.register_counter(&key, &METADATA);
         counter1.increment(1);
 
         let handle = recorder.handle();
@@ -1020,7 +1028,7 @@ mod tests {
         let key = Key::from_name(key_name.clone())
             .with_extra_labels(vec![Label::new("øhno", "\"yeet\nies\\\"")]);
         recorder.describe_counter(key_name, None, "\"Simplë stuff.\nRëally.\"".into());
-        let counter1 = recorder.register_counter(&key);
+        let counter1 = recorder.register_counter(&key, &METADATA);
         counter1.increment(1);
 
         let handle = recorder.handle();

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -579,13 +579,8 @@ mod tests {
 
     use super::{Matcher, PrometheusBuilder};
 
-    static METADATA: metrics::Metadata = metrics::Metadata::new(
-        module_path!(),
-        metrics::Level::INFO,
-        Some(module_path!()),
-        Some(file!()),
-        Some(line!()),
-    );
+    static METADATA: metrics::Metadata =
+        metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
     #[test]
     fn test_render() {

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::{PoisonError, RwLock};
 
 use indexmap::IndexMap;
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
 use metrics_util::registry::{Recency, Registry};
 use quanta::Instant;
 
@@ -246,15 +246,15 @@ impl Recorder for PrometheusRecorder {
         self.add_description_if_missing(&key_name, description);
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
         self.inner.registry.get_or_create_counter(key, |c| c.clone().into())
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
         self.inner.registry.get_or_create_gauge(key, |c| c.clone().into())
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
         self.inner.registry.get_or_create_histogram(key, |c| c.clone().into())
     }
 }

--- a/metrics-exporter-tcp/src/lib.rs
+++ b/metrics-exporter-tcp/src/lib.rs
@@ -62,7 +62,7 @@ use std::{
 use bytes::Bytes;
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
 use metrics::{
-    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Recorder,
+    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder,
     SetRecorderError, SharedString, Unit,
 };
 use mio::{
@@ -333,15 +333,15 @@ impl Recorder for TcpRecorder {
         self.state.register_metric(key_name, MetricType::Histogram, unit, description);
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
         Counter::from_arc(Arc::new(Handle::new(key.clone(), self.state.clone())))
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
         Gauge::from_arc(Arc::new(Handle::new(key.clone(), self.state.clone())))
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
         Histogram::from_arc(Arc::new(Handle::new(key.clone(), self.state.clone())))
     }
 }

--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -397,8 +397,6 @@ fn generate_statics(
             #target,
             #level,
             Some(module_path!()),
-            Some(file!()),
-            Some(line!()),
         );
     };
 

--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -253,7 +253,7 @@ where
                     // Only do this work if there's a recorder installed.
                     if let Some(recorder) = ::metrics::try_recorder() {
                         #locals
-                        let handle = recorder.#register_ident(#metric_key);
+                        let handle = recorder.#register_ident(#metric_key, &METADATA);
                         handle.#op_ident(#op_value);
                     }
                 }
@@ -265,7 +265,7 @@ where
                 {
                     #statics
                     #locals
-                    ::metrics::recorder().#register_ident(#metric_key)
+                    ::metrics::recorder().#register_ident(#metric_key, &METADATA)
                 }
             }
         }
@@ -347,10 +347,26 @@ fn generate_statics(name: &Expr, labels: &Option<Labels>) -> TokenStream2 {
         quote! {}
     };
 
+    let target = quote! {
+        module_path!()
+    };
+    let level = quote! { ::metrics::Level::INFO };
+
+    let metadata_static = quote! {
+        static METADATA: ::metrics::Metadata<'static> = ::metrics::Metadata::new(
+            #target,
+            #level,
+            Some(module_path!()),
+            Some(file!()),
+            Some(line!()),
+        );
+    };
+
     quote! {
         #name_static
         #labels_static
         #key_static
+        #metadata_static
     }
 }
 

--- a/metrics-macros/src/lib.rs
+++ b/metrics-macros/src/lib.rs
@@ -519,7 +519,7 @@ impl Parse for Level {
 
 fn parse_level(input: &mut ParseStream) -> Result<Option<Expr>> {
     let lookahead = input.lookahead1();
-    let opt_level = if lookahead.peek(kw::target) {
+    let opt_level = if lookahead.peek(kw::level) {
         let level = input.parse::<Level>()?.target_value;
         let _colon: Comma = input.parse()?;
         Some(level)

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -181,7 +181,8 @@ fn test_get_register_and_op_code_register_static_name_no_labels() {
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
         "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_name (METRIC_NAME) ; ",
-        ":: metrics :: recorder () . register_mytype (& METRIC_KEY) ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        ":: metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
         "}",
     );
 
@@ -197,9 +198,11 @@ fn test_get_register_and_op_code_register_static_name_static_inline_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
+
         "static METRIC_LABELS : [:: metrics :: Label ; 1usize] = [:: metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
         "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_parts (METRIC_NAME , & METRIC_LABELS) ; ",
-        ":: metrics :: recorder () . register_mytype (& METRIC_KEY) ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        ":: metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
         "}",
     );
 
@@ -215,8 +218,9 @@ fn test_get_register_and_op_code_register_static_name_dynamic_inline_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_parts (METRIC_NAME , vec ! [:: metrics :: Label :: new (\"key1\" , & value1)]) ; ",
-        ":: metrics :: recorder () . register_mytype (& key) ",
+        ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
     );
 
@@ -236,8 +240,9 @@ fn test_get_register_and_op_code_register_static_name_existing_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_parts (METRIC_NAME , mylabels) ; ",
-        ":: metrics :: recorder () . register_mytype (& key) ",
+        ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
     );
 
@@ -255,8 +260,9 @@ fn test_get_register_and_op_code_register_owned_name_no_labels() {
 
     let expected = concat!(
         "{ ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_name (String :: from (\"owned\")) ; ",
-        ":: metrics :: recorder () . register_mytype (& key) ",
+        ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
     );
 
@@ -276,8 +282,9 @@ fn test_get_register_and_op_code_register_owned_name_static_inline_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_LABELS : [:: metrics :: Label ; 1usize] = [:: metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_static_labels (String :: from (\"owned\") , & METRIC_LABELS) ; ",
-        ":: metrics :: recorder () . register_mytype (& key) ",
+        ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
     );
 
@@ -296,8 +303,9 @@ fn test_get_register_and_op_code_register_owned_name_dynamic_inline_labels() {
 
     let expected = concat!(
         "{ ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , vec ! [:: metrics :: Label :: new (\"key1\" , & value1)]) ; ",
-        ":: metrics :: recorder () . register_mytype (& key) ",
+        ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
     );
 
@@ -316,8 +324,9 @@ fn test_get_register_and_op_code_register_owned_name_existing_labels() {
 
     let expected = concat!(
         "{ ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , mylabels) ; ",
-        ":: metrics :: recorder () . register_mytype (& key) ",
+        ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
     );
 
@@ -337,8 +346,9 @@ fn test_get_register_and_op_code_op_static_name_no_labels() {
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
         "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_name (METRIC_NAME) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
-        "let handle = recorder . register_mytype (& METRIC_KEY) ; ",
+        "let handle = recorder . register_mytype (& METRIC_KEY , & METADATA) ; ",
         "handle . myop (1) ; ",
         "} ",
         "}",
@@ -362,8 +372,9 @@ fn test_get_register_and_op_code_op_static_name_static_inline_labels() {
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
         "static METRIC_LABELS : [:: metrics :: Label ; 1usize] = [:: metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
         "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_parts (METRIC_NAME , & METRIC_LABELS) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
-        "let handle = recorder . register_mytype (& METRIC_KEY) ; ",
+        "let handle = recorder . register_mytype (& METRIC_KEY , & METADATA) ; ",
         "handle . myop (1) ; ",
         "} ",
         "}",
@@ -385,9 +396,10 @@ fn test_get_register_and_op_code_op_static_name_dynamic_inline_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (METRIC_NAME , vec ! [:: metrics :: Label :: new (\"key1\" , & value1)]) ; ",
-        "let handle = recorder . register_mytype (& key) ; ",
+        "let handle = recorder . register_mytype (& key , & METADATA) ; ",
         "handle . myop (1) ; ",
         "} ",
         "}",
@@ -409,9 +421,10 @@ fn test_get_register_and_op_code_op_static_name_existing_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (METRIC_NAME , mylabels) ; ",
-        "let handle = recorder . register_mytype (& key) ; ",
+        "let handle = recorder . register_mytype (& key , & METADATA) ; ",
         "handle . myop (1) ; ",
         "} ",
         "}",
@@ -431,9 +444,10 @@ fn test_get_register_and_op_code_op_owned_name_no_labels() {
 
     let expected = concat!(
         "{ ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_name (String :: from (\"owned\")) ; ",
-        "let handle = recorder . register_mytype (& key) ; ",
+        "let handle = recorder . register_mytype (& key , & METADATA) ; ",
         "handle . myop (1) ; ",
         "} ",
         "}",
@@ -455,9 +469,10 @@ fn test_get_register_and_op_code_op_owned_name_static_inline_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_LABELS : [:: metrics :: Label ; 1usize] = [:: metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_static_labels (String :: from (\"owned\") , & METRIC_LABELS) ; ",
-        "let handle = recorder . register_mytype (& key) ; ",
+        "let handle = recorder . register_mytype (& key , & METADATA) ; ",
         "handle . myop (1) ; ",
         "} ",
         "}",
@@ -478,9 +493,10 @@ fn test_get_register_and_op_code_op_owned_name_dynamic_inline_labels() {
 
     let expected = concat!(
         "{ ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , vec ! [:: metrics :: Label :: new (\"key1\" , & value1)]) ; ",
-        "let handle = recorder . register_mytype (& key) ; ",
+        "let handle = recorder . register_mytype (& key , & METADATA) ; ",
         "handle . myop (1) ; ",
         "} ",
         "}",
@@ -501,9 +517,10 @@ fn test_get_register_and_op_code_op_owned_name_existing_labels() {
 
     let expected = concat!(
         "{ ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , mylabels) ; ",
-        "let handle = recorder . register_mytype (& key) ; ",
+        "let handle = recorder . register_mytype (& key , & METADATA) ; ",
         "handle . myop (1) ; ",
         "} ",
         "}",
@@ -523,9 +540,10 @@ fn test_get_register_and_op_code_op_owned_name_constant_key_labels() {
 
     let expected = concat!(
         "{ ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , vec ! [:: metrics :: Label :: new (LABEL_KEY , \"some_val\")]) ; ",
-        "let handle = recorder . register_mytype (& key) ; ",
+        "let handle = recorder . register_mytype (& key , & METADATA) ; ",
         "handle . myop (1) ; ",
         "} ",
         "}",

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -175,7 +175,14 @@ fn test_get_describe_code_with_constants_and_with_relative_unit() {
 
 #[test]
 fn test_get_register_and_op_code_register_static_name_no_labels() {
-    let stream = get_register_and_op_code::<bool>("mytype", parse_quote! {"mykeyname"}, None, None);
+    let stream = get_register_and_op_code::<bool>(
+        None,
+        None,
+        "mytype",
+        parse_quote! {"mykeyname"},
+        None,
+        None,
+    );
 
     let expected = concat!(
         "{ ",
@@ -190,10 +197,62 @@ fn test_get_register_and_op_code_register_static_name_no_labels() {
 }
 
 #[test]
+fn test_get_register_and_op_code_register_static_name_no_labels_target() {
+    let stream = get_register_and_op_code::<bool>(
+        Some(parse_quote! { "foo" }),
+        None,
+        "mytype",
+        parse_quote! {"mykeyname"},
+        None,
+        None,
+    );
+
+    let expected = concat!(
+        "{ ",
+        "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
+        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_name (METRIC_NAME) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (\"foo\" , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
+        "}",
+    );
+
+    assert_eq!(stream.to_string(), expected);
+}
+
+#[test]
+fn test_get_register_and_op_code_register_static_name_no_labels_level() {
+    let stream = get_register_and_op_code::<bool>(
+        None,
+        Some(parse_quote! { metrics::Level::TRACE }),
+        "mytype",
+        parse_quote! {"mykeyname"},
+        None,
+        None,
+    );
+
+    let expected = concat!(
+        "{ ",
+        "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
+        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_name (METRIC_NAME) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , metrics :: Level :: TRACE , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
+        "}",
+    );
+
+    assert_eq!(stream.to_string(), expected);
+}
+
+#[test]
 fn test_get_register_and_op_code_register_static_name_static_inline_labels() {
     let labels = Labels::Inline(vec![(parse_quote! { "key1" }, parse_quote! { "value1" })]);
-    let stream =
-        get_register_and_op_code::<bool>("mytype", parse_quote! {"mykeyname"}, Some(labels), None);
+    let stream = get_register_and_op_code::<bool>(
+        None,
+        None,
+        "mytype",
+        parse_quote! {"mykeyname"},
+        Some(labels),
+        None,
+    );
 
     let expected = concat!(
         "{ ",
@@ -212,8 +271,14 @@ fn test_get_register_and_op_code_register_static_name_static_inline_labels() {
 #[test]
 fn test_get_register_and_op_code_register_static_name_dynamic_inline_labels() {
     let labels = Labels::Inline(vec![(parse_quote! { "key1" }, parse_quote! { &value1 })]);
-    let stream =
-        get_register_and_op_code::<bool>("mytype", parse_quote! {"mykeyname"}, Some(labels), None);
+    let stream = get_register_and_op_code::<bool>(
+        None,
+        None,
+        "mytype",
+        parse_quote! {"mykeyname"},
+        Some(labels),
+        None,
+    );
 
     let expected = concat!(
         "{ ",
@@ -231,6 +296,8 @@ fn test_get_register_and_op_code_register_static_name_dynamic_inline_labels() {
 #[test]
 fn test_get_register_and_op_code_register_static_name_existing_labels() {
     let stream = get_register_and_op_code::<bool>(
+        None,
+        None,
         "mytype",
         parse_quote! {"mykeyname"},
         Some(Labels::Existing(parse_quote! { mylabels })),
@@ -252,6 +319,8 @@ fn test_get_register_and_op_code_register_static_name_existing_labels() {
 #[test]
 fn test_get_register_and_op_code_register_owned_name_no_labels() {
     let stream = get_register_and_op_code::<bool>(
+        None,
+        None,
         "mytype",
         parse_quote! { String::from("owned") },
         None,
@@ -273,6 +342,8 @@ fn test_get_register_and_op_code_register_owned_name_no_labels() {
 fn test_get_register_and_op_code_register_owned_name_static_inline_labels() {
     let labels = Labels::Inline(vec![(parse_quote! { "key1" }, parse_quote! { "value1" })]);
     let stream = get_register_and_op_code::<bool>(
+        None,
+        None,
         "mytype",
         parse_quote! { String::from("owned") },
         Some(labels),
@@ -295,6 +366,8 @@ fn test_get_register_and_op_code_register_owned_name_static_inline_labels() {
 fn test_get_register_and_op_code_register_owned_name_dynamic_inline_labels() {
     let labels = Labels::Inline(vec![(parse_quote! { "key1" }, parse_quote! { &value1 })]);
     let stream = get_register_and_op_code::<bool>(
+        None,
+        None,
         "mytype",
         parse_quote! { String::from("owned") },
         Some(labels),
@@ -316,6 +389,8 @@ fn test_get_register_and_op_code_register_owned_name_dynamic_inline_labels() {
 #[test]
 fn test_get_register_and_op_code_register_owned_name_existing_labels() {
     let stream = get_register_and_op_code::<bool>(
+        None,
+        None,
         "mytype",
         parse_quote! { String::from("owned") },
         Some(Labels::Existing(parse_quote! { mylabels })),
@@ -336,6 +411,8 @@ fn test_get_register_and_op_code_register_owned_name_existing_labels() {
 #[test]
 fn test_get_register_and_op_code_op_static_name_no_labels() {
     let stream = get_register_and_op_code(
+        None,
+        None,
         "mytype",
         parse_quote! {"mykeyname"},
         None,
@@ -361,6 +438,8 @@ fn test_get_register_and_op_code_op_static_name_no_labels() {
 fn test_get_register_and_op_code_op_static_name_static_inline_labels() {
     let labels = Labels::Inline(vec![(parse_quote! { "key1" }, parse_quote! { "value1" })]);
     let stream = get_register_and_op_code(
+        None,
+        None,
         "mytype",
         parse_quote! {"mykeyname"},
         Some(labels),
@@ -387,6 +466,8 @@ fn test_get_register_and_op_code_op_static_name_static_inline_labels() {
 fn test_get_register_and_op_code_op_static_name_dynamic_inline_labels() {
     let labels = Labels::Inline(vec![(parse_quote! { "key1" }, parse_quote! { &value1 })]);
     let stream = get_register_and_op_code(
+        None,
+        None,
         "mytype",
         parse_quote! {"mykeyname"},
         Some(labels),
@@ -412,6 +493,8 @@ fn test_get_register_and_op_code_op_static_name_dynamic_inline_labels() {
 #[test]
 fn test_get_register_and_op_code_op_static_name_existing_labels() {
     let stream = get_register_and_op_code(
+        None,
+        None,
         "mytype",
         parse_quote! {"mykeyname"},
         Some(Labels::Existing(parse_quote! { mylabels })),
@@ -436,6 +519,8 @@ fn test_get_register_and_op_code_op_static_name_existing_labels() {
 #[test]
 fn test_get_register_and_op_code_op_owned_name_no_labels() {
     let stream = get_register_and_op_code(
+        None,
+        None,
         "mytype",
         parse_quote! { String::from("owned") },
         None,
@@ -460,6 +545,8 @@ fn test_get_register_and_op_code_op_owned_name_no_labels() {
 fn test_get_register_and_op_code_op_owned_name_static_inline_labels() {
     let labels = Labels::Inline(vec![(parse_quote! { "key1" }, parse_quote! { "value1" })]);
     let stream = get_register_and_op_code(
+        None,
+        None,
         "mytype",
         parse_quote! { String::from("owned") },
         Some(labels),
@@ -485,6 +572,8 @@ fn test_get_register_and_op_code_op_owned_name_static_inline_labels() {
 fn test_get_register_and_op_code_op_owned_name_dynamic_inline_labels() {
     let labels = Labels::Inline(vec![(parse_quote! { "key1" }, parse_quote! { &value1 })]);
     let stream = get_register_and_op_code(
+        None,
+        None,
         "mytype",
         parse_quote! { String::from("owned") },
         Some(labels),
@@ -509,6 +598,8 @@ fn test_get_register_and_op_code_op_owned_name_dynamic_inline_labels() {
 #[test]
 fn test_get_register_and_op_code_op_owned_name_existing_labels() {
     let stream = get_register_and_op_code(
+        None,
+        None,
         "mytype",
         parse_quote! { String::from("owned") },
         Some(Labels::Existing(parse_quote! { mylabels })),
@@ -532,6 +623,8 @@ fn test_get_register_and_op_code_op_owned_name_existing_labels() {
 #[test]
 fn test_get_register_and_op_code_op_owned_name_constant_key_labels() {
     let stream = get_register_and_op_code(
+        None,
+        None,
         "mytype",
         parse_quote! { String::from("owned") },
         Some(Labels::Inline(vec![(parse_quote! { LABEL_KEY }, parse_quote! { "some_val" })])),

--- a/metrics-macros/src/tests.rs
+++ b/metrics-macros/src/tests.rs
@@ -188,7 +188,7 @@ fn test_get_register_and_op_code_register_static_name_no_labels() {
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
         "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_name (METRIC_NAME) ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         ":: metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
         "}",
     );
@@ -210,9 +210,9 @@ fn test_get_register_and_op_code_register_static_name_no_labels_target() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
-        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_name (METRIC_NAME) ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (\"foo\" , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
-        "metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
+        "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_name (METRIC_NAME) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (\"foo\" , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
+        ":: metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
         "}",
     );
 
@@ -233,9 +233,9 @@ fn test_get_register_and_op_code_register_static_name_no_labels_level() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
-        "static METRIC_KEY : metrics :: Key = metrics :: Key :: from_static_name (METRIC_NAME) ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , metrics :: Level :: TRACE , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
-        "metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
+        "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_name (METRIC_NAME) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , metrics :: Level :: TRACE , Some (module_path ! ()) ,) ; ",
+        ":: metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
         "}",
     );
 
@@ -260,7 +260,7 @@ fn test_get_register_and_op_code_register_static_name_static_inline_labels() {
 
         "static METRIC_LABELS : [:: metrics :: Label ; 1usize] = [:: metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
         "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_parts (METRIC_NAME , & METRIC_LABELS) ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         ":: metrics :: recorder () . register_mytype (& METRIC_KEY , & METADATA) ",
         "}",
     );
@@ -283,7 +283,7 @@ fn test_get_register_and_op_code_register_static_name_dynamic_inline_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_parts (METRIC_NAME , vec ! [:: metrics :: Label :: new (\"key1\" , & value1)]) ; ",
         ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
@@ -307,7 +307,7 @@ fn test_get_register_and_op_code_register_static_name_existing_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_parts (METRIC_NAME , mylabels) ; ",
         ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
@@ -329,7 +329,7 @@ fn test_get_register_and_op_code_register_owned_name_no_labels() {
 
     let expected = concat!(
         "{ ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_name (String :: from (\"owned\")) ; ",
         ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
@@ -353,7 +353,7 @@ fn test_get_register_and_op_code_register_owned_name_static_inline_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_LABELS : [:: metrics :: Label ; 1usize] = [:: metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_static_labels (String :: from (\"owned\") , & METRIC_LABELS) ; ",
         ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
@@ -376,7 +376,7 @@ fn test_get_register_and_op_code_register_owned_name_dynamic_inline_labels() {
 
     let expected = concat!(
         "{ ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , vec ! [:: metrics :: Label :: new (\"key1\" , & value1)]) ; ",
         ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
@@ -399,7 +399,7 @@ fn test_get_register_and_op_code_register_owned_name_existing_labels() {
 
     let expected = concat!(
         "{ ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , mylabels) ; ",
         ":: metrics :: recorder () . register_mytype (& key , & METADATA) ",
         "}",
@@ -423,7 +423,7 @@ fn test_get_register_and_op_code_op_static_name_no_labels() {
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
         "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_name (METRIC_NAME) ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let handle = recorder . register_mytype (& METRIC_KEY , & METADATA) ; ",
         "handle . myop (1) ; ",
@@ -451,7 +451,7 @@ fn test_get_register_and_op_code_op_static_name_static_inline_labels() {
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
         "static METRIC_LABELS : [:: metrics :: Label ; 1usize] = [:: metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
         "static METRIC_KEY : :: metrics :: Key = :: metrics :: Key :: from_static_parts (METRIC_NAME , & METRIC_LABELS) ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let handle = recorder . register_mytype (& METRIC_KEY , & METADATA) ; ",
         "handle . myop (1) ; ",
@@ -477,7 +477,7 @@ fn test_get_register_and_op_code_op_static_name_dynamic_inline_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (METRIC_NAME , vec ! [:: metrics :: Label :: new (\"key1\" , & value1)]) ; ",
         "let handle = recorder . register_mytype (& key , & METADATA) ; ",
@@ -504,7 +504,7 @@ fn test_get_register_and_op_code_op_static_name_existing_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_NAME : & 'static str = \"mykeyname\" ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (METRIC_NAME , mylabels) ; ",
         "let handle = recorder . register_mytype (& key , & METADATA) ; ",
@@ -529,7 +529,7 @@ fn test_get_register_and_op_code_op_owned_name_no_labels() {
 
     let expected = concat!(
         "{ ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_name (String :: from (\"owned\")) ; ",
         "let handle = recorder . register_mytype (& key , & METADATA) ; ",
@@ -556,7 +556,7 @@ fn test_get_register_and_op_code_op_owned_name_static_inline_labels() {
     let expected = concat!(
         "{ ",
         "static METRIC_LABELS : [:: metrics :: Label ; 1usize] = [:: metrics :: Label :: from_static_parts (\"key1\" , \"value1\")] ; ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_static_labels (String :: from (\"owned\") , & METRIC_LABELS) ; ",
         "let handle = recorder . register_mytype (& key , & METADATA) ; ",
@@ -582,7 +582,7 @@ fn test_get_register_and_op_code_op_owned_name_dynamic_inline_labels() {
 
     let expected = concat!(
         "{ ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , vec ! [:: metrics :: Label :: new (\"key1\" , & value1)]) ; ",
         "let handle = recorder . register_mytype (& key , & METADATA) ; ",
@@ -608,7 +608,7 @@ fn test_get_register_and_op_code_op_owned_name_existing_labels() {
 
     let expected = concat!(
         "{ ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , mylabels) ; ",
         "let handle = recorder . register_mytype (& key , & METADATA) ; ",
@@ -633,7 +633,7 @@ fn test_get_register_and_op_code_op_owned_name_constant_key_labels() {
 
     let expected = concat!(
         "{ ",
-        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) , Some (file ! ()) , Some (line ! ()) ,) ; ",
+        "static METADATA : :: metrics :: Metadata < 'static > = :: metrics :: Metadata :: new (module_path ! () , :: metrics :: Level :: INFO , Some (module_path ! ()) ,) ; ",
         "if let Some (recorder) = :: metrics :: try_recorder () { ",
         "let key = :: metrics :: Key :: from_parts (String :: from (\"owned\") , vec ! [:: metrics :: Label :: new (LABEL_KEY , \"some_val\")]) ; ",
         "let handle = recorder . register_mytype (& key , & METADATA) ; ",

--- a/metrics-tracing-context/benches/layer.rs
+++ b/metrics-tracing-context/benches/layer.rs
@@ -19,8 +19,6 @@ fn layer_benchmark(c: &mut Criterion) {
             module_path!(),
             metrics::Level::INFO,
             Some(module_path!()),
-            Some(file!()),
-            Some(line!()),
         );
 
         b.iter(|| {
@@ -40,13 +38,8 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "key";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
-            static METADATA: metrics::Metadata = metrics::Metadata::new(
-                module_path!(),
-                metrics::Level::INFO,
-                Some(module_path!()),
-                Some(file!()),
-                Some(line!()),
-            );
+            static METADATA: metrics::Metadata =
+                metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
             b.iter(|| {
                 let _ = recorder.register_counter(&KEY_DATA, &METADATA);
@@ -66,13 +59,8 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "key";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
-            static METADATA: metrics::Metadata = metrics::Metadata::new(
-                module_path!(),
-                metrics::Level::INFO,
-                Some(module_path!()),
-                Some(file!()),
-                Some(line!()),
-            );
+            static METADATA: metrics::Metadata =
+                metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
             b.iter(|| {
                 let _ = recorder.register_counter(&KEY_DATA, &METADATA);
@@ -93,13 +81,8 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "key";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
-            static METADATA: metrics::Metadata = metrics::Metadata::new(
-                module_path!(),
-                metrics::Level::INFO,
-                Some(module_path!()),
-                Some(file!()),
-                Some(line!()),
-            );
+            static METADATA: metrics::Metadata =
+                metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
             b.iter(|| {
                 let _ = recorder.register_counter(&KEY_DATA, &METADATA);
@@ -120,13 +103,8 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "key";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
-            static METADATA: metrics::Metadata = metrics::Metadata::new(
-                module_path!(),
-                metrics::Level::INFO,
-                Some(module_path!()),
-                Some(file!()),
-                Some(line!()),
-            );
+            static METADATA: metrics::Metadata =
+                metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
             b.iter(|| {
                 let _ = recorder.register_counter(&KEY_DATA, &METADATA);

--- a/metrics-tracing-context/benches/layer.rs
+++ b/metrics-tracing-context/benches/layer.rs
@@ -15,9 +15,16 @@ fn layer_benchmark(c: &mut Criterion) {
         static KEY_NAME: &'static str = "key";
         static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
         static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+        static METADATA: metrics::Metadata = metrics::Metadata::new(
+            module_path!(),
+            metrics::Level::INFO,
+            Some(module_path!()),
+            Some(file!()),
+            Some(line!()),
+        );
 
         b.iter(|| {
-            let _ = recorder.register_counter(&KEY_DATA);
+            let _ = recorder.register_counter(&KEY_DATA, &METADATA);
         })
     });
     group.bench_function("no integration", |b| {
@@ -33,9 +40,16 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "key";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static METADATA: metrics::Metadata = metrics::Metadata::new(
+                module_path!(),
+                metrics::Level::INFO,
+                Some(module_path!()),
+                Some(file!()),
+                Some(line!()),
+            );
 
             b.iter(|| {
-                let _ = recorder.register_counter(&KEY_DATA);
+                let _ = recorder.register_counter(&KEY_DATA, &METADATA);
             })
         })
     });
@@ -52,9 +66,16 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "key";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static METADATA: metrics::Metadata = metrics::Metadata::new(
+                module_path!(),
+                metrics::Level::INFO,
+                Some(module_path!()),
+                Some(file!()),
+                Some(line!()),
+            );
 
             b.iter(|| {
-                let _ = recorder.register_counter(&KEY_DATA);
+                let _ = recorder.register_counter(&KEY_DATA, &METADATA);
             })
         })
     });
@@ -72,9 +93,16 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "key";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static METADATA: metrics::Metadata = metrics::Metadata::new(
+                module_path!(),
+                metrics::Level::INFO,
+                Some(module_path!()),
+                Some(file!()),
+                Some(line!()),
+            );
 
             b.iter(|| {
-                let _ = recorder.register_counter(&KEY_DATA);
+                let _ = recorder.register_counter(&KEY_DATA, &METADATA);
             })
         })
     });
@@ -92,9 +120,16 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "key";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static METADATA: metrics::Metadata = metrics::Metadata::new(
+                module_path!(),
+                metrics::Level::INFO,
+                Some(module_path!()),
+                Some(file!()),
+                Some(line!()),
+            );
 
             b.iter(|| {
-                let _ = recorder.register_counter(&KEY_DATA);
+                let _ = recorder.register_counter(&KEY_DATA, &METADATA);
             })
         })
     });

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -95,7 +95,9 @@
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Label, Recorder, SharedString, Unit};
+use metrics::{
+    Counter, Gauge, Histogram, Key, KeyName, Label, Metadata, Recorder, SharedString, Unit,
+};
 use metrics_util::layers::Layer;
 
 pub mod label_filter;
@@ -217,21 +219,21 @@ where
         self.inner.describe_histogram(key_name, unit, description)
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
         let new_key = self.enhance_key(key);
         let key = new_key.as_ref().unwrap_or(key);
-        self.inner.register_counter(key)
+        self.inner.register_counter(key, metadata)
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
         let new_key = self.enhance_key(key);
         let key = new_key.as_ref().unwrap_or(key);
-        self.inner.register_gauge(key)
+        self.inner.register_gauge(key, metadata)
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
         let new_key = self.enhance_key(key);
         let key = new_key.as_ref().unwrap_or(key);
-        self.inner.register_histogram(key)
+        self.inner.register_histogram(key, metadata)
     }
 }

--- a/metrics-util/benches/filter.rs
+++ b/metrics-util/benches/filter.rs
@@ -18,9 +18,16 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "tokio.foo";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static METADATA: metrics::Metadata = metrics::Metadata::new(
+                module_path!(),
+                metrics::Level::INFO,
+                Some(module_path!()),
+                Some(file!()),
+                Some(line!()),
+            );
 
             b.iter(|| {
-                let _ = recorder.register_counter(&KEY_DATA);
+                let _ = recorder.register_counter(&KEY_DATA, &METADATA);
             })
         });
         group.bench_function("no match", |b| {
@@ -30,9 +37,16 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "hyper.foo";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static METADATA: metrics::Metadata = metrics::Metadata::new(
+                module_path!(),
+                metrics::Level::INFO,
+                Some(module_path!()),
+                Some(file!()),
+                Some(line!()),
+            );
 
             b.iter(|| {
-                let _ = recorder.register_counter(&KEY_DATA);
+                let _ = recorder.register_counter(&KEY_DATA, &METADATA);
             })
         });
         group.bench_function("noop recorder overhead (increment_counter)", |b| {
@@ -40,9 +54,16 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "tokio.foo";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+            static METADATA: metrics::Metadata = metrics::Metadata::new(
+                module_path!(),
+                metrics::Level::INFO,
+                Some(module_path!()),
+                Some(file!()),
+                Some(line!()),
+            );
 
             b.iter(|| {
-                let _ = recorder.register_counter(&KEY_DATA);
+                let _ = recorder.register_counter(&KEY_DATA, &METADATA);
             })
         });
     }

--- a/metrics-util/benches/filter.rs
+++ b/metrics-util/benches/filter.rs
@@ -18,13 +18,8 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "tokio.foo";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
-            static METADATA: metrics::Metadata = metrics::Metadata::new(
-                module_path!(),
-                metrics::Level::INFO,
-                Some(module_path!()),
-                Some(file!()),
-                Some(line!()),
-            );
+            static METADATA: metrics::Metadata =
+                metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
             b.iter(|| {
                 let _ = recorder.register_counter(&KEY_DATA, &METADATA);
@@ -37,13 +32,8 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "hyper.foo";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
-            static METADATA: metrics::Metadata = metrics::Metadata::new(
-                module_path!(),
-                metrics::Level::INFO,
-                Some(module_path!()),
-                Some(file!()),
-                Some(line!()),
-            );
+            static METADATA: metrics::Metadata =
+                metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
             b.iter(|| {
                 let _ = recorder.register_counter(&KEY_DATA, &METADATA);
@@ -54,13 +44,8 @@ fn layer_benchmark(c: &mut Criterion) {
             static KEY_NAME: &'static str = "tokio.foo";
             static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
             static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
-            static METADATA: metrics::Metadata = metrics::Metadata::new(
-                module_path!(),
-                metrics::Level::INFO,
-                Some(module_path!()),
-                Some(file!()),
-                Some(line!()),
-            );
+            static METADATA: metrics::Metadata =
+                metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
             b.iter(|| {
                 let _ = recorder.register_counter(&KEY_DATA, &METADATA);

--- a/metrics-util/benches/prefix.rs
+++ b/metrics-util/benches/prefix.rs
@@ -10,13 +10,8 @@ fn layer_benchmark(c: &mut Criterion) {
         static KEY_NAME: &'static str = "simple_key";
         static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
         static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
-        static METADATA: metrics::Metadata = metrics::Metadata::new(
-            module_path!(),
-            metrics::Level::INFO,
-            Some(module_path!()),
-            Some(file!()),
-            Some(line!()),
-        );
+        static METADATA: metrics::Metadata =
+            metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
         b.iter(|| {
             let _ = recorder.register_counter(&KEY_DATA, &METADATA);
@@ -27,13 +22,8 @@ fn layer_benchmark(c: &mut Criterion) {
         static KEY_NAME: &'static str = "simple_key";
         static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
         static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
-        static METADATA: metrics::Metadata = metrics::Metadata::new(
-            module_path!(),
-            metrics::Level::INFO,
-            Some(module_path!()),
-            Some(file!()),
-            Some(line!()),
-        );
+        static METADATA: metrics::Metadata =
+            metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
         b.iter(|| {
             let _ = recorder.register_counter(&KEY_DATA, &METADATA);

--- a/metrics-util/benches/prefix.rs
+++ b/metrics-util/benches/prefix.rs
@@ -10,9 +10,16 @@ fn layer_benchmark(c: &mut Criterion) {
         static KEY_NAME: &'static str = "simple_key";
         static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
         static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+        static METADATA: metrics::Metadata = metrics::Metadata::new(
+            module_path!(),
+            metrics::Level::INFO,
+            Some(module_path!()),
+            Some(file!()),
+            Some(line!()),
+        );
 
         b.iter(|| {
-            let _ = recorder.register_counter(&KEY_DATA);
+            let _ = recorder.register_counter(&KEY_DATA, &METADATA);
         })
     });
     group.bench_function("noop recorder overhead (increment_counter)", |b| {
@@ -20,9 +27,16 @@ fn layer_benchmark(c: &mut Criterion) {
         static KEY_NAME: &'static str = "simple_key";
         static KEY_LABELS: [Label; 1] = [Label::from_static_parts("foo", "bar")];
         static KEY_DATA: Key = Key::from_static_parts(&KEY_NAME, &KEY_LABELS);
+        static METADATA: metrics::Metadata = metrics::Metadata::new(
+            module_path!(),
+            metrics::Level::INFO,
+            Some(module_path!()),
+            Some(file!()),
+            Some(line!()),
+        );
 
         b.iter(|| {
-            let _ = recorder.register_counter(&KEY_DATA);
+            let _ = recorder.register_counter(&KEY_DATA, &METADATA);
         })
     });
     group.finish();

--- a/metrics-util/benches/router.rs
+++ b/metrics-util/benches/router.rs
@@ -9,13 +9,8 @@ fn layer_benchmark(c: &mut Criterion) {
     group.bench_function("default target (via mask)", |b| {
         let recorder = RouterBuilder::from_recorder(NoopRecorder).build();
         let key = Key::from_name("test_key");
-        static METADATA: metrics::Metadata = metrics::Metadata::new(
-            module_path!(),
-            metrics::Level::INFO,
-            Some(module_path!()),
-            Some(file!()),
-            Some(line!()),
-        );
+        static METADATA: metrics::Metadata =
+            metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
         b.iter(|| {
             let _ = recorder.register_counter(&key, &METADATA);
@@ -26,13 +21,8 @@ fn layer_benchmark(c: &mut Criterion) {
         builder.add_route(MetricKindMask::COUNTER, "override", NoopRecorder);
         let recorder = builder.build();
         let key = Key::from_name("normal_key");
-        static METADATA: metrics::Metadata = metrics::Metadata::new(
-            module_path!(),
-            metrics::Level::INFO,
-            Some(module_path!()),
-            Some(file!()),
-            Some(line!()),
-        );
+        static METADATA: metrics::Metadata =
+            metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
         b.iter(|| {
             let _ = recorder.register_counter(&key, &METADATA);
@@ -43,13 +33,8 @@ fn layer_benchmark(c: &mut Criterion) {
         builder.add_route(MetricKindMask::COUNTER, "override", NoopRecorder);
         let recorder = builder.build();
         let key = Key::from_name("override_key");
-        static METADATA: metrics::Metadata = metrics::Metadata::new(
-            module_path!(),
-            metrics::Level::INFO,
-            Some(module_path!()),
-            Some(file!()),
-            Some(line!()),
-        );
+        static METADATA: metrics::Metadata =
+            metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
         b.iter(|| {
             let _ = recorder.register_counter(&key, &METADATA);

--- a/metrics-util/benches/router.rs
+++ b/metrics-util/benches/router.rs
@@ -9,9 +9,16 @@ fn layer_benchmark(c: &mut Criterion) {
     group.bench_function("default target (via mask)", |b| {
         let recorder = RouterBuilder::from_recorder(NoopRecorder).build();
         let key = Key::from_name("test_key");
+        static METADATA: metrics::Metadata = metrics::Metadata::new(
+            module_path!(),
+            metrics::Level::INFO,
+            Some(module_path!()),
+            Some(file!()),
+            Some(line!()),
+        );
 
         b.iter(|| {
-            let _ = recorder.register_counter(&key);
+            let _ = recorder.register_counter(&key, &METADATA);
         })
     });
     group.bench_function("default target (via fallback)", |b| {
@@ -19,9 +26,16 @@ fn layer_benchmark(c: &mut Criterion) {
         builder.add_route(MetricKindMask::COUNTER, "override", NoopRecorder);
         let recorder = builder.build();
         let key = Key::from_name("normal_key");
+        static METADATA: metrics::Metadata = metrics::Metadata::new(
+            module_path!(),
+            metrics::Level::INFO,
+            Some(module_path!()),
+            Some(file!()),
+            Some(line!()),
+        );
 
         b.iter(|| {
-            let _ = recorder.register_counter(&key);
+            let _ = recorder.register_counter(&key, &METADATA);
         })
     });
     group.bench_function("routed target", |b| {
@@ -29,9 +43,16 @@ fn layer_benchmark(c: &mut Criterion) {
         builder.add_route(MetricKindMask::COUNTER, "override", NoopRecorder);
         let recorder = builder.build();
         let key = Key::from_name("override_key");
+        static METADATA: metrics::Metadata = metrics::Metadata::new(
+            module_path!(),
+            metrics::Level::INFO,
+            Some(module_path!()),
+            Some(file!()),
+            Some(line!()),
+        );
 
         b.iter(|| {
-            let _ = recorder.register_counter(&key);
+            let _ = recorder.register_counter(&key, &METADATA);
         })
     });
 }

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use indexmap::IndexMap;
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
 use ordered_float::OrderedFloat;
 
 thread_local! {
@@ -292,7 +292,7 @@ impl Recorder for DebuggingRecorder {
         self.describe_metric(ckey, unit, description);
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
         let ckey = CompositeKey::new(MetricKind::Counter, key.clone());
         self.track_metric(ckey);
 
@@ -313,7 +313,7 @@ impl Recorder for DebuggingRecorder {
         }
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
         let ckey = CompositeKey::new(MetricKind::Gauge, key.clone());
         self.track_metric(ckey);
 
@@ -334,7 +334,7 @@ impl Recorder for DebuggingRecorder {
         }
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
         let ckey = CompositeKey::new(MetricKind::Histogram, key.clone());
         self.track_metric(ckey);
 

--- a/metrics-util/src/layers/fanout.rs
+++ b/metrics-util/src/layers/fanout.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use metrics::{
-    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Recorder,
+    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder,
     SharedString, Unit,
 };
 
@@ -119,22 +119,29 @@ impl Recorder for Fanout {
         }
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
-        let counters =
-            self.recorders.iter().map(|recorder| recorder.register_counter(key)).collect();
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
+        let counters = self
+            .recorders
+            .iter()
+            .map(|recorder| recorder.register_counter(key, metadata))
+            .collect();
 
         FanoutCounter::from_counters(counters).into()
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
-        let gauges = self.recorders.iter().map(|recorder| recorder.register_gauge(key)).collect();
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
+        let gauges =
+            self.recorders.iter().map(|recorder| recorder.register_gauge(key, metadata)).collect();
 
         FanoutGauge::from_gauges(gauges).into()
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
-        let histograms =
-            self.recorders.iter().map(|recorder| recorder.register_histogram(key)).collect();
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
+        let histograms = self
+            .recorders
+            .iter()
+            .map(|recorder| recorder.register_histogram(key, metadata))
+            .collect();
 
         FanoutHistogram::from_histograms(histograms).into()
     }
@@ -170,6 +177,14 @@ mod tests {
     use crate::test_util::*;
     use metrics::{Counter, Gauge, Histogram, Unit};
 
+    static METADATA: metrics::Metadata = metrics::Metadata::new(
+        module_path!(),
+        metrics::Level::INFO,
+        Some(module_path!()),
+        Some(file!()),
+        Some(line!()),
+    );
+
     #[test]
     fn test_basic_functionality() {
         let operations = vec![
@@ -188,9 +203,13 @@ mod tests {
                 Some(Unit::Nanoseconds),
                 "histogram desc".into(),
             ),
-            RecorderOperation::RegisterCounter("counter_key".into(), Counter::noop()),
-            RecorderOperation::RegisterGauge("gauge_key".into(), Gauge::noop()),
-            RecorderOperation::RegisterHistogram("histogram_key".into(), Histogram::noop()),
+            RecorderOperation::RegisterCounter("counter_key".into(), Counter::noop(), &METADATA),
+            RecorderOperation::RegisterGauge("gauge_key".into(), Gauge::noop(), &METADATA),
+            RecorderOperation::RegisterHistogram(
+                "histogram_key".into(),
+                Histogram::noop(),
+                &METADATA,
+            ),
         ];
 
         let recorder1 = MockBasicRecorder::from_operations(operations.clone());

--- a/metrics-util/src/layers/fanout.rs
+++ b/metrics-util/src/layers/fanout.rs
@@ -177,13 +177,8 @@ mod tests {
     use crate::test_util::*;
     use metrics::{Counter, Gauge, Histogram, Unit};
 
-    static METADATA: metrics::Metadata = metrics::Metadata::new(
-        module_path!(),
-        metrics::Level::INFO,
-        Some(module_path!()),
-        Some(file!()),
-        Some(line!()),
-    );
+    static METADATA: metrics::Metadata =
+        metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
     #[test]
     fn test_basic_functionality() {

--- a/metrics-util/src/layers/filter.rs
+++ b/metrics-util/src/layers/filter.rs
@@ -153,13 +153,8 @@ mod tests {
     use crate::{layers::Layer, test_util::*};
     use metrics::{Counter, Gauge, Histogram, Unit};
 
-    static METADATA: metrics::Metadata = metrics::Metadata::new(
-        module_path!(),
-        metrics::Level::INFO,
-        Some(module_path!()),
-        Some(file!()),
-        Some(line!()),
-    );
+    static METADATA: metrics::Metadata =
+        metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
     #[test]
     fn test_basic_functionality() {

--- a/metrics-util/src/layers/mod.rs
+++ b/metrics-util/src/layers/mod.rs
@@ -8,7 +8,7 @@
 //! Here's an example of a layer that filters out all metrics that start with a specific string:
 //!
 //! ```rust
-//! # use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
+//! # use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
 //! # use metrics::NoopRecorder as BasicRecorder;
 //! # use metrics_util::layers::{Layer, Stack, PrefixLayer};
 //! // A simple layer that denies any metrics that have "stairway" or "heaven" in their name.
@@ -53,25 +53,25 @@
 //!         self.0.describe_histogram(key_name, unit, description)
 //!     }
 //!
-//!     fn register_counter(&self, key: &Key) -> Counter {
+//!     fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
 //!         if self.is_invalid_key(key.name()) {
 //!             return Counter::noop();
 //!         }
-//!         self.0.register_counter(key)
+//!         self.0.register_counter(key, metadata)
 //!     }
 //!
-//!     fn register_gauge(&self, key: &Key) -> Gauge {
+//!     fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
 //!         if self.is_invalid_key(key.name()) {
 //!             return Gauge::noop();
 //!         }
-//!         self.0.register_gauge(key)
+//!         self.0.register_gauge(key, metadata)
 //!     }
 //!
-//!     fn register_histogram(&self, key: &Key) -> Histogram {
+//!     fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
 //!         if self.is_invalid_key(key.name()) {
 //!             return Histogram::noop();
 //!         }
-//!         self.0.register_histogram(key)
+//!         self.0.register_histogram(key, metadata)
 //!     }
 //! }
 //!
@@ -111,7 +111,7 @@
 //!     .expect("failed to install stack");
 //! # }
 //! ```
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
 
 use metrics::SetRecorderError;
 
@@ -179,15 +179,15 @@ impl<R: Recorder> Recorder for Stack<R> {
         self.inner.describe_histogram(key_name, unit, description);
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
-        self.inner.register_counter(key)
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
+        self.inner.register_counter(key, metadata)
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
-        self.inner.register_gauge(key)
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
+        self.inner.register_gauge(key, metadata)
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
-        self.inner.register_histogram(key)
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
+        self.inner.register_histogram(key, metadata)
     }
 }

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -1,5 +1,5 @@
 use crate::layers::Layer;
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
 
 /// Applies a prefix to every metric key.
 ///
@@ -45,19 +45,19 @@ impl<R: Recorder> Recorder for Prefix<R> {
         self.inner.describe_histogram(new_key_name, unit, description)
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
         let new_key = self.prefix_key(key);
-        self.inner.register_counter(&new_key)
+        self.inner.register_counter(&new_key, metadata)
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
         let new_key = self.prefix_key(key);
-        self.inner.register_gauge(&new_key)
+        self.inner.register_gauge(&new_key, metadata)
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
         let new_key = self.prefix_key(key);
-        self.inner.register_histogram(&new_key)
+        self.inner.register_histogram(&new_key, metadata)
     }
 }
 
@@ -88,6 +88,14 @@ mod tests {
     use crate::test_util::*;
     use metrics::{Counter, Gauge, Histogram, Key, KeyName, Unit};
 
+    static METADATA: metrics::Metadata = metrics::Metadata::new(
+        module_path!(),
+        metrics::Level::INFO,
+        Some(module_path!()),
+        Some(file!()),
+        Some(line!()),
+    );
+
     #[test]
     fn test_basic_functionality() {
         let inputs = vec![
@@ -106,9 +114,13 @@ mod tests {
                 Some(Unit::Nanoseconds),
                 "histogram desc".into(),
             ),
-            RecorderOperation::RegisterCounter("counter_key".into(), Counter::noop()),
-            RecorderOperation::RegisterGauge("gauge_key".into(), Gauge::noop()),
-            RecorderOperation::RegisterHistogram("histogram_key".into(), Histogram::noop()),
+            RecorderOperation::RegisterCounter("counter_key".into(), Counter::noop(), &METADATA),
+            RecorderOperation::RegisterGauge("gauge_key".into(), Gauge::noop(), &METADATA),
+            RecorderOperation::RegisterHistogram(
+                "histogram_key".into(),
+                Histogram::noop(),
+                &METADATA,
+            ),
         ];
 
         let expectations = vec![
@@ -127,9 +139,17 @@ mod tests {
                 Some(Unit::Nanoseconds),
                 "histogram desc".into(),
             ),
-            RecorderOperation::RegisterCounter("testing.counter_key".into(), Counter::noop()),
-            RecorderOperation::RegisterGauge("testing.gauge_key".into(), Gauge::noop()),
-            RecorderOperation::RegisterHistogram("testing.histogram_key".into(), Histogram::noop()),
+            RecorderOperation::RegisterCounter(
+                "testing.counter_key".into(),
+                Counter::noop(),
+                &METADATA,
+            ),
+            RecorderOperation::RegisterGauge("testing.gauge_key".into(), Gauge::noop(), &METADATA),
+            RecorderOperation::RegisterHistogram(
+                "testing.histogram_key".into(),
+                Histogram::noop(),
+                &METADATA,
+            ),
         ];
 
         let recorder = MockBasicRecorder::from_operations(expectations);

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -88,13 +88,8 @@ mod tests {
     use crate::test_util::*;
     use metrics::{Counter, Gauge, Histogram, Key, KeyName, Unit};
 
-    static METADATA: metrics::Metadata = metrics::Metadata::new(
-        module_path!(),
-        metrics::Level::INFO,
-        Some(module_path!()),
-        Some(file!()),
-        Some(line!()),
-    );
+    static METADATA: metrics::Metadata =
+        metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
     #[test]
     fn test_basic_functionality() {

--- a/metrics-util/src/layers/router.rs
+++ b/metrics-util/src/layers/router.rs
@@ -1,4 +1,4 @@
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
 use radix_trie::{Trie, TrieCommon};
 
 use crate::{MetricKind, MetricKindMask};
@@ -54,19 +54,19 @@ impl Recorder for Router {
         target.describe_histogram(key_name, unit, description)
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
         let target = self.route(MetricKind::Counter, key.name(), &self.counter_routes);
-        target.register_counter(key)
+        target.register_counter(key, metadata)
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
         let target = self.route(MetricKind::Gauge, key.name(), &self.gauge_routes);
-        target.register_gauge(key)
+        target.register_gauge(key, metadata)
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
         let target = self.route(MetricKind::Histogram, key.name(), &self.histogram_routes);
-        target.register_histogram(key)
+        target.register_histogram(key, metadata)
     }
 }
 
@@ -161,12 +161,18 @@ impl RouterBuilder {
 
 #[cfg(test)]
 mod tests {
-    use mockall::{mock, predicate::eq, Sequence};
+    use mockall::{
+        mock,
+        predicate::{always, eq},
+        Sequence,
+    };
     use std::borrow::Cow;
 
     use super::RouterBuilder;
     use crate::MetricKindMask;
-    use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
+    use metrics::{
+        Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit,
+    };
 
     mock! {
         pub TestRecorder {
@@ -176,9 +182,9 @@ mod tests {
             fn describe_counter(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString);
             fn describe_gauge(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString);
             fn describe_histogram(&self, key_name: KeyName, unit: Option<Unit>, description: SharedString);
-            fn register_counter(&self, key: &Key) -> Counter;
-            fn register_gauge(&self, key: &Key) -> Gauge;
-            fn register_histogram(&self, key: &Key) -> Histogram;
+            fn register_counter<'a>(&'a self, key: &'a Key, metadata: &'a Metadata<'a>) -> Counter;
+            fn register_gauge<'a>(&'a self, key: &'a Key, metadata: &'a Metadata<'a>) -> Gauge;
+            fn register_histogram<'a>(&'a self, key: &'a Key, metadata: &'a Metadata<'a>) -> Histogram;
         }
     }
 
@@ -215,33 +221,41 @@ mod tests {
 
         let mut seq = Sequence::new();
 
+        static METADATA: metrics::Metadata = metrics::Metadata::new(
+            module_path!(),
+            metrics::Level::INFO,
+            Some(module_path!()),
+            Some(file!()),
+            Some(line!()),
+        );
+
         default_mock
             .expect_register_counter()
             .times(1)
             .in_sequence(&mut seq)
-            .with(eq(default_counter.clone()))
-            .returning(|_| Counter::noop());
+            .with(eq(default_counter.clone()), always())
+            .returning(|_, _| Counter::noop());
 
         counter_mock
             .expect_register_counter()
             .times(1)
             .in_sequence(&mut seq)
-            .with(eq(override_counter.clone()))
-            .returning(|_| Counter::noop());
+            .with(eq(override_counter.clone()), always())
+            .returning(|_, _| Counter::noop());
 
         all_mock
             .expect_register_counter()
             .times(1)
             .in_sequence(&mut seq)
-            .with(eq(all_override.clone()))
-            .returning(|_| Counter::noop());
+            .with(eq(all_override.clone()), always())
+            .returning(|_, _| Counter::noop());
 
         all_mock
             .expect_register_histogram()
             .times(1)
             .in_sequence(&mut seq)
-            .with(eq(all_override.clone()))
-            .returning(|_| Histogram::noop());
+            .with(eq(all_override.clone()), always())
+            .returning(|_, _| Histogram::noop());
 
         let mut builder = RouterBuilder::from_recorder(default_mock);
         builder.add_route(MetricKindMask::COUNTER, "counter_override", counter_mock).add_route(
@@ -251,9 +265,9 @@ mod tests {
         );
         let recorder = builder.build();
 
-        let _ = recorder.register_counter(&default_counter);
-        let _ = recorder.register_counter(&override_counter);
-        let _ = recorder.register_counter(&all_override);
-        let _ = recorder.register_histogram(&all_override);
+        let _ = recorder.register_counter(&default_counter, &METADATA);
+        let _ = recorder.register_counter(&override_counter, &METADATA);
+        let _ = recorder.register_counter(&all_override, &METADATA);
+        let _ = recorder.register_histogram(&all_override, &METADATA);
     }
 }

--- a/metrics-util/src/layers/router.rs
+++ b/metrics-util/src/layers/router.rs
@@ -221,13 +221,8 @@ mod tests {
 
         let mut seq = Sequence::new();
 
-        static METADATA: metrics::Metadata = metrics::Metadata::new(
-            module_path!(),
-            metrics::Level::INFO,
-            Some(module_path!()),
-            Some(file!()),
-            Some(line!()),
-        );
+        static METADATA: metrics::Metadata =
+            metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
         default_mock
             .expect_register_counter()

--- a/metrics-util/src/recoverable.rs
+++ b/metrics-util/src/recoverable.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Weak};
 
 use metrics::{
-    Counter, Gauge, Histogram, Key, KeyName, Recorder, SetRecorderError, SharedString, Unit,
+    Counter, Gauge, Histogram, Key, KeyName, Recorder, SetRecorderError, SharedString, Unit, Metadata,
 };
 
 /// Wraps a recorder to allow for recovering it after being installed.
@@ -92,25 +92,25 @@ impl<R: Recorder> Recorder for WeakRecorder<R> {
         }
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
         if let Some(recorder) = self.recorder.upgrade() {
-            recorder.register_counter(key)
+            recorder.register_counter(key, metadata)
         } else {
             Counter::noop()
         }
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
         if let Some(recorder) = self.recorder.upgrade() {
-            recorder.register_gauge(key)
+            recorder.register_gauge(key, metadata)
         } else {
             Gauge::noop()
         }
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
         if let Some(recorder) = self.recorder.upgrade() {
-            recorder.register_histogram(key)
+            recorder.register_histogram(key, metadata)
         } else {
             Histogram::noop()
         }
@@ -226,15 +226,15 @@ mod tests {
             todo!()
         }
 
-        fn register_counter(&self, _: &Key) -> Counter {
+        fn register_counter(&self, _: &Key, _: &Metadata<'_>) -> Counter {
             Counter::from_arc(Arc::clone(&self.counter))
         }
 
-        fn register_gauge(&self, _: &Key) -> Gauge {
+        fn register_gauge(&self, _: &Key, _: &Metadata<'_>) -> Gauge {
             Gauge::from_arc(Arc::clone(&self.gauge))
         }
 
-        fn register_histogram(&self, _: &Key) -> Histogram {
+        fn register_histogram(&self, _: &Key, _: &Metadata<'_>) -> Histogram {
             Histogram::from_arc(Arc::clone(&self.histogram))
         }
     }

--- a/metrics/benches/macros.rs
+++ b/metrics/benches/macros.rs
@@ -3,7 +3,9 @@ extern crate criterion;
 
 use criterion::Criterion;
 
-use metrics::{counter, Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
+use metrics::{
+    counter, Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit,
+};
 use rand::{thread_rng, Rng};
 
 #[derive(Default)]
@@ -12,13 +14,13 @@ impl Recorder for TestRecorder {
     fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
     fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
     fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
-    fn register_counter(&self, _: &Key) -> Counter {
+    fn register_counter(&self, _: &Key, _: &Metadata<'_>) -> Counter {
         Counter::noop()
     }
-    fn register_gauge(&self, _: &Key) -> Gauge {
+    fn register_gauge(&self, _: &Key, _: &Metadata<'_>) -> Gauge {
         Gauge::noop()
     }
-    fn register_histogram(&self, _: &Key) -> Histogram {
+    fn register_histogram(&self, _: &Key, _: &Metadata<'_>) -> Histogram {
         Histogram::noop()
     }
 }

--- a/metrics/examples/basic.rs
+++ b/metrics/examples/basic.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use metrics::{
     absolute_counter, counter, decrement_gauge, describe_counter, describe_gauge,
     describe_histogram, gauge, histogram, increment_counter, increment_gauge, register_counter,
-    register_gauge, register_histogram, KeyName, SharedString,
+    register_gauge, register_histogram, KeyName, Metadata, SharedString,
 };
 use metrics::{Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, Recorder, Unit};
 
@@ -77,15 +77,15 @@ impl Recorder for PrintRecorder {
         );
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
         Counter::from_arc(Arc::new(PrintHandle(key.clone())))
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
         Gauge::from_arc(Arc::new(PrintHandle(key.clone())))
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
         Histogram::from_arc(Arc::new(PrintHandle(key.clone())))
     }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -270,6 +270,9 @@ pub use self::key::*;
 mod label;
 pub use self::label::*;
 
+mod metadata;
+pub use self::metadata::*;
+
 mod recorder;
 pub use self::recorder::*;
 

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -523,10 +523,13 @@ pub use metrics_macros::register_histogram;
 ///
 /// # Example
 /// ```
-/// # use metrics::counter;
+/// # use metrics::{counter, Level};
 /// # fn main() {
 /// // A basic counter:
 /// counter!("some_metric_name", 12);
+///
+/// // A basic counter with level and target specified:
+/// counter!(target: "specific_target", level: Level::DEBUG, "some_metric_name", 12);
 ///
 /// // Specifying labels inline, including using constants for either the key or value:
 /// counter!("some_metric_name", 12, "service" => "http");
@@ -561,10 +564,13 @@ pub use metrics_macros::counter;
 ///
 /// # Example
 /// ```
-/// # use metrics::increment_counter;
+/// # use metrics::{increment_counter, Level};
 /// # fn main() {
 /// // A basic increment:
 /// increment_counter!("some_metric_name");
+///
+/// // A basic increment with level and target specified:
+/// increment_counter!(target: "specific_target", level: Level::DEBUG, "some_metric_name");
 ///
 /// // Specifying labels inline, including using constants for either the key or value:
 /// increment_counter!("some_metric_name", "service" => "http");
@@ -606,10 +612,13 @@ pub use metrics_macros::increment_counter;
 ///
 /// # Example
 /// ```
-/// # use metrics::absolute_counter;
+/// # use metrics::{absolute_counter, Level};
 /// # fn main() {
 /// // A basic counter:
 /// absolute_counter!("some_metric_name", 12);
+///
+/// // A basic counter with level and target specified:
+/// absolute_counter!(target: "specific_target", level: Level::DEBUG, "some_metric_name", 12);
 ///
 /// // Specifying labels inline, including using constants for either the key or value:
 /// absolute_counter!("some_metric_name", 13, "service" => "http");
@@ -644,10 +653,13 @@ pub use metrics_macros::absolute_counter;
 ///
 /// # Example
 /// ```
-/// # use metrics::gauge;
+/// # use metrics::{gauge, Level};
 /// # fn main() {
 /// // A basic gauge:
 /// gauge!("some_metric_name", 42.2222);
+///
+/// // A basic gauge with level and target specified:
+/// gauge!(target: "specific_target", level: Level::DEBUG, "some_metric_name", 42.2222);
 ///
 /// // Specifying labels inline, including using constants for either the key or value:
 /// gauge!("some_metric_name", 66.6666, "service" => "http");
@@ -682,10 +694,13 @@ pub use metrics_macros::gauge;
 ///
 /// # Example
 /// ```
-/// # use metrics::increment_gauge;
+/// # use metrics::{increment_gauge, Level};
 /// # fn main() {
 /// // A basic gauge:
 /// increment_gauge!("some_metric_name", 42.2222);
+///
+/// // A basic gauge with level and target specified:
+/// increment_gauge!(target: "specific_target", level: Level::DEBUG, "some_metric_name", 42.2222);
 ///
 /// // Specifying labels inline, including using constants for either the key or value:
 /// increment_gauge!("some_metric_name", 66.6666, "service" => "http");
@@ -720,10 +735,13 @@ pub use metrics_macros::increment_gauge;
 ///
 /// # Example
 /// ```
-/// # use metrics::decrement_gauge;
+/// # use metrics::{decrement_gauge, Level};
 /// # fn main() {
 /// // A basic gauge:
 /// decrement_gauge!("some_metric_name", 42.2222);
+///
+/// // A basic gauge with level and target specified:
+/// decrement_gauge!(target: "specific_target", level: Level::DEBUG, "some_metric_name", 42.2222);
 ///
 /// // Specifying labels inline, including using constants for either the key or value:
 /// decrement_gauge!("some_metric_name", 66.6666, "service" => "http");
@@ -767,11 +785,14 @@ pub use metrics_macros::decrement_gauge;
 ///
 /// # Example
 /// ```
-/// # use metrics::histogram;
+/// # use metrics::{histogram, Level};
 /// # use std::time::Duration;
 /// # fn main() {
 /// // A basic histogram:
 /// histogram!("some_metric_name", 34.3);
+///
+/// // A basic histogram with level and target specified:
+/// histogram!(target: "specific_target", level: Level::DEBUG, "some_metric_name", 34.3);
 ///
 /// // An implicit conversion from `Duration`:
 /// let d = Duration::from_millis(17);

--- a/metrics/src/metadata.rs
+++ b/metrics/src/metadata.rs
@@ -25,19 +25,11 @@ pub struct Metadata<'a> {
     target: &'a str,
     level: Level,
     module_path: Option<&'a str>,
-    file: Option<&'a str>,
-    line: Option<u32>,
 }
 
 impl<'a> Metadata<'a> {
-    pub const fn new(
-        target: &'a str,
-        level: Level,
-        module_path: Option<&'a str>,
-        file: Option<&'a str>,
-        line: Option<u32>,
-    ) -> Self {
-        Self { target, level, module_path, file, line }
+    pub const fn new(target: &'a str, level: Level, module_path: Option<&'a str>) -> Self {
+        Self { target, level, module_path }
     }
 
     pub fn level(&self) -> &Level {
@@ -50,13 +42,5 @@ impl<'a> Metadata<'a> {
 
     pub fn module_path(&self) -> Option<&'a str> {
         self.module_path
-    }
-
-    pub fn file(&self) -> Option<&'a str> {
-        self.file
-    }
-
-    pub fn line(&self) -> Option<u32> {
-        self.line
     }
 }

--- a/metrics/src/metadata.rs
+++ b/metrics/src/metadata.rs
@@ -30,11 +30,13 @@ enum LevelInner {
 /// Contains the following:
 /// 
 /// - A [`target`](Metadata::target), specifying the part of the system where the metric event occurred. When
-/// initialized via the [metrics macro](metrics_macro), and left unspecified, this defaults to the module path the
+/// initialized via the [metrics macro], and left unspecified, this defaults to the module path the
 /// macro was invoked from.
 /// - A [`level`](Metadata::level), specifying the verbosity the metric event is emitted at.
 /// - An optional [`module_path`](Metadata::module_path), specifying the the module path the metric event was emitted
 /// from.
+/// 
+/// [metrics_macros]: https://docs.rs/metrics/latest/metrics/#macros
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Metadata<'a> {
     target: &'a str,

--- a/metrics/src/metadata.rs
+++ b/metrics/src/metadata.rs
@@ -1,0 +1,62 @@
+#![allow(missing_docs)]
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Level(LevelInner);
+
+impl Level {
+    pub const TRACE: Self = Self(LevelInner::Trace);
+    pub const DEBUG: Self = Self(LevelInner::Debug);
+    pub const ERROR: Self = Self(LevelInner::Error);
+    pub const WARN: Self = Self(LevelInner::Warn);
+    pub const INFO: Self = Self(LevelInner::Info);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LevelInner {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Metadata<'a> {
+    target: &'a str,
+    level: Level,
+    module_path: Option<&'a str>,
+    file: Option<&'a str>,
+    line: Option<u32>,
+}
+
+impl<'a> Metadata<'a> {
+    pub const fn new(
+        target: &'a str,
+        level: Level,
+        module_path: Option<&'a str>,
+        file: Option<&'a str>,
+        line: Option<u32>,
+    ) -> Self {
+        Self { target, level, module_path, file, line }
+    }
+
+    pub fn level(&self) -> &Level {
+        &self.level
+    }
+
+    pub fn target(&self) -> &'a str {
+        self.target
+    }
+
+    pub fn module_path(&self) -> Option<&'a str> {
+        self.module_path
+    }
+
+    pub fn file(&self) -> Option<&'a str> {
+        self.file
+    }
+
+    pub fn line(&self) -> Option<u32> {
+        self.line
+    }
+}

--- a/metrics/src/metadata.rs
+++ b/metrics/src/metadata.rs
@@ -26,16 +26,16 @@ enum LevelInner {
 
 /// Metadata describing a metric event. This provides additional context to [`Recorder`](crate::Recorder), allowing for
 /// fine-grained filtering.
-/// 
+///
 /// Contains the following:
-/// 
+///
 /// - A [`target`](Metadata::target), specifying the part of the system where the metric event occurred. When
 /// initialized via the [metrics macro], and left unspecified, this defaults to the module path the
 /// macro was invoked from.
 /// - A [`level`](Metadata::level), specifying the verbosity the metric event is emitted at.
 /// - An optional [`module_path`](Metadata::module_path), specifying the the module path the metric event was emitted
 /// from.
-/// 
+///
 /// [metrics_macros]: https://docs.rs/metrics/latest/metrics/#macros
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Metadata<'a> {

--- a/metrics/src/metadata.rs
+++ b/metrics/src/metadata.rs
@@ -1,14 +1,18 @@
-#![allow(missing_docs)]
-
+/// Describes the level of verbosity of a metric event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Level(LevelInner);
 
 impl Level {
+    /// The "error" level.
     pub const TRACE: Self = Self(LevelInner::Trace);
+    /// The "warn" level.
     pub const DEBUG: Self = Self(LevelInner::Debug);
-    pub const ERROR: Self = Self(LevelInner::Error);
-    pub const WARN: Self = Self(LevelInner::Warn);
+    /// The "info" level.
     pub const INFO: Self = Self(LevelInner::Info);
+    /// The "debug" level.
+    pub const WARN: Self = Self(LevelInner::Warn);
+    /// The "trace" level.
+    pub const ERROR: Self = Self(LevelInner::Error);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,6 +24,17 @@ enum LevelInner {
     Error = 4,
 }
 
+/// Metadata describing a metric event. This provides additional context to [`Recorder`](crate::Recorder), allowing for
+/// fine-grained filtering.
+/// 
+/// Contains the following:
+/// 
+/// - A [`target`](Metadata::target), specifying the part of the system where the metric event occurred. When
+/// initialized via the [metrics macro](metrics_macro), and left unspecified, this defaults to the module path the
+/// macro was invoked from.
+/// - A [`level`](Metadata::level), specifying the verbosity the metric event is emitted at.
+/// - An optional [`module_path`](Metadata::module_path), specifying the the module path the metric event was emitted
+/// from.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Metadata<'a> {
     target: &'a str,
@@ -28,18 +43,22 @@ pub struct Metadata<'a> {
 }
 
 impl<'a> Metadata<'a> {
+    /// Constructs a new [`Metadata`].
     pub const fn new(target: &'a str, level: Level, module_path: Option<&'a str>) -> Self {
         Self { target, level, module_path }
     }
 
+    /// Returns the verbosity level of the metric event.
     pub fn level(&self) -> &Level {
         &self.level
     }
 
+    /// Returns the target of the metric event. This specifies the part of the system where the event occurred.
     pub fn target(&self) -> &'a str {
         self.target
     }
 
+    /// Returns the module path of the metric event. This specifies the module where the event occurred.
     pub fn module_path(&self) -> Option<&'a str> {
         self.module_path
     }

--- a/metrics/src/recorder.rs
+++ b/metrics/src/recorder.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
 use self::cell::RecorderOnceCell;
-use crate::{Counter, Gauge, Histogram, Key, KeyName, SharedString, Unit};
+
+use crate::{Counter, Gauge, Histogram, Key, KeyName, Metadata, SharedString, Unit};
 
 mod cell {
     use super::{Recorder, SetRecorderError};
@@ -119,13 +120,13 @@ pub trait Recorder {
     fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, description: SharedString);
 
     /// Registers a counter.
-    fn register_counter(&self, key: &Key) -> Counter;
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter;
 
     /// Registers a gauge.
-    fn register_gauge(&self, key: &Key) -> Gauge;
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge;
 
     /// Registers a histogram.
-    fn register_histogram(&self, key: &Key) -> Histogram;
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram;
 }
 
 /// A no-op recorder.
@@ -138,13 +139,13 @@ impl Recorder for NoopRecorder {
     fn describe_counter(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
     fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
     fn describe_histogram(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
-    fn register_counter(&self, _key: &Key) -> Counter {
+    fn register_counter(&self, _key: &Key, _metadata: &Metadata<'_>) -> Counter {
         Counter::noop()
     }
-    fn register_gauge(&self, _key: &Key) -> Gauge {
+    fn register_gauge(&self, _key: &Key, _metadata: &Metadata<'_>) -> Gauge {
         Gauge::noop()
     }
-    fn register_histogram(&self, _key: &Key) -> Histogram {
+    fn register_histogram(&self, _key: &Key, _metadata: &Metadata<'_>) -> Histogram {
         Histogram::noop()
     }
 }


### PR DESCRIPTION
**Motivation**

Closes https://github.com/metrics-rs/metrics/issues/370

**Changes**

- Add `&Metadata` argument to the `Recorder::register_*` methods
- Add `target: *` and `Level::*` arguments to macros.
    - `target` defaults to `module_path!()`
    - `Level` defaults to `Level::INFO`.

**TODO**

- [ ] Add documentation
- [ ] Add `info_counter!`, `warn_counter!`, etc
- [ ] Improve test coverage