### PR TITLE
Remove unneeded unsafe from test

### DIFF
--- a/metrics-exporter-prometheus/src/distribution.rs
+++ b/metrics-exporter-prometheus/src/distribution.rs
@@ -353,10 +353,10 @@ mod tests {
         let (clock, mock) = Clock::mock();
         mock.increment(Duration::from_secs(4));
 
-        const BUCKET_COUNT: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(2) };
-        const BUCKET_WIDTH: Duration = Duration::from_secs(5);
+        let bucket_count = NonZeroU32::new(2).unwrap();
+        let bucket_width = Duration::from_secs(5);
 
-        let mut summary = RollingSummary::new(BUCKET_COUNT, BUCKET_WIDTH);
+        let mut summary = RollingSummary::new(bucket_count, bucket_width);
         assert_eq!(0, summary.buckets().len());
         assert_eq!(0, summary.count());
 

--- a/metrics-util/src/bucket.rs
+++ b/metrics-util/src/bucket.rs
@@ -153,8 +153,6 @@ impl<T> Drop for Block<T> {
 
 impl<T> std::fmt::Debug for Block<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // SAFETY:
-        // This is unsound but there is no way to call this from the public API so its probably fine?
         let has_next = unsafe { !self.next.load(Ordering::Acquire, unprotected()).is_null() };
         f.debug_struct("Block")
             .field("type", &std::any::type_name::<T>())

--- a/metrics-util/src/bucket.rs
+++ b/metrics-util/src/bucket.rs
@@ -153,6 +153,8 @@ impl<T> Drop for Block<T> {
 
 impl<T> std::fmt::Debug for Block<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // SAFETY:
+        // This is unsound but there is no way to call this from the public API so its probably fine?
         let has_next = unsafe { !self.next.load(Ordering::Acquire, unprotected()).is_null() };
         f.debug_struct("Block")
             .field("type", &std::any::type_name::<T>())


### PR DESCRIPTION
I replaced unsafe by making the test use a regular variable instead of a constant, any potential performance here is irreverent as its just a test and now we have one less unsafe to audit.

I also added a SAFETY comment for a suspicious looking unsafe.
If you know for sure its fine to have that kind of unsoundness there if its never actually called then I can remove the ambiguity from the phrasing.