### PR TITLE
Add a clippy ci check (#416)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,17 @@ jobs:
       run: rustup default stable
     - name: Run Benchmarks
       run: cargo bench --all-features --workspace --exclude=metrics-observer
+  clippy:
+    name: Clippy ${{ matrix.rust_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust_version: ['1.61.0', 'stable', 'nightly']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Protobuf Compiler
+      run: sudo apt-get install protobuf-compiler
+    - name: Install Rust ${{ matrix.rust_version }}
+      run: rustup default ${{ matrix.rust_version }}
+    - name: Run Clippy
+      run: cargo clippy --all-features --workspace --exclude=metrics-observer

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -403,6 +403,7 @@ impl PrometheusBuilder {
     ///
     /// If there is an error while building the recorder and exporter, an error variant will be
     /// returned describing the error.
+    #[warn(clippy::too_many_lines)]
     #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "http-listener", feature = "push-gateway"))))]
     #[cfg_attr(not(feature = "http-listener"), allow(unused_mut))]
@@ -500,7 +501,7 @@ impl PrometheusBuilder {
                                         .map(|mut b| b.copy_to_bytes(b.remaining()))
                                         .map(|b| b[..].to_vec())
                                         .and_then(|s| String::from_utf8(s).map_err(|_| ()))
-                                        .unwrap_or_else(|_| {
+                                        .unwrap_or_else(|()| {
                                             String::from("<failed to read response body>")
                                         });
                                     error!(

--- a/metrics-exporter-prometheus/src/distribution.rs
+++ b/metrics-exporter-prometheus/src/distribution.rs
@@ -27,6 +27,7 @@ pub enum Distribution {
 
 impl Distribution {
     /// Creates a histogram distribution.
+    #[warn(clippy::missing_panics_doc)]
     pub fn new_histogram(buckets: &[f64]) -> Distribution {
         let hist = Histogram::new(buckets).expect("buckets should never be empty");
         Distribution::Histogram(hist)
@@ -83,7 +84,7 @@ impl DistributionBuilder {
     /// Returns a distribution for the given metric key.
     pub fn get_distribution(&self, name: &str) -> Distribution {
         if let Some(ref overrides) = self.bucket_overrides {
-            for (matcher, buckets) in overrides.iter() {
+            for (matcher, buckets) in overrides {
                 if matcher.matches(name) {
                     return Distribution::new_histogram(buckets);
                 }
@@ -104,7 +105,7 @@ impl DistributionBuilder {
         }
 
         if let Some(ref overrides) = self.bucket_overrides {
-            for (matcher, _) in overrides.iter() {
+            for (matcher, _) in overrides {
                 if matcher.matches(name) {
                     return "histogram";
                 }

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -86,7 +86,7 @@ impl Inner {
             let mut wg = self.distributions.write().unwrap_or_else(PoisonError::into_inner);
             let entry = wg
                 .entry(name.clone())
-                .or_insert_with(IndexMap::new)
+                .or_default()
                 .entry(labels)
                 .or_insert_with(|| self.distribution_builder.get_distribution(name.as_str()));
 


### PR DESCRIPTION
This change adds a ci test for clippy and quickly addresses the blocking points by downgrading them to warnings if they can't be trivially addressed.