### PR TITLE
Expand lifetime of KeyName as_str

### DIFF
--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -20,7 +20,7 @@ impl KeyName {
     }
 
     /// Gets a reference to the strin used for this name.
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         &self.0
     }
 }


### PR DESCRIPTION
A `SharedString` is valid during the duration of the program, once built. This PR extends the lifetime of the string slice returned by `as_str` to avoid needing to clone the key name.