### PR TITLE
Make tls optional and add rustls support (#418)

### DIFF
--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -20,7 +20,9 @@ keywords = ["metrics", "telemetry", "prometheus"]
 default = ["http-listener", "push-gateway"]
 async-runtime = ["tokio", "hyper"]
 http-listener = ["async-runtime", "hyper/server", "ipnet"]
-push-gateway = ["async-runtime", "hyper/client", "hyper-tls", "tracing"]
+push-gateway = ["async-runtime", "hyper/client", "tracing"]
+native-tls = ["hyper-tls"]
+rustls-tls = ["hyper-rustls"]
 
 [dependencies]
 metrics = { version = "^0.21", path = "../metrics" }
@@ -36,6 +38,7 @@ ipnet = { version = "2", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time"], optional = true }
 tracing = { version = "0.1.26", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
+hyper-rustls = { version = "0.24.2", optional = true }
 
 [dev-dependencies]
 tracing = "0.1"


### PR DESCRIPTION
This change removed the required dependency to hyper-tls and openssl. The allow tls, clients will now have to enable either the `native-tls` or `rustls-tls` features.

BREAKING: tls isn't enabled by default anymore.