### PR TITLE
Add support for `tracing::Span::record`ed fields in `metrics-tracing-context`

### DIFF
--- a/metrics-tracing-context/CHANGELOG.md
+++ b/metrics-tracing-context/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Support for dynamism using `tracing::Span::record` to add label values. ([#408](https://github.com/metrics-rs/metrics/pull/408))
+
 ## [0.14.0] - 2023-04-16
 
 ### Changed

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -32,6 +32,7 @@ itoa = { version = "1", default-features = false }
 metrics = { version = "^0.21", path = "../metrics" }
 metrics-util = { version = "^0.15", path = "../metrics-util" }
 lockfree-object-pool = { version = "0.1.3", default-features = false }
+indexmap = "2.1"
 once_cell = { version = "1", default-features = false, features = ["std"] }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.21", default-features = false }

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -37,10 +37,12 @@ once_cell = { version = "1", default-features = false, features = ["std"] }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.21", default-features = false }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["std"] }
+tracing-test = "0.2.4"
 
 [dev-dependencies]
 criterion = { version = "=0.3.3", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 tracing = { version = "0.1.29", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3.1", default-features = false, features = ["registry"] }
+tracing-subscriber = { version = "0.3.1", default-features = false, features = ["registry", "fmt"] }
 pretty_assertions = "*"
+itertools = "*"

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -43,3 +43,4 @@ criterion = { version = "=0.3.3", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 tracing = { version = "0.1.29", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["registry"] }
+pretty_assertions = "*"

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -37,7 +37,6 @@ once_cell = { version = "1", default-features = false, features = ["std"] }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.21", default-features = false }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["std"] }
-tracing-test = "0.2.4"
 
 [dev-dependencies]
 criterion = { version = "=0.3.3", default-features = false }
@@ -45,4 +44,4 @@ parking_lot = { version = "0.12.1", default-features = false }
 tracing = { version = "0.1.29", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["registry", "fmt"] }
 pretty_assertions = "*"
-itertools = "*"
+itertools = { version = "0.12.0", default-features = false, features = ["use_std"] }

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -32,7 +32,7 @@ itoa = { version = "1", default-features = false }
 metrics = { version = "^0.21", path = "../metrics" }
 metrics-util = { version = "^0.15", path = "../metrics-util" }
 lockfree-object-pool = { version = "0.1.3", default-features = false }
-indexmap = "2.1"
+indexmap = { version = "2.1", default-features = false, features = ["std"] }
 once_cell = { version = "1", default-features = false, features = ["std"] }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.21", default-features = false }

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -42,6 +42,5 @@ tracing-subscriber = { version = "0.3.1", default-features = false, features = [
 criterion = { version = "=0.3.3", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 tracing = { version = "0.1.29", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3.1", default-features = false, features = ["registry", "fmt"] }
-pretty_assertions = "*"
+tracing-subscriber = { version = "0.3.1", default-features = false, features = ["registry"] }
 itertools = { version = "0.12.0", default-features = false, features = ["use_std"] }

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use indexmap::IndexMap;
 use lockfree_object_pool::LinearObjectPool;
-use metrics::Label;
+use metrics::{Label, SharedString};
 use metrics_tracing_context::Labels;
 use once_cell::sync::OnceCell;
 use tracing::Metadata;
@@ -13,9 +14,11 @@ use tracing_core::{
     Callsite, Interest,
 };
 
-fn get_pool() -> &'static Arc<LinearObjectPool<Vec<Label>>> {
-    static POOL: OnceCell<Arc<LinearObjectPool<Vec<Label>>>> = OnceCell::new();
-    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(|| Vec::new(), |vec| vec.clear())))
+pub(crate) type Map = IndexMap<SharedString, Label>;
+
+fn get_pool() -> &'static Arc<LinearObjectPool<Map>> {
+    static POOL: OnceCell<Arc<LinearObjectPool<Map>>> = OnceCell::new();
+    POOL.get_or_init(|| Arc::new(LinearObjectPool::new(Map::new, Map::clear)))
 }
 
 const BATCH_SIZE: usize = 1000;

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use indexmap::IndexMap;
 use lockfree_object_pool::LinearObjectPool;
-use metrics::Label;
+use metrics::SharedString;
 use metrics_tracing_context::Labels;
 use once_cell::sync::OnceCell;
 use tracing::Metadata;
@@ -14,7 +14,7 @@ use tracing_core::{
     Callsite, Interest,
 };
 
-type Map = IndexMap<&'static str, Label>;
+type Map = IndexMap<SharedString, SharedString>;
 
 fn get_pool() -> &'static Arc<LinearObjectPool<Map>> {
     static POOL: OnceCell<Arc<LinearObjectPool<Map>>> = OnceCell::new();

--- a/metrics-tracing-context/benches/visit.rs
+++ b/metrics-tracing-context/benches/visit.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use indexmap::IndexMap;
 use lockfree_object_pool::LinearObjectPool;
-use metrics::{Label, SharedString};
+use metrics::Label;
 use metrics_tracing_context::Labels;
 use once_cell::sync::OnceCell;
 use tracing::Metadata;
@@ -14,7 +14,7 @@ use tracing_core::{
     Callsite, Interest,
 };
 
-pub(crate) type Map = IndexMap<SharedString, Label>;
+type Map = IndexMap<&'static str, Label>;
 
 fn get_pool() -> &'static Arc<LinearObjectPool<Map>> {
     static POOL: OnceCell<Arc<LinearObjectPool<Map>>> = OnceCell::new();

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -110,8 +110,8 @@ pub mod label_filter;
 mod tracing_integration;
 
 pub use label_filter::LabelFilter;
+use tracing_integration::Map;
 pub use tracing_integration::{Labels, MetricsLayer};
-use tracing_integration::{Map, WithContext};
 
 /// [`TracingContextLayer`] provides an implementation of a [`Layer`] for [`TracingContext`].
 pub struct TracingContextLayer<F> {
@@ -176,7 +176,7 @@ where
         tracing::dispatcher::get_default(|dispatch| {
             let current = dispatch.current_span();
             let id = current.id()?;
-            let ctx = dispatch.downcast_ref::<WithContext>()?;
+            let ctx = dispatch.downcast_ref::<MetricsLayer>()?;
 
             let mut f = |mut span_labels: Map| {
                 (!span_labels.is_empty()).then(|| {

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -186,7 +186,7 @@ where
 
                     let labels = span_labels
                         .into_iter()
-                        .map(|(key, value)| Label::new(key.clone(), value.clone()))
+                        .map(|(key, value)| Label::new(key, value))
                         .filter(|label| self.label_filter.should_include_label(&name, label))
                         .collect::<Vec<_>>();
 

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -55,19 +55,18 @@
 //!
 //! # Implementation
 //!
-//! The integration layer works by capturing all fields present when a span is created and storing
-//! them as an extension to the span.  If a metric is emitted while a span is entered, we check that
-//! span to see if it has any fields in the extension data, and if it does, we add those fields as
-//! labels to the metric key.
+//! The integration layer works by capturing all fields present when a span is
+//! created or then new fields are recorded afterward, and storing them as an
+//! extension to the span.  If a metric is emitted while a span is entered, we
+//! check that span to see if it has any fields in the extension data, and if
+//! it does, we add those fields as labels to the metric key.
 //!
-//! There are two important behaviors to be aware of:
-//! - we only capture the fields present when the span is created
-//! - we store all fields that a span has, including the fields of its parent span(s)
+//! Be aware that we store all fields that a span has, including the fields of its parent span(s).
 //!
-//! ## Lack of dynamism
+//! ## Support for dynamism
 //!
 //! This means that if you use [`Span::record`][tracing::Span::record] to add fields to a span after
-//! it has been created, those fields will not be captured and added to your metric key.
+//! it has been created, those fields will be captured and added to your metric key.
 //!
 //! ## Span fields and ancestry
 //!

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -55,18 +55,17 @@
 //!
 //! # Implementation
 //!
-//! The integration layer works by capturing all fields present when a span is
-//! created or then new fields are recorded afterward, and storing them as an
-//! extension to the span.  If a metric is emitted while a span is entered, we
-//! check that span to see if it has any fields in the extension data, and if
-//! it does, we add those fields as labels to the metric key.
+//! The integration layer works by capturing all fields present when a span is created or then
+//! new fields are recorded afterward, and storing them as an extension to the span.  If a metric
+//! is emitted while a span is entered, we check that span to see if it has any fields in the
+//! extension data, and if it does, we add those fields as labels to the metric key.
 //!
 //! Be aware that we store all fields that a span has, including the fields of its parent span(s).
 //!
 //! ## Support for dynamism
 //!
-//! This means that if you use [`Span::record`][tracing::Span::record] to add fields to a span after
-//! it has been created, those fields will be captured and added to your metric key.
+//! If you use [`Span::record`][tracing::Span::record] to add fields to a span after it has been
+//! created, those fields will be captured and added to your metric key.
 //!
 //! ## Span fields and ancestry
 //!

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -182,12 +182,18 @@ where
                 (!span_labels.is_empty()).then(|| {
                     let (name, labels) = key.clone().into_parts();
 
+                    // Filter only span labels
+                    span_labels.retain(|key: &SharedString, value: &mut SharedString| {
+                        let label = Label::new(key.clone(), value.clone());
+                        self.label_filter.should_include_label(&name, &label)
+                    });
+
+                    // Overwrites labels from spans
                     span_labels.extend(labels.into_iter().map(Label::into_parts));
 
                     let labels = span_labels
                         .into_iter()
                         .map(|(key, value)| Label::new(key, value))
-                        .filter(|label| self.label_filter.should_include_label(&name, label))
                         .collect::<Vec<_>>();
 
                     Key::from_parts(name, labels)

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -2,7 +2,7 @@
 
 use indexmap::IndexMap;
 use lockfree_object_pool::{LinearObjectPool, LinearOwnedReusable};
-use metrics::{Key, Label, SharedString};
+use metrics::{Key, Label};
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
 use std::{any::TypeId, cmp, marker::PhantomData};
@@ -10,7 +10,7 @@ use tracing_core::span::{Attributes, Id, Record};
 use tracing_core::{field::Visit, Dispatch, Field, Subscriber};
 use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
-pub(crate) type Map = IndexMap<SharedString, Label>;
+pub(crate) type Map = IndexMap<&'static str, Label>;
 
 fn get_pool() -> &'static Arc<LinearObjectPool<Map>> {
     static POOL: OnceCell<Arc<LinearObjectPool<Map>>> = OnceCell::new();
@@ -30,7 +30,7 @@ impl Labels {
         let additional = new_len - self.as_ref().len();
         self.0.reserve(additional);
         for (k, v) in other.as_ref() {
-            self.0.insert(k.clone(), v.clone());
+            self.0.insert(k, v.clone());
         }
     }
 }
@@ -44,32 +44,32 @@ impl Default for Labels {
 impl Visit for Labels {
     fn record_str(&mut self, field: &Field, value: &str) {
         let label = Label::new(field.name(), value.to_string());
-        self.0.insert(field.name().into(), label);
+        self.0.insert(field.name(), label);
     }
 
     fn record_bool(&mut self, field: &Field, value: bool) {
         let label = Label::from_static_parts(field.name(), if value { "true" } else { "false" });
-        self.0.insert(field.name().into(), label);
+        self.0.insert(field.name(), label);
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
         let mut buf = itoa::Buffer::new();
         let s = buf.format(value);
         let label = Label::new(field.name(), s.to_string());
-        self.0.insert(field.name().into(), label);
+        self.0.insert(field.name(), label);
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
         let mut buf = itoa::Buffer::new();
         let s = buf.format(value);
         let label = Label::new(field.name(), s.to_string());
-        self.0.insert(field.name().into(), label);
+        self.0.insert(field.name(), label);
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
         let value_string = format!("{value:?}");
         let label = Label::new(field.name(), value_string);
-        self.0.insert(field.name().into(), label);
+        self.0.insert(field.name(), label);
     }
 }
 
@@ -131,8 +131,8 @@ where
             .expect("subscriber should downcast to expected type; this is a bug!");
         let span = subscriber.span(id).expect("registry should have a span for the current ID");
 
-        let result = span.extensions().get::<Labels>().and_then(f);
-        result
+        let ext = span.extensions();
+        ext.get::<Labels>().and_then(f)
     }
 }
 

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -4,8 +4,9 @@ use indexmap::IndexMap;
 use lockfree_object_pool::{LinearObjectPool, LinearOwnedReusable};
 use metrics::{Key, SharedString};
 use once_cell::sync::OnceCell;
+use std::cmp;
 use std::sync::Arc;
-use std::{any::TypeId, cmp, marker::PhantomData};
+use tracing::span;
 use tracing_core::span::{Attributes, Id, Record};
 use tracing_core::{field::Visit, Dispatch, Field, Subscriber};
 use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
@@ -24,13 +25,23 @@ fn get_pool() -> &'static Arc<LinearObjectPool<Map>> {
 #[doc(hidden)]
 pub struct Labels(pub LinearOwnedReusable<Map>);
 
+impl std::fmt::Debug for Labels {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Labels").field(self.as_ref()).finish()
+    }
+}
+
 impl Labels {
-    pub(crate) fn extend_from_labels(&mut self, other: &Labels) {
+    pub(crate) fn extend_from_labels(&mut self, other: &Labels, overwrite: bool) {
         let new_len = cmp::max(self.as_ref().len(), other.as_ref().len());
         let additional = new_len - self.as_ref().len();
         self.0.reserve(additional);
         for (k, v) in other.as_ref() {
-            self.0.insert(k.clone(), v.clone());
+            if overwrite {
+                self.0.insert(k.clone(), v.clone());
+            } else {
+                self.0.entry(k.clone()).or_insert_with(|| v.clone());
+            }
         }
     }
 }
@@ -81,66 +92,57 @@ impl AsRef<Map> for Labels {
     }
 }
 
-pub struct WithContext {
-    with_labels: fn(&Dispatch, &Id, f: &mut dyn FnMut(&Labels) -> Option<Key>) -> Option<Key>,
+/// [`MetricsLayer`] is a [`tracing_subscriber::Layer`] that captures the span
+/// fields and allows them to be later on used as metrics labels.
+#[derive(Default)]
+pub struct MetricsLayer {
+    with_labels:
+        Option<fn(&Dispatch, &Id, f: &mut dyn FnMut(&Labels) -> Option<Key>) -> Option<Key>>,
 }
 
-impl WithContext {
-    pub fn with_labels(
+impl MetricsLayer {
+    /// Create a new [`MetricsLayer`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn with_labels(
         &self,
         dispatch: &Dispatch,
         id: &Id,
         f: &mut dyn FnMut(Map) -> Option<Key>,
     ) -> Option<Key> {
         let mut ff = |labels: &Labels| f(labels.0.clone());
-        (self.with_labels)(dispatch, id, &mut ff)
+        (self.with_labels?)(dispatch, id, &mut ff)
     }
 }
 
-/// [`MetricsLayer`] is a [`tracing_subscriber::Layer`] that captures the span
-/// fields and allows them to be later on used as metrics labels.
-pub struct MetricsLayer<S> {
-    ctx: WithContext,
-    _subscriber: PhantomData<fn(S)>,
-}
-
-impl<S> MetricsLayer<S>
-where
-    S: Subscriber + for<'span> LookupSpan<'span>,
-{
-    /// Create a new `MetricsLayer`.
-    pub fn new() -> Self {
-        let ctx = WithContext { with_labels: Self::with_labels };
-
-        Self { ctx, _subscriber: PhantomData }
-    }
-
-    fn with_labels(
-        dispatch: &Dispatch,
-        id: &Id,
-        f: &mut dyn FnMut(&Labels) -> Option<Key>,
-    ) -> Option<Key> {
-        let subscriber = dispatch
-            .downcast_ref::<S>()
-            .expect("subscriber should downcast to expected type; this is a bug!");
-        let span = subscriber.span(id).expect("registry should have a span for the current ID");
-
-        let ext = span.extensions();
-        f(ext.get::<Labels>()?)
-    }
-}
-
-impl<S> Layer<S> for MetricsLayer<S>
+impl<S> Layer<S> for MetricsLayer
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
+    fn on_layer(&mut self, _: &mut S) {
+        self.with_labels = Some(
+            |dispatch: &Dispatch, id: &span::Id, f: &mut dyn FnMut(&Labels) -> Option<Key>| {
+                let subscriber = dispatch
+                    .downcast_ref::<S>()
+                    .expect("subscriber should downcast to expected type; this is a bug!");
+                let span =
+                    subscriber.span(id).expect("registry should have a span for the current ID");
+
+                let ext = span.extensions();
+                f(ext.get::<Labels>()?)
+            },
+        );
+    }
+
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, cx: Context<'_, S>) {
         let span = cx.span(id).expect("span must already exist!");
         let mut labels = Labels::from_record(&Record::new(attrs.values()));
 
         if let Some(parent) = span.parent() {
             if let Some(parent_labels) = parent.extensions().get::<Labels>() {
-                labels.extend_from_labels(parent_labels);
+                labels.extend_from_labels(parent_labels, false);
             }
         }
 
@@ -153,26 +155,9 @@ where
 
         let ext = &mut span.extensions_mut();
         if let Some(existing) = ext.get_mut::<Labels>() {
-            existing.extend_from_labels(&labels);
+            existing.extend_from_labels(&labels, true);
         } else {
             ext.insert(labels);
         }
-    }
-
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
-        match id {
-            id if id == TypeId::of::<Self>() => Some(self as *const _ as *const ()),
-            id if id == TypeId::of::<WithContext>() => Some(&self.ctx as *const _ as *const ()),
-            _ => None,
-        }
-    }
-}
-
-impl<S> Default for MetricsLayer<S>
-where
-    S: Subscriber + for<'span> LookupSpan<'span>,
-{
-    fn default() -> Self {
-        MetricsLayer::new()
     }
 }

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -147,13 +147,7 @@ where
 
     fn on_record(&self, id: &Id, values: &Record<'_>, cx: Context<'_, S>) {
         let span = cx.span(id).expect("span must already exist!");
-        let mut labels = Labels::from_record(values);
-
-        if let Some(parent) = span.parent() {
-            if let Some(parent_labels) = parent.extensions().get::<Labels>() {
-                labels.extend_from_labels(parent_labels);
-            }
-        }
+        let labels = Labels::from_record(values);
 
         let ext = &mut span.extensions_mut();
         if let Some(existing) = ext.get_mut::<Labels>() {

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -131,8 +131,7 @@ where
             .expect("subscriber should downcast to expected type; this is a bug!");
         let span = subscriber.span(id).expect("registry should have a span for the current ID");
 
-        let result =
-            if let Some(labels) = span.extensions().get::<Labels>() { f(labels) } else { None };
+        let result = span.extensions().get::<Labels>().and_then(f);
         result
     }
 }

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -1,4 +1,9 @@
-use metrics::{counter, Key, KeyName, Label};
+#![deny(unreachable_patterns)]
+
+use std::panic;
+
+use itertools::Itertools as _;
+use metrics::{counter, Key, KeyName, Label, SharedString};
 use metrics_tracing_context::{LabelFilter, MetricsLayer, TracingContextLayer};
 use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
 use metrics_util::{layers::Layer, CompositeKey, MetricKind};
@@ -54,7 +59,7 @@ static SVC_NODE_USER_EMAIL: &[Label] = &[
     Label::from_static_parts("node_name", "localhost"),
 ];
 static COMBINED_LABELS: &[Label] = &[
-    Label::from_static_parts("shared_field", "outer"),
+    Label::from_static_parts("shared_field", "inner"),
     Label::from_static_parts("inner_specific", "foo"),
     Label::from_static_parts("inner_specific_dynamic", "foo_dynamic"),
     Label::from_static_parts("outer_specific", "bar"),
@@ -608,4 +613,210 @@ fn test_label_allowlist() {
             DebugValue::Counter(1),
         )]
     );
+}
+
+#[tracing_test::traced_test]
+#[test]
+fn test_all_permutations() {
+    let perms = (0..9).map(|_| [false, true]).multi_cartesian_product();
+
+    for v in perms {
+        let &[metric_has_labels, in_span, span_has_fields, span_field_same_as_metric, span_has_parent, parent_field_same_as_span, span_field_is_empty, record_field, emit_before_recording] =
+            &*v
+        else {
+            unreachable!("{:?}, {}", v, v.len());
+        };
+
+        test(
+            metric_has_labels,
+            in_span,
+            span_has_fields,
+            span_field_same_as_metric,
+            span_has_parent,
+            parent_field_same_as_span,
+            span_field_is_empty,
+            record_field,
+            emit_before_recording,
+        );
+    }
+}
+
+#[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments, clippy::too_many_lines)]
+fn test(
+    metric_has_labels: bool,
+    in_span: bool,
+    span_has_fields: bool,
+    span_field_same_as_metric: bool,
+    span_has_parent: bool,
+    parent_field_same_as_span: bool,
+    span_field_is_empty: bool,
+    record_field: bool,
+    emit_before_recording: bool,
+) {
+    let (_guard, snapshotter) = setup(TracingContextLayer::all());
+
+    let parent = if span_field_same_as_metric && parent_field_same_as_span {
+        tracing::trace_span!("outer", user.email = "changed@domain.com")
+    } else {
+        tracing::trace_span!("outer", user.id = 999)
+    };
+
+    let _parent_guard = span_has_parent.then(|| parent.enter());
+
+    let span = if span_has_fields {
+        match (span_field_same_as_metric, span_field_is_empty) {
+            (false, false) => tracing::trace_span!("login", user.id = 666),
+            (false, true) => tracing::trace_span!("login", user.id = tracing_core::field::Empty),
+            (true, false) => tracing::trace_span!("login", user.email = "user@domain.com"),
+            (true, true) => tracing::trace_span!("login", user.email = tracing_core::field::Empty),
+        }
+    } else {
+        tracing::trace_span!("login")
+    };
+
+    let _guard = in_span.then(|| span.enter());
+
+    let inc = || {
+        if metric_has_labels {
+            counter!("login_attempts", "user.email" => "ferris@rust-lang.org").increment(1);
+        } else {
+            counter!("login_attempts").increment(1);
+        }
+    };
+
+    if emit_before_recording {
+        inc();
+    }
+
+    if record_field {
+        span.record("user.id", 42);
+    }
+
+    inc();
+
+    let snapshot = snapshotter.snapshot().into_vec();
+
+    let expected1: (CompositeKey, Option<metrics::Unit>, Option<SharedString>, DebugValue) = (
+        CompositeKey::new(
+            MetricKind::Counter,
+            Key::from_parts(
+                LOGIN_ATTEMPTS,
+                IntoIterator::into_iter([
+                    (metric_has_labels
+                        && in_span
+                        && span_has_fields
+                        && span_field_same_as_metric
+                        && span_has_parent
+                        && !span_field_is_empty)
+                        .then(|| Label::new("user.email", "ferris@rust-lang.org")),
+                    (in_span
+                        && span_has_fields
+                        && !span_field_same_as_metric
+                        && !span_field_is_empty
+                        && record_field
+                        && emit_before_recording)
+                        .then(|| Label::new("user.id", "666")),
+                    (in_span
+                        && span_has_fields
+                        && !span_field_same_as_metric
+                        && span_has_parent
+                        && span_field_is_empty
+                        && record_field
+                        && emit_before_recording)
+                        .then(|| Label::new("user.id", "999")),
+                    (metric_has_labels
+                        && !(in_span
+                            && span_has_fields
+                            && span_field_same_as_metric
+                            && span_has_parent
+                            && !span_field_is_empty))
+                        .then(|| Label::new("user.email", "ferris@rust-lang.org")),
+                ])
+                .flatten()
+                .collect::<Vec<_>>(),
+            ),
+        ),
+        None,
+        None,
+        DebugValue::Counter(1),
+    );
+
+    let labels2 = IntoIterator::into_iter([
+        (metric_has_labels
+            && in_span
+            && span_has_fields
+            && span_field_same_as_metric
+            && span_has_parent
+            && !span_field_is_empty)
+            .then(|| Label::new("user.email", "ferris@rust-lang.org")),
+        (in_span && span_has_fields)
+            .then(|| {
+                match (
+                    metric_has_labels,
+                    span_field_same_as_metric,
+                    span_field_is_empty,
+                    record_field,
+                ) {
+                    (_, false, _, true) => Some(Label::new("user.id", "42")),
+                    (_, false, false, false) => Some(Label::new("user.id", "666")),
+                    (false, true, false, _) => Some(Label::new("user.email", "user@domain.com")),
+                    _ => None,
+                }
+            })
+            .flatten(),
+        if span_has_parent
+            && (!in_span || !span_has_fields || span_field_is_empty)
+            && parent_field_same_as_span
+            && span_field_same_as_metric
+            && !metric_has_labels
+        {
+            Some(Label::new("user.email", "changed@domain.com"))
+        } else if !span_has_parent
+            || span_field_same_as_metric && metric_has_labels && parent_field_same_as_span
+            || in_span
+                && span_has_fields
+                && ((parent_field_same_as_span || !span_field_same_as_metric)
+                    && !span_field_is_empty
+                    || !span_field_same_as_metric && record_field)
+        {
+            None
+        } else {
+            Some(Label::new("user.id", "999"))
+        },
+        (metric_has_labels
+            && !(in_span
+                && span_has_fields
+                && span_field_same_as_metric
+                && span_has_parent
+                && !span_field_is_empty))
+            .then(|| Label::new("user.email", "ferris@rust-lang.org")),
+    ])
+    .flatten()
+    .collect::<Vec<_>>();
+
+    let expected2 = (
+        CompositeKey::new(MetricKind::Counter, Key::from_parts(LOGIN_ATTEMPTS, labels2)),
+        None,
+        None,
+        DebugValue::Counter(
+            if !emit_before_recording
+                || in_span && span_has_fields && !span_field_same_as_metric && record_field
+            {
+                1
+            } else {
+                2
+            },
+        ),
+    );
+    let expected: Vec<_> = (in_span
+        && span_has_fields
+        && !span_field_same_as_metric
+        && record_field
+        && emit_before_recording)
+        .then(|| expected1)
+        .into_iter()
+        .chain([expected2])
+        .collect();
+    // let expected = vec![expected2];
+    assert_eq!(snapshot, expected);
 }


### PR DESCRIPTION
I wondered for the reason of why [`record`ed fields are not added to the `Labels`](https://docs.rs/metrics-tracing-context/0.14.0/metrics_tracing_context/index.html#lack-of-dynamism) and found none. Implemented it as just `Label::extend_from_labels` call in a `Layer::on_record` method. For the tests I am not sure, maybe I missed some corner case, but I can't see such a case.

P.S. Should I ignore falling CI checks?