### PR TITLE
Add support for `Arc<T>` to `metrics::Cow<'a, T>`.

### DIFF
--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -107,8 +107,7 @@ pub use label_filter::LabelFilter;
 use tracing_integration::WithContext;
 pub use tracing_integration::{Labels, MetricsLayer};
 
-/// [`TracingContextLayer`] provides an implementation of a [`Layer`][metrics_util::layers::Layer]
-/// for [`TracingContext`].
+/// [`TracingContextLayer`] provides an implementation of a [`Layer`] for [`TracingContext`].
 pub struct TracingContextLayer<F> {
     label_filter: F,
 }

--- a/metrics-util/src/registry/mod.rs
+++ b/metrics-util/src/registry/mod.rs
@@ -32,17 +32,14 @@ type RegistryHashMap<K, V> = HashMap<K, V, BuildHasherDefault<RegistryHasher>>;
 /// ## Using `Registry` as the basis of an exporter
 ///
 /// As a reusable building blocking for building exporter implementations, users should look at
-/// [`Key`] and [`AtomicStorage`][crate::registry::AtomicStorage] to use for their key and storage,
-/// respectively.
+/// [`Key`] and [`AtomicStorage`] to use for their key and storage, respectively.
 ///
 /// These two implementations provide behavior that is suitable for most exporters, providing
 /// seamless integration with the existing key type used by the core
 /// [`Recorder`][metrics::Recorder] trait, as well as atomic storage for metrics.
 ///
