### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,11 @@ jobs:
     - name: Install Rust Stable
       run: rustup default stable
     - name: Install cargo-hack
-      run: cargo install cargo-hack
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-hack
     - name: Check Feature Matrix
-      run: cargo hack build --all --all-targets --feature-powerset
+      run: cargo hack check --all --all-targets --feature-powerset --release
   test:
     name: Test ${{ matrix.rust_version }}
     runs-on: ubuntu-latest

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -29,6 +29,7 @@ use hyper::{
     http::HeaderValue,
     Method, Request, Uri,
 };
+#[cfg(feature = "push-gateway")]
 use hyper_tls::HttpsConnector;
 
 use indexmap::IndexMap;

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,11 @@
 [build]
   command = """
   rustup install nightly --profile minimal && \
-  cargo doc --no-deps --workspace --exclude=metrics-observer && cp -r target/doc _netlify_out
+  PROTOC_ZIP=protoc-3.14.0-linux-x86_64.zip && \
+  curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP && \
+  unzip $PROTOC_ZIP && \
+  PATH=$PATH:/$PWD/bin cargo +nightly doc --no-deps --workspace --exclude=metrics-observer && \
+  cp -r target/doc _netlify_out
   """
   environment = { RUSTDOCFLAGS= "--cfg docsrs" }
   publish = "_netlify_out"


### PR DESCRIPTION
These changes fix CI:

* Swapping from `cargo install` to `install-action` cuts 45 seconds off the time to run the feature-check workflow.
* Changing cargo hack to run as `check` and `--release` reduces disk space usage allowing it to complete on the CI runner.
* I added `#[cfg(feature = "push-gateway")]` to avoid triggering a warning for unused import.
* netlify needed to install protoc binary and provide path to rust build.
