### PR TITLE
Update `hashbrown` to `0.14`

### DIFF
--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -58,7 +58,7 @@ radix_trie = { version = "0.2", default-features = false, optional = true }
 ordered-float = { version = "4.2", default-features = false, optional = true }
 num_cpus = { version = "1", default-features = false, optional = true }
 ahash = { version = "0.8", default-features = false, optional = true }
-hashbrown = { version = "=0.13.1", default-features = false, optional = true, features = ["ahash"] }
+hashbrown = { version = "0.14", default-features = false, optional = true, features = ["ahash"] }
 
 [dev-dependencies]
 approx = "0.5"


### PR DESCRIPTION
As the MSRV of `metrics-util` now is `1.65` we can now update to `hashbrown` version `0.14` (which has MSRV `1.63`).