-/// In some cases, users may prefer
-/// [`GenerationalAtomicStorage`][crate::registry::GenerationalAtomicStorage] when know if a metric
-/// has been touched, even if its value has not changed since the last time it was observed, is
-/// necessary.
+/// In some cases, users may prefer [`GenerationalAtomicStorage`] when know if a metric has been
+/// touched, even if its value has not changed since the last time it was observed, is necessary.
 ///
 /// ## Performance
 ///

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Support for using `Arc<T>` with `Cow<'a, T>`.
+  ([#402](https://github.com/metrics-rs/metrics/pull/402))
+
+  This will primarily allow using `Arc<str>` for metric names and labels, where previously only
+  `&'static str` or `String` were allowed. There's still work to be done to also support labels in
+  this regard.
+
 ## [0.21.1] - 2023-07-02
 
 ### Added

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -6,12 +6,15 @@ use crate::cow::Cow;
 
 /// An allocation-optimized string.
 ///
-/// We specify `SharedString` to attempt to get the best of both worlds: flexibility to provide a
-/// static or dynamic (owned) string, while retaining the performance benefits of being able to
-/// take ownership of owned strings and borrows of completely static strings.
+/// `SharedString` uses a custom copy-on-write implementation that is optimized for metric keys,
+/// providing ergonomic sharing of single instances, or slices, of strings and labels. This
+/// copy-on-write implementation is optimized to allow for constant-time construction (using static
+/// values), as well as accepting owned values and values shared through [`Arc<T>`](std::sync::Arc).
 ///
-/// `SharedString` can be converted to from either `&'static str` or `String`, with a method,
-/// `const_str`, from constructing `SharedString` from `&'static str` in a `const` fashion.
+/// End users generally will not need to interact with this type directly, as the top-level macros
+/// (`counter!`, etc), as well as the various conversion implementations
+/// ([`From<T>`](std::convert::From)), generally allow users to pass whichever variant of a value
+/// (static, owned, shared) is best for them.
 pub type SharedString = Cow<'static, str>;
 
 /// Key-specific hashing algorithm.

--- a/metrics/src/cow.rs
+++ b/metrics/src/cow.rs
@@ -5,32 +5,178 @@ use std::{
     hash::{Hash, Hasher},
     marker::PhantomData,
     mem::ManuallyDrop,
+    ops::Deref,
     ptr::{slice_from_raw_parts, NonNull},
+    sync::Arc,
 };
 
-use crate::label::Label;
+#[derive(Clone, Copy)]
+enum Kind {
+    Owned,
+    Borrowed,
+    Shared,
+}
 
-/// A clone-on-write smart pointer with an optimized memory layout.
+/// A clone-on-write smart pointer with an optimized memory layout, based on `beef`.
+///
+/// # Strings, strings everywhere
+///
+/// In `metrics`, strings are arguably the most common data type used despite the fact that metrics
+/// are measuring numerical values. Both the name of a metric, and its labels, are strings: emitting
+/// a metric may involve one string, or 10 strings. Many of these strings tend to be used over and
+/// over during the life of the process, as well.
+///
+/// In order to achieve and maintain a high level of performance, we use a "clone-on-write" smart
+/// pointer to handle passing these strings around. Doing so allows us to potentially avoid having
+/// to allocate entire copies of a string, instead using a lightweight smart pointer that can live
+/// on the stack.
+///
+/// # Why not `std::borrow::Cow`?
+///
+/// The standard library already provides a clone-on-write smart pointer, `std::borrow::Cow`, which
+/// works well in many cases. However, `metrics` strives to provide minimal overhead where possible,
+/// and so `std::borrow::Cow` falls down in one particular way: it uses an enum representation which
+/// consumes an additional word of storage.
+///
+/// As an example, let's look at strings. A string in `std::borrow::Cow` implies that `T` is `str`,
+/// and the owned version of `str` is simply `String`. Thus, for `std::borrow::Cow`, the in-memory
+/// layout looks like this:
+///
+/// ```text
+///                                                                       Padding
+///                                                                          |
+///                                                                          v
+///                       +--------------+-------------+--------------+--------------+
+/// stdlib Cow::Borrowed: |   Enum Tag   |   Pointer   |    Length    |   XXXXXXXX   |
+///                       +--------------+-------------+--------------+--------------+
+///                       +--------------+-------------+--------------+--------------+
+/// stdlib Cow::Owned:    |   Enum Tag   |   Pointer   |    Length    |   Capacity   |
+///                       +--------------+-------------+--------------+--------------+
+/// ```
+///
+/// As you can see, you pay a memory size penalty to be able to wrap an owned string. This
+/// additional word adds minimal overhead, but we can easily avoid it with some clever logic around
+/// the values of the length and capacity fields.
+///
+/// There is an existing crate that does just that: `beef`. Instead of using an enum, it is simply a
+/// struct that encodes the discriminant values in the length and capacity fields directly. If we're
+/// wrapping a borrowed value, we can infer that the "capacity" will always be zero, as we only need
+/// to track the capacity when we're wrapping an owned value, in order to be able to recreate the
+/// underlying storage when consuming the smart pointer, or dropping it. Instead of the above
+/// layout, `beef` looks like this:
+///
+/// ```text
+///                        +-------------+--------------+----------------+
+/// `beef` Cow (borrowed): |   Pointer   |  Length (N)  |  Capacity (0)  |
+///                        +-------------+--------------+----------------+
+///                        +-------------+--------------+----------------+
+/// `beef` Cow (owned):    |   Pointer   |  Length (N)  |  Capacity (M)  |
+///                        +-------------+--------------+----------------+
+/// ```
+///
+/// # Why not `beef`?
+///
+/// Up until this point, it might not be clear why we didn't just use `beef`. In truth, our design
+/// is fundamentally based on `beef`. Crucially, however, `beef` did not/still does not support
+/// `const` construction for generic slices.  Remember how we mentioned labels? The labels of a
+/// metric `are `[Label]` under-the-hood, and so without a way to construct them in a `const`
+/// fashion, our previous work to allow entirely static keys would not be possible.
+///
+/// Thus, we forked `beef` and copied into directly into `metrics` so that we could write a
+/// specialized `const` constructor for `[Label]`.
+///
+/// This is why we have our own `Cow` bundled into `metrics` directly, which is based on `beef`. In
+/// doing so, we can experiment with more interesting optimizations, and, as mentioned above, we can
+/// add const methods to support all of the types involved in statically building metrics keys.
+///
+/// # What we do that `beef` doesn't do
+///
+/// It was already enough to use our own implementation for the specialized `const` capabilities,
+/// but we've taken things even further in a key way: support for `Arc`-wrapped values.
+///
+/// ## `Arc`-wrapped values
+///
+/// For many strings, there is still a desire to share them cheaply even when they are constructed
+/// at run-time.  Remember, cloning a `Cow` of an owned value means cloning the value itself, so we
+/// need another level of indirection to allow the cheap sharing, which is where `Arc<T>` can
+/// provide value.
+///
+/// Users can construct a `Arc<T>`, where `T` is lined up with the `T` of `metrics::Cow`, and use
+/// that as the initial value instead. When `Cow` is cloned, we end up cloning the underlying
+/// `Arc<T>` instead, avoiding a new allocation.  `Arc<T>` still handles all of the normal logic
+/// necessary to know when the wrapped value must be dropped, and how many live references to the
+/// value that there are, and so on.
+///
+/// We handle this by relying on an invariant of `Vec<T>`: it never allocates more than `isize::MAX`
+/// [1]. This lets us derive the following truth table of the valid combinations of length/capacity:
+///
+/// ```text
+///                         Length (N)     Capacity (M)
+///                     +---------------+----------------+
+/// Borrowed (&T):      |       N       |        0       |
+///                     +---------------+----------------+
+/// Owned (T::ToOwned): |       N       | M < usize::MAX |
+///                     +---------------+----------------+
+/// Shared (Arc<T>):    |       N       |   usize::MAX   |
+///                     +---------------+----------------+
+/// ```
+///
+/// As we only implement `Cow` for types where their owned variants are either explicitly or
+/// implicitly backed by `Vec<_>`, we know that our capacity will never be `usize::MAX`, as it is
+/// limited to `isize::MAX`, and thus we can safely encode our "shared" state within the capacity
+/// field.
+///
+/// # Notes
+///
+/// [1] - technically, `Vec<T>` can have a capacity greater than `isize::MAX` when storing
+/// zero-sized types, but we don't do that here, so we always enforce that an owned version's
+/// capacity cannot be `usize::MAX` when constructing `Cow`.
 pub struct Cow<'a, T: Cowable + ?Sized + 'a> {
-    /// Pointer to data.
     ptr: NonNull<T::Pointer>,
-
-    /// Pointer metadata: length and capacity.
-    meta: Metadata,
-
-    /// Lifetime marker.
-    marker: PhantomData<&'a T>,
+    metadata: Metadata,
+    _lifetime: PhantomData<&'a T>,
 }
 
 impl<T> Cow<'_, T>
 where
     T: Cowable + ?Sized,
 {
-    #[inline]
-    pub fn owned(val: T::Owned) -> Self {
-        let (ptr, meta) = T::owned_into_parts(val);
+    fn from_parts(ptr: NonNull<T::Pointer>, metadata: Metadata) -> Self {
+        Self { ptr, metadata, _lifetime: PhantomData }
+    }
 
-        Cow { ptr, meta, marker: PhantomData }
+    /// Creates a pointer to an owned value, consuming it.
+    pub fn from_owned(owned: T::Owned) -> Self {
+        let (ptr, metadata) = T::owned_into_parts(owned);
+
+        // This check is partially to guard against the semantics of `Vec<T>` changing in the
+        // future, and partially to ensure that we don't somehow implement `Cowable` for a type
+        // where its owned version is backed by a vector of ZSTs, where the capacity could
+        // _legitimately_ be `usize::MAX`.
+        if metadata.capacity() == usize::MAX {
+            panic!("Invalid capacity of `usize::MAX` for owned value.");
+        }
+
+        Self::from_parts(ptr, metadata)
+    }
+
+    /// Creates a pointer to a shared value.
+    pub fn from_shared(arc: Arc<T>) -> Self {
+        let (ptr, metadata) = T::shared_into_parts(arc);
+        Self::from_parts(ptr, metadata)
+    }
+
+    /// Extracts the owned data.
+    ///
+    /// Clones the data if it is not already owned.
+    pub fn into_owned(self) -> <T as ToOwned>::Owned {
+        // We need to ensure that our own `Drop` impl does _not_ run because we're simply
+        // transferring ownership of the value back to the caller. For borrowed values, this is
+        // naturally a no-op because there's nothing to drop, but for owned values, like `String` or
+        // `Arc<T>`, we wouldn't want to double drop.
+        let cow = ManuallyDrop::new(self);
+
+        T::owned_from_parts(cow.ptr, &cow.metadata)
     }
 }
 
@@ -38,71 +184,69 @@ impl<'a, T> Cow<'a, T>
 where
     T: Cowable + ?Sized,
 {
-    #[inline]
-    pub fn borrowed(val: &'a T) -> Self {
-        let (ptr, meta) = T::ref_into_parts(val);
+    /// Creates a pointer to a borrowed value.
+    pub fn from_borrowed(borrowed: &'a T) -> Self {
+        let (ptr, metadata) = T::borrowed_into_parts(borrowed);
 
-        Cow { ptr, meta, marker: PhantomData }
-    }
-
-    #[inline]
-    pub fn into_owned(self) -> T::Owned {
-        let cow = ManuallyDrop::new(self);
-
-        if cow.is_borrowed() {
-            unsafe { T::clone_from_parts(cow.ptr, &cow.meta) }
-        } else {
-            unsafe { T::owned_from_parts(cow.ptr, &cow.meta) }
-        }
-    }
-
-    #[inline]
-    pub fn is_borrowed(&self) -> bool {
-        self.meta.capacity() == 0
-    }
-
-    #[inline]
-    pub fn is_owned(&self) -> bool {
-        self.meta.capacity() != 0
-    }
-
-    #[inline]
-    fn borrow(&self) -> &T {
-        unsafe { &*T::ref_from_parts(self.ptr, &self.meta) }
+        Self::from_parts(ptr, metadata)
     }
 }
 
-// Implementations of constant functions for creating `Cow` via static strings, static string
-// slices, and static label slices.
+impl<'a, T> Cow<'a, [T]>
+where
+    T: Clone,
+{
+    pub const fn const_slice(val: &'a [T]) -> Cow<'a, [T]> {
+        // SAFETY: We can never create a null pointer by casting a reference to a pointer.
+        let ptr = unsafe { NonNull::new_unchecked(val.as_ptr() as *mut _) };
+        let metadata = Metadata::borrowed(val.len());
+
+        Self { ptr, metadata, _lifetime: PhantomData }
+    }
+}
+
 impl<'a> Cow<'a, str> {
     pub const fn const_str(val: &'a str) -> Self {
-        Cow {
-            // We are casting *const T to *mut T, however for all borrowed values
-            // this raw pointer is only ever dereferenced back to &T.
-            ptr: unsafe { NonNull::new_unchecked(val.as_ptr() as *mut u8) },
-            meta: Metadata::from_ref(val.len()),
-            marker: PhantomData,
-        }
+        // SAFETY: We can never create a null pointer by casting a reference to a pointer.
+        let ptr = unsafe { NonNull::new_unchecked(val.as_ptr() as *mut _) };
+        let metadata = Metadata::borrowed(val.len());
+
+        Self { ptr, metadata, _lifetime: PhantomData }
     }
 }
 
-impl<'a> Cow<'a, [Cow<'static, str>]> {
-    pub const fn const_slice(val: &'a [Cow<'static, str>]) -> Self {
-        Cow {
-            ptr: unsafe { NonNull::new_unchecked(val.as_ptr() as *mut Cow<'static, str>) },
-            meta: Metadata::from_ref(val.len()),
-            marker: PhantomData,
-        }
+impl<T> Deref for Cow<'_, T>
+where
+    T: Cowable + ?Sized,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        let borrowed_ptr = T::borrowed_from_parts(self.ptr, &self.metadata);
+
+        // SAFETY: We only ever hold a pointer to a borrowed value of at least the lifetime of
+        // `Self`, or an owned value which we have ownership of (albeit indirectly when using
+        // `Arc<T>`), so our pointer is always valid and live for derefencing.
+        unsafe { borrowed_ptr.as_ref().unwrap() }
     }
 }
 
-impl<'a> Cow<'a, [Label]> {
-    pub const fn const_slice(val: &'a [Label]) -> Self {
-        Cow {
-            ptr: unsafe { NonNull::new_unchecked(val.as_ptr() as *mut Label) },
-            meta: Metadata::from_ref(val.len()),
-            marker: PhantomData,
-        }
+impl<T> Clone for Cow<'_, T>
+where
+    T: Cowable + ?Sized,
+{
+    fn clone(&self) -> Self {
+        let (ptr, metadata) = T::clone_from_parts(self.ptr, &self.metadata);
+        Self { ptr, metadata, _lifetime: PhantomData }
+    }
+}
+
+impl<T> Drop for Cow<'_, T>
+where
+    T: Cowable + ?Sized,
+{
+    fn drop(&mut self) {
+        T::drop_from_parts(self.ptr, &self.metadata);
     }
 }
 
@@ -112,7 +256,7 @@ where
 {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.borrow().hash(state)
+        self.deref().hash(state)
     }
 }
 
@@ -123,7 +267,7 @@ where
 {
     #[inline]
     fn default() -> Self {
-        Cow::borrowed(Default::default())
+        Cow::from_borrowed(Default::default())
     }
 }
 
@@ -136,7 +280,7 @@ where
 {
     #[inline]
     fn partial_cmp(&self, other: &Cow<'_, B>) -> Option<Ordering> {
-        PartialOrd::partial_cmp(self.borrow(), other.borrow())
+        PartialOrd::partial_cmp(self.deref(), other.deref())
     }
 }
 
@@ -146,7 +290,7 @@ where
 {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
-        Ord::cmp(self.borrow(), other.borrow())
+        Ord::cmp(self.deref(), other.deref())
     }
 }
 
@@ -156,16 +300,26 @@ where
 {
     #[inline]
     fn from(val: &'a T) -> Self {
-        Cow::borrowed(val)
+        Cow::from_borrowed(val)
     }
 }
 
-impl From<std::borrow::Cow<'static, str>> for Cow<'_, str> {
+impl<'a, T> From<Arc<T>> for Cow<'a, T>
+where
+    T: Cowable + ?Sized,
+{
     #[inline]
-    fn from(s: std::borrow::Cow<'static, str>) -> Self {
+    fn from(val: Arc<T>) -> Self {
+        Cow::from_shared(val)
+    }
+}
+
+impl<'a> From<std::borrow::Cow<'a, str>> for Cow<'a, str> {
+    #[inline]
+    fn from(s: std::borrow::Cow<'a, str>) -> Self {
         match s {
-            std::borrow::Cow::Borrowed(bs) => Cow::borrowed(bs),
-            std::borrow::Cow::Owned(os) => Cow::owned(os),
+            std::borrow::Cow::Borrowed(bs) => Cow::from_borrowed(bs),
+            std::borrow::Cow::Owned(os) => Cow::from_owned(os),
         }
     }
 }
@@ -173,60 +327,17 @@ impl From<std::borrow::Cow<'static, str>> for Cow<'_, str> {
 impl From<String> for Cow<'_, str> {
     #[inline]
     fn from(s: String) -> Self {
-        Cow::owned(s)
+        Cow::from_owned(s)
     }
 }
 
-impl From<Vec<Label>> for Cow<'_, [Label]> {
-    #[inline]
-    fn from(v: Vec<Label>) -> Self {
-        Cow::owned(v)
-    }
-}
-
-impl From<Vec<Cow<'static, str>>> for Cow<'_, [Cow<'static, str>]> {
-    #[inline]
-    fn from(v: Vec<Cow<'static, str>>) -> Self {
-        Cow::owned(v)
-    }
-}
-
-impl<T> Drop for Cow<'_, T>
+impl<T> From<Vec<T>> for Cow<'_, [T]>
 where
-    T: Cowable + ?Sized,
+    T: Clone,
 {
     #[inline]
-    fn drop(&mut self) {
-        if self.is_owned() {
-            unsafe { T::owned_from_parts(self.ptr, &self.meta) };
-        }
-    }
-}
-
-impl<'a, T> Clone for Cow<'a, T>
-where
-    T: Cowable + ?Sized,
-{
-    #[inline]
-    fn clone(&self) -> Self {
-        if self.is_owned() {
-            // Gotta clone the actual inner value.
-            Cow::owned(unsafe { T::clone_from_parts(self.ptr, &self.meta) })
-        } else {
-            Cow { ..*self }
-        }
-    }
-}
-
-impl<T> core::ops::Deref for Cow<'_, T>
-where
-    T: Cowable + ?Sized,
-{
-    type Target = T;
-
-    #[inline]
-    fn deref(&self) -> &T {
-        self.borrow()
+    fn from(v: Vec<T>) -> Self {
+        Cow::from_owned(v)
     }
 }
 
@@ -246,7 +357,7 @@ where
 {
     #[inline]
     fn borrow(&self) -> &T {
-        self.borrow()
+        self.deref()
     }
 }
 
@@ -257,7 +368,7 @@ where
     A: PartialEq<B>,
 {
     fn eq(&self, other: &Cow<B>) -> bool {
-        self.borrow() == other.borrow()
+        self.deref() == other.deref()
     }
 }
 
@@ -267,7 +378,7 @@ where
 {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.borrow().fmt(f)
+        self.deref().fmt(f)
     }
 }
 
@@ -277,249 +388,303 @@ where
 {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.borrow().fmt(f)
+        self.deref().fmt(f)
     }
 }
 
+// SAFETY: `NonNull<T>` is not `Send` or `Sync` by default, but we're asserting that `Cow` is so
+// long as the underlying `T` is.
 unsafe impl<T: Cowable + Sync + ?Sized> Sync for Cow<'_, T> {}
 unsafe impl<T: Cowable + Send + ?Sized> Send for Cow<'_, T> {}
 
-/// Helper trait required by `Cow<T>` to extract capacity of owned variant of `T`, and manage
-/// conversions.
-///
-/// This can be only implemented on types that match requirements:
-///
-/// + `T::Owned` has a `capacity`, which is an extra word that is absent in `T`.
-/// + `T::Owned` with `capacity` of `0` does not allocate memory.
-/// + `T::Owned` can be reconstructed from `*mut T` borrowed out of it, plus capacity.
-///
-/// # Safety
-///
-/// - While mutable pointers are used, no mutable reference is ever taken against it, whether the
-///   string is borrowed or owned.
-pub unsafe trait Cowable {
-    type Pointer;
-    type Owned;
-
-    fn ref_into_parts(&self) -> (NonNull<Self::Pointer>, Metadata);
-    fn owned_into_parts(owned: Self::Owned) -> (NonNull<Self::Pointer>, Metadata);
-
-    unsafe fn ref_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) -> *const Self;
-    unsafe fn owned_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) -> Self::Owned;
-    unsafe fn clone_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) -> Self::Owned;
-}
-
-unsafe impl Cowable for str {
-    type Pointer = u8;
-    type Owned = String;
-
-    #[inline]
-    fn ref_into_parts(&self) -> (NonNull<u8>, Metadata) {
-        // A note on soundness:
-        //
-        // We are casting *const T to *mut T, however for all borrowed values
-        // this raw pointer is only ever dereferenced back to &T.
-        let ptr = unsafe { NonNull::new_unchecked(self.as_ptr() as *mut _) };
-        let metadata = Metadata::from_ref(self.len());
-        (ptr, metadata)
-    }
-
-    #[inline]
-    unsafe fn ref_from_parts(ptr: NonNull<u8>, metadata: &Metadata) -> *const str {
-        slice_from_raw_parts(ptr.as_ptr(), metadata.length()) as *const _
-    }
-
-    #[inline]
-    fn owned_into_parts(owned: String) -> (NonNull<u8>, Metadata) {
-        // We need to go through Vec here to get provenance for the entire allocation
-        // instead of just the initialized parts.
-        let mut owned = ManuallyDrop::new(owned.into_bytes());
-        let ptr = unsafe { NonNull::new_unchecked(owned.as_mut_ptr()) };
-        let metadata = Metadata::from_owned(owned.len(), owned.capacity());
-        (ptr, metadata)
-    }
-
-    #[inline]
-    unsafe fn owned_from_parts(ptr: NonNull<u8>, metadata: &Metadata) -> String {
-        String::from_utf8_unchecked(Vec::from_raw_parts(
-            ptr.as_ptr(),
-            metadata.length(),
-            metadata.capacity(),
-        ))
-    }
-
-    #[inline]
-    unsafe fn clone_from_parts(ptr: NonNull<u8>, metadata: &Metadata) -> Self::Owned {
-        let str = Self::ref_from_parts(ptr, metadata);
-        str.as_ref().unwrap().to_string()
-    }
-}
-
-unsafe impl<'a> Cowable for [Cow<'a, str>] {
-    type Pointer = Cow<'a, str>;
-    type Owned = Vec<Cow<'a, str>>;
-
-    #[inline]
-    fn ref_into_parts(&self) -> (NonNull<Cow<'a, str>>, Metadata) {
-        // A note on soundness:
-        //
-        // We are casting *const T to *mut T, however for all borrowed values
-        // this raw pointer is only ever dereferenced back to &T.
-        let ptr = unsafe { NonNull::new_unchecked(self.as_ptr() as *mut _) };
-        let metadata = Metadata::from_ref(self.len());
-        (ptr, metadata)
-    }
-
-    #[inline]
-    unsafe fn ref_from_parts(
-        ptr: NonNull<Cow<'a, str>>,
-        metadata: &Metadata,
-    ) -> *const [Cow<'a, str>] {
-        slice_from_raw_parts(ptr.as_ptr(), metadata.length())
-    }
-
-    #[inline]
-    fn owned_into_parts(owned: Vec<Cow<'a, str>>) -> (NonNull<Cow<'a, str>>, Metadata) {
-        let mut owned = ManuallyDrop::new(owned);
-        let ptr = unsafe { NonNull::new_unchecked(owned.as_mut_ptr()) };
-        let metadata = Metadata::from_owned(owned.len(), owned.capacity());
-        (ptr, metadata)
-    }
-
-    #[inline]
-    unsafe fn owned_from_parts(
-        ptr: NonNull<Cow<'a, str>>,
-        metadata: &Metadata,
-    ) -> Vec<Cow<'a, str>> {
-        Vec::from_raw_parts(ptr.as_ptr(), metadata.length(), metadata.capacity())
-    }
-
-    #[inline]
-    unsafe fn clone_from_parts(ptr: NonNull<Cow<'a, str>>, metadata: &Metadata) -> Self::Owned {
-        let ptr = Self::ref_from_parts(ptr, metadata);
-        let xs = ptr.as_ref().unwrap();
-        let mut owned = Vec::with_capacity(xs.len() + 1);
-        owned.extend_from_slice(xs);
-        owned
-    }
-}
-
-unsafe impl Cowable for [Label] {
-    type Pointer = Label;
-    type Owned = Vec<Label>;
-
-    #[inline]
-    fn ref_into_parts(&self) -> (NonNull<Label>, Metadata) {
-        // A note on soundness:
-        //
-        // We are casting *const T to *mut T, however for all borrowed values
-        // this raw pointer is only ever dereferenced back to &T.
-        let ptr = unsafe { NonNull::new_unchecked(self.as_ptr() as *mut _) };
-        let metadata = Metadata::from_ref(self.len());
-        (ptr, metadata)
-    }
-
-    #[inline]
-    unsafe fn ref_from_parts(ptr: NonNull<Label>, metadata: &Metadata) -> *const [Label] {
-        slice_from_raw_parts(ptr.as_ptr(), metadata.length())
-    }
-
-    #[inline]
-    fn owned_into_parts(owned: Vec<Label>) -> (NonNull<Label>, Metadata) {
-        let mut owned = ManuallyDrop::new(owned);
-        let ptr = unsafe { NonNull::new_unchecked(owned.as_mut_ptr()) };
-        let metadata = Metadata::from_owned(owned.len(), owned.capacity());
-        (ptr, metadata)
-    }
-
-    #[inline]
-    unsafe fn owned_from_parts(ptr: NonNull<Label>, metadata: &Metadata) -> Vec<Label> {
-        Vec::from_raw_parts(ptr.as_ptr(), metadata.length(), metadata.capacity())
-    }
-
-    #[inline]
-    unsafe fn clone_from_parts(ptr: NonNull<Label>, metadata: &Metadata) -> Self::Owned {
-        let xs = Self::ref_from_parts(ptr, metadata);
-        xs.as_ref().unwrap().to_vec()
-    }
-}
-
+#[repr(C)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Metadata(usize, usize);
 
 impl Metadata {
     #[inline]
-    fn length(&self) -> usize {
+    const fn len(&self) -> usize {
         self.0
     }
 
     #[inline]
-    fn capacity(&self) -> usize {
+    const fn capacity(&self) -> usize {
         self.1
     }
 
-    pub const fn from_ref(len: usize) -> Metadata {
+    #[inline]
+    const fn kind(&self) -> Kind {
+        match (self.0, self.1) {
+            (_, usize::MAX) => Kind::Shared,
+            (_, 0) => Kind::Borrowed,
+            _ => Kind::Owned,
+        }
+    }
+
+    #[inline]
+    const fn shared(len: usize) -> Metadata {
+        Metadata(len, usize::MAX)
+    }
+
+    #[inline]
+    const fn borrowed(len: usize) -> Metadata {
         Metadata(len, 0)
     }
 
-    pub const fn from_owned(len: usize, capacity: usize) -> Metadata {
+    #[inline]
+    const fn owned(len: usize, capacity: usize) -> Metadata {
         Metadata(len, capacity)
-    }
-
-    pub const fn borrowed() -> Metadata {
-        Metadata(0, 0)
-    }
-
-    pub const fn owned() -> Metadata {
-        Metadata(0, 1)
     }
 }
 
-/*
+pub trait Cowable: ToOwned {
+    type Pointer;
 
-This can be enabled again when we have a way to do panics/asserts in stable Rust,
-since const panicking is behind a feature flag at the moment.
+    fn borrowed_into_parts(&self) -> (NonNull<Self::Pointer>, Metadata);
+    fn owned_into_parts(owned: <Self as ToOwned>::Owned) -> (NonNull<Self::Pointer>, Metadata);
+    fn shared_into_parts(arc: Arc<Self>) -> (NonNull<Self::Pointer>, Metadata);
 
-const MASK_LO: usize = u32::MAX as usize;
-const MASK_HI: usize = !MASK_LO;
+    fn borrowed_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) -> *const Self;
+    fn owned_from_parts(
+        ptr: NonNull<Self::Pointer>,
+        metadata: &Metadata,
+    ) -> <Self as ToOwned>::Owned;
+    fn clone_from_parts(
+        ptr: NonNull<Self::Pointer>,
+        metadata: &Metadata,
+    ) -> (NonNull<Self::Pointer>, Metadata);
+    fn drop_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata);
+}
 
-#[cfg(target_pointer_width = "64")]
-impl Metadata {
+impl Cowable for str {
+    type Pointer = u8;
+
     #[inline]
-    fn length(&self) -> usize {
-        self.0 & MASK_LO
+    fn borrowed_into_parts(&self) -> (NonNull<Self::Pointer>, Metadata) {
+        // SAFETY: We know that it's safe to take and hold a pointer to a reference to `Self` since
+        // `Cow` can only live as long as the input reference does, and an invalid pointer cannot
+        // be taken from a live reference.
+        let ptr = unsafe { NonNull::new_unchecked(self.as_ptr() as *mut _) };
+        let metadata = Metadata::borrowed(self.len());
+        (ptr, metadata)
     }
 
     #[inline]
-    fn capacity(&self) -> usize {
-        self.0 & MASK_HI
+    fn owned_into_parts(owned: Self::Owned) -> (NonNull<Self::Pointer>, Metadata) {
+        // SAFETY: We know that it's safe to take and hold a pointer to a reference to `owned` since
+        // we own the allocation by virtue of consuming it here without dropping it.
+        let mut owned = ManuallyDrop::new(owned.into_bytes());
+        let ptr = unsafe { NonNull::new_unchecked(owned.as_mut_ptr()) };
+        let metadata = Metadata::owned(owned.len(), owned.capacity());
+        (ptr, metadata)
     }
 
-    pub const fn from_ref(len: usize) -> Metadata {
-        if len & MASK_HI != 0 {
-            panic!("Cow: length out of bounds for referenced value");
+    #[inline]
+    fn shared_into_parts(arc: Arc<Self>) -> (NonNull<Self::Pointer>, Metadata) {
+        let metadata = Metadata::shared(arc.len());
+        // SAFETY: We know that the pointer given back by `Arc::into_raw` is valid.
+        let ptr = unsafe { NonNull::new_unchecked(Arc::into_raw(arc) as *mut _) };
+        (ptr, metadata)
+    }
+
+    #[inline]
+    fn borrowed_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) -> *const Self {
+        slice_from_raw_parts(ptr.as_ptr(), metadata.len()) as *const _
+    }
+
+    #[inline]
+    fn owned_from_parts(
+        ptr: NonNull<Self::Pointer>,
+        metadata: &Metadata,
+    ) -> <Self as ToOwned>::Owned {
+        match metadata.kind() {
+            Kind::Borrowed => {
+                // SAFETY: We know that it's safe to take and hold a pointer to a reference to
+                // `Self` since `Cow` can only live as long as the input reference does, and an
+                // invalid pointer cannot be taken from a live reference.
+                let s = unsafe { &*Self::borrowed_from_parts(ptr, metadata) };
+                s.to_owned()
+            }
+
+            // SAFETY: We know that the pointer is valid because it could have only been constructed
+            // from a valid `String` handed to `Cow::from_owned`, which we assumed ownership of.
+            Kind::Owned => unsafe {
+                String::from_raw_parts(ptr.as_ptr(), metadata.len(), metadata.capacity())
+            },
+            Kind::Shared => {
+                // SAFETY: We know that the pointer is valid because it could have only been
+                // constructed from a valid `Arc<str>` handed to `Cow::from_shared`, which we
+                // assumed ownership of, also ensuring that the strong count is at least one.
+                let s = unsafe { Arc::from_raw(Self::borrowed_from_parts(ptr, metadata)) };
+                s.to_string()
+            }
         }
-
-        Metadata(len)
     }
 
-    pub const fn from_owned(len: usize, capacity: usize) -> Metadata {
-        if len & MASK_HI != 0 {
-            panic!("Cow: length out of bounds for owned value");
+    #[inline]
+    fn clone_from_parts(
+        ptr: NonNull<Self::Pointer>,
+        metadata: &Metadata,
+    ) -> (NonNull<Self::Pointer>, Metadata) {
+        match metadata.kind() {
+            Kind::Borrowed => (ptr, *metadata),
+            Kind::Owned => {
+                // SAFETY: We know that the pointer is valid because it could have only been constructed
+                // from a valid `String` handed to `Cow::from_owned`, which we assumed ownership of.
+                let s = unsafe { &*Self::borrowed_from_parts(ptr, metadata) };
+
+                Self::owned_into_parts(s.to_string())
+            }
+            Kind::Shared => clone_shared::<Self>(ptr, metadata),
         }
+    }
 
-        if capacity & MASK_HI != 0 {
-            panic!("Cow: capacity out of bounds for owned value");
+    #[inline]
+    fn drop_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) {
+        match metadata.kind() {
+            Kind::Borrowed => {}
+
+            // SAFETY: We know that the pointer is valid because it could have only been constructed
+            // from a valid `String` handed to `Cow::from_owned`, which we assumed ownership of.
+            Kind::Owned => unsafe {
+                drop(Vec::from_raw_parts(ptr.as_ptr(), metadata.len(), metadata.capacity()));
+            },
+
+            // SAFETY: We know that the pointer is valid because it could have only been constructed
+            // from a valid `Arc<str>` handed to `Cow::from_shared`, which we assumed ownership of,
+            // also ensuring that the strong count is at least one.
+            Kind::Shared => unsafe {
+                drop(Arc::from_raw(Self::borrowed_from_parts(ptr, metadata)));
+            },
         }
+    }
+}
 
-        Metadata((capacity & MASK_LO) << 32 | len & MASK_LO)
+impl<T> Cowable for [T]
+where
+    T: Clone,
+{
+    type Pointer = T;
+
+    #[inline]
+    fn borrowed_into_parts(&self) -> (NonNull<Self::Pointer>, Metadata) {
+        // SAFETY: We know that it's safe to take and hold a pointer to a reference to `Self` since
+        // `Cow` can only live as long as the input reference does, and an invalid pointer cannot
+        // be taken from a live reference.
+        let ptr = unsafe { NonNull::new_unchecked(self.as_ptr() as *mut _) };
+        let metadata = Metadata::borrowed(self.len());
+        (ptr, metadata)
     }
 
-    pub const fn borrowed() -> Metadata {
-        Metadata(0)
+    #[inline]
+    fn owned_into_parts(owned: <Self as ToOwned>::Owned) -> (NonNull<Self::Pointer>, Metadata) {
+        let mut owned = ManuallyDrop::new(owned);
+
+        // SAFETY: We know that it's safe to take and hold a pointer to a reference to `owned` since
+        // we own the allocation by virtue of consuming it here without dropping it.
+        let ptr = unsafe { NonNull::new_unchecked(owned.as_mut_ptr()) };
+        let metadata = Metadata::owned(owned.len(), owned.capacity());
+        (ptr, metadata)
     }
 
-    pub const fn owned() -> Metadata {
-        Metadata(1 << 32)
+    #[inline]
+    fn shared_into_parts(arc: Arc<Self>) -> (NonNull<Self::Pointer>, Metadata) {
+        let metadata = Metadata::shared(arc.len());
+        // SAFETY: We know that the pointer given back by `Arc::into_raw` is valid.
+        let ptr = unsafe { NonNull::new_unchecked(Arc::into_raw(arc) as *mut _) };
+        (ptr, metadata)
     }
-}*/
+
+    #[inline]
+    fn borrowed_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) -> *const Self {
+        slice_from_raw_parts(ptr.as_ptr(), metadata.len()) as *const _
+    }
+
+    #[inline]
+    fn owned_from_parts(
+        ptr: NonNull<Self::Pointer>,
+        metadata: &Metadata,
+    ) -> <Self as ToOwned>::Owned {
+        match metadata.kind() {
+            Kind::Borrowed => {
+                // SAFETY: We know that it's safe to take and hold a pointer to a reference to
+                // `Self` since `Cow` can only live as long as the input reference does, and an
+                // invalid pointer cannot be taken from a live reference.
+                let data = unsafe { &*Self::borrowed_from_parts(ptr, metadata) };
+                data.to_vec()
+            }
+
+            // SAFETY: We know that the pointer is valid because it could have only been
+            // constructed from a valid `Vec<T>` handed to `Cow::from_owned`, which we
+            // assumed ownership of.
+            Kind::Owned => unsafe {
+                Vec::from_raw_parts(ptr.as_ptr(), metadata.len(), metadata.capacity())
+            },
+
+            Kind::Shared => {
+                // SAFETY: We know that the pointer is valid because it could have only been
+                // constructed from a valid `Arc<[T]>` handed to `Cow::from_shared`, which we
+                // assumed ownership of, also ensuring that the strong count is at least one.
+                let arc = unsafe { Arc::from_raw(Self::borrowed_from_parts(ptr, metadata)) };
+                arc.to_vec()
+            }
+        }
+    }
+
+    #[inline]
+    fn clone_from_parts(
+        ptr: NonNull<Self::Pointer>,
+        metadata: &Metadata,
+    ) -> (NonNull<Self::Pointer>, Metadata) {
+        match metadata.kind() {
+            Kind::Borrowed => (ptr, *metadata),
+            Kind::Owned => {
+                let vec_ptr = Self::borrowed_from_parts(ptr, metadata);
+
+                // SAFETY: We know that the pointer is valid because it could have only been
+                // constructed from a valid `Vec<T>` handed to `Cow::from_owned`, which we assumed
+                // ownership of.
+                let new_vec = unsafe { vec_ptr.as_ref().unwrap().to_vec() };
+
+                Self::owned_into_parts(new_vec)
+            }
+            Kind::Shared => clone_shared::<Self>(ptr, metadata),
+        }
+    }
+
+    #[inline]
+    fn drop_from_parts(ptr: NonNull<Self::Pointer>, metadata: &Metadata) {
+        match metadata.kind() {
+            Kind::Borrowed => {}
+
+            // SAFETY: We know that the pointer is valid because it could have only been constructed
+            // from a valid `Vec<T>` handed to `Cow::from_owned`, which we assumed ownership of.
+            Kind::Owned => unsafe {
+                drop(Vec::from_raw_parts(ptr.as_ptr(), metadata.len(), metadata.capacity()));
+            },
+
+            // SAFETY: We know that the pointer is valid because it could have only been constructed
+            // from a valid `Arc<[T]>` handed to `Cow::from_shared`, which we assumed ownership of,
+            // also ensuring that the strong count is at least one.
+            Kind::Shared => unsafe {
+                drop(Arc::from_raw(Self::borrowed_from_parts(ptr, metadata)));
+            },
+        }
+    }
+}
+
+fn clone_shared<T: Cowable + ?Sized>(
+    ptr: NonNull<T::Pointer>,
+    metadata: &Metadata,
+) -> (NonNull<T::Pointer>, Metadata) {
+    let arc_ptr = T::borrowed_from_parts(ptr, metadata);
+
+    // SAFETY: We know that the pointer is valid because it could have only been
+    // constructed from a valid `Arc<T>` handed to `Cow::from_shared`, which we assumed
+    // ownership of, also ensuring that the strong count is at least one.
+    unsafe {
+        Arc::increment_strong_count(arc_ptr);
+    }
+
+    (ptr, *metadata)
+}

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -25,21 +25,12 @@ impl KeyName {
     }
 }
 
-impl From<&'static str> for KeyName {
-    fn from(name: &'static str) -> Self {
-        KeyName(SharedString::from(name))
-    }
-}
-
-impl From<String> for KeyName {
-    fn from(name: String) -> Self {
-        KeyName(SharedString::from(name))
-    }
-}
-
-impl From<std::borrow::Cow<'static, str>> for KeyName {
-    fn from(name: std::borrow::Cow<'static, str>) -> Self {
-        KeyName(SharedString::from(name))
+impl<T> From<T> for KeyName
+where
+    T: Into<SharedString>,
+{
+    fn from(name: T) -> Self {
+        KeyName(name.into())
     }
 }
 
@@ -80,7 +71,7 @@ impl Key {
         N: Into<KeyName>,
     {
         let name = name.into();
-        let labels = Cow::owned(Vec::new());
+        let labels = Cow::from_owned(Vec::new());
 
         Self::builder(name, labels)
     }
@@ -92,7 +83,7 @@ impl Key {
         L: IntoLabels,
     {
         let name = name.into();
-        let labels = Cow::owned(labels.into_labels());
+        let labels = Cow::from_owned(labels.into_labels());
 
         Self::builder(name, labels)
     }
@@ -104,7 +95,7 @@ impl Key {
     {
         Self {
             name: name.into(),
-            labels: Cow::<[Label]>::const_slice(labels),
+            labels: Cow::const_slice(labels),
             hashed: AtomicBool::new(false),
             hash: AtomicU64::new(0),
         }
@@ -123,7 +114,7 @@ impl Key {
     pub const fn from_static_parts(name: &'static str, labels: &'static [Label]) -> Self {
         Self {
             name: KeyName::from_const_str(name),
-            labels: Cow::<[Label]>::const_slice(labels),
+            labels: Cow::const_slice(labels),
             hashed: AtomicBool::new(false),
             hash: AtomicU64::new(0),
         }
@@ -244,14 +235,11 @@ impl fmt::Display for Key {
     }
 }
 
-impl From<String> for Key {
-    fn from(name: String) -> Self {
-        Self::from_name(name)
-    }
-}
-
-impl From<&'static str> for Key {
-    fn from(name: &'static str) -> Self {
+impl<T> From<T> for Key
+where
+    T: Into<KeyName>,
+{
+    fn from(name: T) -> Self {
         Self::from_name(name)
     }
 }
@@ -269,8 +257,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Key;
-    use crate::Label;
-    use std::collections::HashMap;
+    use crate::{KeyName, Label};
+    use std::{collections::HashMap, ops::Deref, sync::Arc};
 
     static BORROWED_NAME: &'static str = "name";
     static FOOBAR_NAME: &'static str = "foobar";
@@ -362,5 +350,49 @@ mod tests {
         );
         let result4 = key4.to_string();
         assert_eq!(result4, "Key(foobar, [black = black, lives = lives, matter = matter])");
+    }
+
+    #[test]
+    fn test_key_name_equality() {
+        static KEY_NAME: &'static str = "key_name";
+
+        let borrowed_const = KeyName::from_const_str(KEY_NAME);
+        let borrowed_nonconst = KeyName::from(KEY_NAME);
+        let owned = KeyName::from(KEY_NAME.to_owned());
+
+        let shared_arc = Arc::from(KEY_NAME);
+        let shared = KeyName::from(Arc::clone(&shared_arc));
+
+        assert_eq!(borrowed_const, borrowed_nonconst);
+        assert_eq!(borrowed_const.as_str(), borrowed_nonconst.as_str());
+        assert_eq!(borrowed_const, owned);
+        assert_eq!(borrowed_const.as_str(), owned.as_str());
+        assert_eq!(borrowed_const, shared);
+        assert_eq!(borrowed_const.as_str(), shared.as_str());
+    }
+
+    #[test]
+    fn test_shared_key_name_drop_logic() {
+        let shared_arc = Arc::from("foo");
+        let shared = KeyName::from(Arc::clone(&shared_arc));
+
+        assert_eq!(shared_arc.deref(), shared.as_str());
+
+        assert_eq!(Arc::strong_count(&shared_arc), 2);
+        drop(shared);
+        assert_eq!(Arc::strong_count(&shared_arc), 1);
+
+        let shared_weak = Arc::downgrade(&shared_arc);
+        assert_eq!(Arc::strong_count(&shared_arc), 1);
+
+        let shared = KeyName::from(Arc::clone(&shared_arc));
+        assert_eq!(shared_arc.deref(), shared.as_str());
+        assert_eq!(Arc::strong_count(&shared_arc), 2);
+
+        drop(shared_arc);
+        assert_eq!(shared_weak.strong_count(), 1);
+
+        drop(shared);
+        assert_eq!(shared_weak.strong_count(), 0);
     }
 }

--- a/metrics/tests/macros.rs
+++ b/metrics/tests/macros.rs
@@ -1,4 +1,4 @@
-#[test]
+#[cfg_attr(not(miri), test)]
 pub fn macros() {
     let t = trybuild::TestCases::new();
     t.pass("tests/macros/01_basic.rs");


### PR DESCRIPTION
This PR adds support for creating `metrics::Cow<'a, T>` from `Arc<T>`.

## Context

Generally, users specify a metric name and optional labels for the metric, each of which has a key and value pair. All three of these -- metric name, label key, and label value -- are wrapped in `metrics::Cow<'static, str>` (which is exported from the crate as `SharedString` for simplicity). Additionally, in some cases, we construct a `metrics::Cow<'static, [Label]>` when labels are entirely static.

All of this works fine and well for both static strings (string literals) and owned strings, but did not allow users to use strings shared via a smart pointer such as `Arc<T>`. It is common practice to amortize allocation costs for long-lived strings by sharing them via something like `Arc<str>`. You still pay the cost of the atomic operations here and there, but it can end up much cheaper in the long-term than constantly allocating small strings all over the place, and that's to say nothing of the potential heap fragmentation caused by doing so.

This is important to users as if you're not able to use static strings for a metric key (name, labels) then you're stuck with owned strings, which can involve many of these small allocations every single time a metric is emitted.

## Solution

We've added support for passing `Arc<T>` when constructing a `metrics::Cow<'a, T>`. This involved a little bit of work to properly track the variant of our pointer (borrowed vs owned vs shared) but ultimately functions a lot like if we were simply cloning `Arc<T>` and holding it internally. Of course, we only deal with pointers and pointer metadata (in the context of our code, not pointer metadata as the stdlib might talk about) and so we've had to resort to the manual functions for interacting with `Arc<T>`, such as incrementing and decrementing the strong count by hand, and so on.

We've additionally simplified a lot of the `From<T>` implementations to avoid having one for each pointer variant, as well at a higher-level in the types that are based on `metrics::Cow<'a, T>` itself.