### PR TITLE
chore/hyper 1.1 upgrade

### DIFF
--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -31,7 +31,7 @@ indexmap = { version = "2.1", default-features = false, features = ["std"] }
 base64 = { version = "0.21.0", default-features = false, features = ["std"] }
 
 # Optional
-hyper = { version = "0.14", default-features = false, features = ["tcp", "http1"], optional = true }
+hyper = { version = "1.1", default-features = false, features = ["tcp", "http1"], optional = true }
 ipnet = { version = "2", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time"], optional = true }
 tracing = { version = "0.1.26", optional = true }

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -35,13 +35,11 @@ base64 = { version = "0.21.0", default-features = false, features = ["std"] }
 # Optional
 hyper = { version = "1.1", features = [ "server", "client" ],  optional = true }
 hyper-util = { version="0.1.2", features = [ "tokio", "service", "client" ], optional = true }
-#http-body = { version ="0.4", optional = true }
 http-body-util = { version = "0.1.0", optional = true }
 ipnet = { version = "2", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time", "rt-multi-thread"], optional = true }
 tracing = { version = "0.1.26", optional = true }
 hyper-tls = { version = "0.6.0", optional = true }
-futures-util = "0.3.30"
 
 [dev-dependencies]
 tracing = "0.1"

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -18,9 +18,11 @@ keywords = ["metrics", "telemetry", "prometheus"]
 
 [features]
 default = ["http-listener", "push-gateway"]
-async-runtime = ["tokio", "hyper"]
-http-listener = ["async-runtime", "hyper/server", "ipnet"]
-push-gateway = ["async-runtime", "hyper/client", "hyper-tls", "http-body", "tracing"]
+async-runtime = ["tokio", "hyper-util/tokio"]
+http-listener = ["async-runtime", "ipnet", "_hyper-server", ]
+push-gateway = ["async-runtime", "_hyper-client", "tracing"]
+_hyper-server = ["http-body-util", "hyper/server", "hyper-util/server-auto"]
+_hyper-client = ["http-body-util", "hyper-util/client", "hyper-tls"]
 
 [dependencies]
 metrics = { version = "^0.22", path = "../metrics" }
@@ -31,12 +33,15 @@ indexmap = { version = "2.1", default-features = false, features = ["std"] }
 base64 = { version = "0.21.0", default-features = false, features = ["std"] }
 
 # Optional
-hyper = { version = "0.14.28", features = [ "server", "runtime", "http1", "backports", "deprecated"],  optional = true }
-http-body = { version ="0.4", optional = true }
+hyper = { version = "1.1", features = [ "server", "client" ],  optional = true }
+hyper-util = { version="0.1.2", features = [ "tokio", "service", "client" ], optional = true }
+#http-body = { version ="0.4", optional = true }
+http-body-util = { version = "0.1.0", optional = true }
 ipnet = { version = "2", optional = true }
-tokio = { version = "1", features = ["rt", "net", "time"], optional = true }
+tokio = { version = "1", features = ["rt", "net", "time", "rt-multi-thread"], optional = true }
 tracing = { version = "0.1.26", optional = true }
-hyper-tls = { version = "0.5.0", optional = true }
+hyper-tls = { version = "0.6.0", optional = true }
+futures-util = "0.3.30"
 
 [dev-dependencies]
 tracing = "0.1"

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -20,7 +20,7 @@ keywords = ["metrics", "telemetry", "prometheus"]
 default = ["http-listener", "push-gateway"]
 async-runtime = ["tokio", "hyper"]
 http-listener = ["async-runtime", "hyper/server", "ipnet"]
-push-gateway = ["async-runtime", "hyper/client", "hyper-tls", "tracing"]
+push-gateway = ["async-runtime", "hyper/client", "hyper-tls", "http-body", "tracing"]
 
 [dependencies]
 metrics = { version = "^0.22", path = "../metrics" }
@@ -31,7 +31,8 @@ indexmap = { version = "2.1", default-features = false, features = ["std"] }
 base64 = { version = "0.21.0", default-features = false, features = ["std"] }
 
 # Optional
-hyper = { version = "1.1", default-features = false, features = ["tcp", "http1"], optional = true }
+hyper = { version = "0.14.28", features = [ "server", "runtime", "http1", "backports", "deprecated"],  optional = true }
+http-body = { version ="0.4", optional = true }
 ipnet = { version = "2", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time"], optional = true }
 tracing = { version = "0.1.26", optional = true }

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -19,10 +19,10 @@ keywords = ["metrics", "telemetry", "prometheus"]
 [features]
 default = ["http-listener", "push-gateway"]
 async-runtime = ["tokio", "hyper-util/tokio"]
-http-listener = ["async-runtime", "ipnet", "_hyper-server", ]
-push-gateway = ["async-runtime", "_hyper-client", "tracing"]
+http-listener = ["async-runtime", "ipnet", "tracing", "_hyper-server"]
+push-gateway = ["async-runtime", "tracing", "_hyper-client"]
 _hyper-server = ["http-body-util", "hyper/server", "hyper-util/server-auto"]
-_hyper-client = ["http-body-util", "hyper-util/client", "hyper-tls"]
+_hyper-client = ["http-body-util", "hyper/client", "hyper-util/client", "hyper-util/http1", "hyper-util/client-legacy", "hyper-tls"]
 
 [dependencies]
 metrics = { version = "^0.22", path = "../metrics" }
@@ -34,7 +34,7 @@ base64 = { version = "0.21.0", default-features = false, features = ["std"] }
 
 # Optional
 hyper = { version = "1.1", features = [ "server", "client" ],  optional = true }
-hyper-util = { version="0.1.2", features = [ "tokio", "service", "client" ], optional = true }
+hyper-util = { version="0.1.3", features = [ "tokio", "service", "client", "client-legacy", "http1" ], optional = true }
 http-body-util = { version = "0.1.0", optional = true }
 ipnet = { version = "2", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time", "rt-multi-thread"], optional = true }

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -1,41 +1,24 @@
 use std::collections::HashMap;
 #[cfg(feature = "push-gateway")]
 use std::convert::TryFrom;
-#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 use std::future::Future;
 #[cfg(feature = "http-listener")]
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::num::NonZeroU32;
 #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 use std::pin::Pin;
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 use std::sync::RwLock;
 #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 use std::thread;
 use std::time::Duration;
 
-#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
-use hyper::Body;
-
-#[cfg(feature = "http-listener")]
-use hyper::{
-    server::{conn::AddrStream, Server},
-    service::{make_service_fn, service_fn},
-    Response, StatusCode,
-};
-
 #[cfg(feature = "push-gateway")]
-use hyper::{body::Buf, client::Client, http::HeaderValue, Method, Request, Uri};
-#[cfg(feature = "push-gateway")]
-use hyper_tls::HttpsConnector;
-
+use hyper::Uri;
 use indexmap::IndexMap;
 #[cfg(feature = "http-listener")]
 use ipnet::IpNet;
 use quanta::Clock;
-#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
-use tokio::runtime;
-#[cfg(feature = "push-gateway")]
-use tracing::error;
 
 use metrics_util::{
     parse_quantiles,
@@ -50,7 +33,7 @@ use crate::registry::AtomicStorage;
 use crate::{common::BuildError, PrometheusHandle};
 
 #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
-type ExporterFuture = Pin<Box<dyn Future<Output = Result<(), hyper::Error>> + Send + 'static>>;
+pub type ExporterFuture = Pin<Box<dyn Future<Output = Result<(), hyper::Error>> + Send + 'static>>;
 
 #[derive(Clone)]
 enum ExporterConfig {
@@ -385,6 +368,8 @@ impl PrometheusBuilder {
     #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "http-listener", feature = "push-gateway"))))]
     pub fn install(self) -> Result<(), BuildError> {
+        use tokio::runtime;
+
         let recorder = if let Ok(handle) = runtime::Handle::try_current() {
             let (recorder, exporter) = {
                 let _g = handle.enter();
@@ -510,38 +495,208 @@ impl PrometheusBuilder {
 
                 Ok((recorder, Box::pin(exporter)))
             }
+        Ok((
+            recorder,
+            match exporter_config {
+                ExporterConfig::Unconfigured => Err(BuildError::MissingExporterConfiguration)?,
 
-            #[cfg(feature = "push-gateway")]
-            ExporterConfig::PushGateway { endpoint, interval, username, password } => {
-                use http_body::Collected;
-                use hyper::body::HttpBody;
+                #[cfg(feature = "http-listener")]
+                ExporterConfig::HttpListener { listen_address } => {
+                    http_listener::new_http_listener(handle, listen_address, allowed_addresses)?
+                }
 
-                let exporter = async move {
-                    let https = HttpsConnector::new();
-                    let client = Client::builder().build::<_, hyper::Body>(https);
-                    let auth = username.as_ref().map(|name| basic_auth(name, password.as_deref()));
+                #[cfg(feature = "push-gateway")]
+                ExporterConfig::PushGateway { endpoint, interval, username, password } => {
+                    push_gateway::new_push_gateway(endpoint, interval, username, password, handle)
+                }
+            },
+        ))
+    }
 
-                    loop {
-                        // Sleep for `interval` amount of time, and then do a push.
-                        tokio::time::sleep(interval).await;
+    /// Builds the recorder and returns it.
+    pub fn build_recorder(self) -> PrometheusRecorder {
+        self.build_with_clock(Clock::new())
+    }
 
-                        let mut builder = Request::builder();
-                        if let Some(auth) = &auth {
-                            builder = builder.header("authorization", auth.clone());
-                        }
+    pub(crate) fn build_with_clock(self, clock: Clock) -> PrometheusRecorder {
+        let inner = Inner {
+            registry: Registry::new(GenerationalStorage::new(AtomicStorage)),
+            recency: Recency::new(clock, self.recency_mask, self.idle_timeout),
+            distributions: RwLock::new(HashMap::new()),
+            distribution_builder: DistributionBuilder::new(
+                self.quantiles,
+                self.buckets,
+                self.bucket_overrides,
+            ),
+            descriptions: RwLock::new(HashMap::new()),
+            global_labels: self.global_labels.unwrap_or_default(),
+        };
 
-                        let output = handle.render();
-                        let result = builder
-                            .method(Method::PUT)
-                            .uri(endpoint.clone())
-                            .body(Body::from(output));
-                        let req = match result {
-                            Ok(req) => req,
-                            Err(e) => {
-                                error!("failed to build push gateway request: {}", e);
-                                continue;
-                            }
-                        };
+        PrometheusRecorder::from(inner)
+    }
+}
+
+impl Default for PrometheusBuilder {
+    fn default() -> Self {
+        PrometheusBuilder::new()
+    }
+}
+
+#[cfg(feature = "http-listener")]
+mod http_listener {
+    use std::net::SocketAddr;
+
+    use http_body_util::Full;
+    use hyper::{
+        body::{self, Bytes, Incoming},
+        server::conn::http1,
+        service::service_fn,
+        Request, Response, StatusCode,
+    };
+    use hyper_util::rt::TokioIo;
+    use ipnet::IpNet;
+    use tokio::net::TcpListener;
+
+    use crate::{common::BuildError, PrometheusHandle};
+
+    /// Creates an ExporterFuture implementing a http listener that servies prometheus metrics.
+    ///
+    /// # Errors
+    /// Will return Err if it cannot bind to the listen address
+    pub(crate) fn new_http_listener(
+        handle: PrometheusHandle,
+        listen_address: SocketAddr,
+        allowed_addresses: Option<Vec<IpNet>>,
+    ) -> Result<crate::builder::ExporterFuture, BuildError> {
+        async fn handle_request(
+            is_allowed: bool,
+            handle: PrometheusHandle,
+            req: &Request<Incoming>,
+        ) -> hyper::Response<http_body_util::Full<hyper::body::Bytes>> {
+            if is_allowed {
+                match req.uri().path() {
+                    "/health" => Response::new(Full::<Bytes>::from("OK")),
+                    _ => Response::new(Full::<Bytes>::from(handle.render())),
+                }
+            } else {
+                Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .body(Full::<Bytes>::from(""))
+                    .expect("static response is valid")
+            }
+        }
+
+        // non-async tokio TcpListener creation
+        let listener = std::net::TcpListener::bind(listen_address)
+            .map_err(|e| BuildError::FailedToCreateHTTPListener(e.to_string()))?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|e| BuildError::FailedToCreateHTTPListener(e.to_string()))?;
+        println!("bound to {listen_address}");
+
+        Ok(Box::pin(async move {
+            let listener = TcpListener::from_std(listener)
+                .expect(&format!("Counldn't bind to {listen_address}"));
+            //.map_err(|e| hyper::Error { inner = Box::new(BuildError::FailedToCreateHTTPListener(e.to_string()) })?;
+
+            loop {
+                let handle = handle.clone();
+
+                // waiting for to listen
+                let stream = match listener.accept().await {
+                    Ok((stream, _)) => stream,
+                    Err(e) => {
+                        println!("Error accepting connection: {}", e.kind());
+                        continue;
+                    }
+                };
+
+                let remote_addr = match stream.peer_addr() {
+                    Ok(remote_address) => remote_address.ip(),
+                    Err(e) => {
+                        println!("Error obtaining remote address: {}", e.kind());
+                        continue;
+                    }
+                };
+
+                // If the allowlist is empty, the request is allowed.  Otherwise, it must
+                // match one of the entries in the allowlist or it will be denied.
+                let is_allowed = allowed_addresses.as_ref().map_or(true, |addresses| {
+                    addresses.iter().any(|address| address.contains(&remote_addr))
+                });
+
+                let service = service_fn(move |req: Request<body::Incoming>| {
+                    let handle_clone = handle.clone();
+                    async move {
+                        Ok::<_, hyper::Error>(handle_request(is_allowed, handle_clone, &req).await)
+                    }
+                });
+
+                let io = TokioIo::new(stream);
+
+                tokio::task::spawn(async move {
+                    let a = http1::Builder::new().serve_connection(io, service);
+                    match a.await {
+                        Ok(_) => println!("Done serving connection"),
+                        Err(err) => println!("Error serving connection: {:?}", err),
+                    };
+                });
+            }
+        }))
+    }
+}
+
+#[cfg(feature = "push-gateway")]
+mod push_gateway {
+    use std::time::Duration;
+
+    use hyper::{header::HeaderValue, Uri};
+    use tracing::error;
+
+    use crate::builder::ExporterFuture;
+    use crate::PrometheusHandle;
+
+    // Creates an ExporterFuture implementing a push gateway.
+    pub(super) fn new_push_gateway(
+        endpoint: Uri,
+        interval: Duration,
+        username: Option<String>,
+        password: Option<String>,
+        handle: PrometheusHandle,
+    ) -> ExporterFuture {
+        use http_body_util::{BodyExt, Collected, Full};
+        use hyper::body::{Buf, Bytes};
+        use hyper::{Method, Request};
+        use hyper_tls::HttpsConnector;
+        use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+
+        Box::pin(async move {
+            let https = HttpsConnector::new();
+            let client: Client<_, Full<Bytes>> = Client::builder(TokioExecutor::new())
+                .pool_idle_timeout(Duration::from_secs(30))
+                .build(https);
+
+            let auth = username.as_ref().map(|name| basic_auth(name, password.as_deref()));
+
+            loop {
+                // Sleep for `interval` amount of time, and then do a push.
+                tokio::time::sleep(interval).await;
+
+                let mut builder = Request::builder();
+                if let Some(auth) = &auth {
+                    builder = builder.header("authorization", auth.clone());
+                }
+
+                let output = handle.render();
+                let result =
+                    builder.method(Method::PUT).uri(endpoint.clone()).body(Full::from(output));
+                let req = match result {
+                    Ok(req) => req,
+                    Err(e) => {
+                        error!("failed to build push gateway request: {}", e);
+                        continue;
+                    }
+                };
 
                         match client.request(req).await {
                             Ok(response) => {
@@ -608,27 +763,96 @@ impl Default for PrometheusBuilder {
         PrometheusBuilder::new()
     }
 }
+                match client.request(req).await {
+                    Ok(response) => {
+                        if !response.status().is_success() {
+                            let status = response.status();
+                            let status =
+                                status.canonical_reason().unwrap_or_else(|| status.as_str());
+                            let body = response
+                                .into_body()
+                                .collect()
+                                .await
+                                .map(Collected::aggregate)
+                                .map_err(|_| ())
+                                .map(|mut b| b.copy_to_bytes(b.remaining()))
+                                .map(|b| b[..].to_vec())
+                                .and_then(|s| String::from_utf8(s).map_err(|_| ()))
+                                .unwrap_or_else(|()| {
+                                    String::from("<failed to read response body>")
+                                });
+                            error!(
+                                message = "unexpected status after pushing metrics to push gateway",
+                                status,
+                                %body,
+                            );
+                        }
+                    }
+                    Err(e) => error!("error sending request to push gateway: {:?}", e),
+                }
+            }
+        })
+    }
 
-#[cfg(feature = "push-gateway")]
-fn basic_auth(username: &str, password: Option<&str>) -> HeaderValue {
-    use base64::prelude::BASE64_STANDARD;
-    use base64::write::EncoderWriter;
-    use std::io::Write;
+    #[cfg(feature = "push-gateway")]
+    fn basic_auth(username: &str, password: Option<&str>) -> HeaderValue {
+        use base64::prelude::BASE64_STANDARD;
+        use base64::write::EncoderWriter;
+        use std::io::Write;
 
-    let mut buf = b"Basic ".to_vec();
-    {
-        let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
-        write!(encoder, "{username}:").expect("should not fail to encode username");
-        if let Some(password) = password {
-            write!(encoder, "{password}").expect("should not fail to encode password");
+        let mut buf = b"Basic ".to_vec();
+        {
+            let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
+            write!(encoder, "{username}:").expect("should not fail to encode username");
+            if let Some(password) = password {
+                write!(encoder, "{password}").expect("should not fail to encode password");
+            }
+        }
+        let mut header = HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");
+        header.set_sensitive(true);
+        header
+    }
+
+    #[cfg(all(test))]
+    mod tests {
+        use super::basic_auth;
+
+        #[test]
+        #[allow(clippy::similar_names)] // reader vs header, sheesh clippy
+        pub fn test_basic_auth() {
+            use base64::prelude::BASE64_STANDARD;
+            use base64::read::DecoderReader;
+            use std::io::Read;
+
+            const BASIC: &str = "Basic ";
+
+            // username only
+            let username = "metrics";
+            let header = basic_auth(username, None);
+
+            let reader = &header.as_ref()[BASIC.len()..];
+            let mut decoder = DecoderReader::new(reader, &BASE64_STANDARD);
+            let mut result = Vec::new();
+            decoder.read_to_end(&mut result).unwrap();
+            assert_eq!(b"metrics:", &result[..]);
+            assert!(header.is_sensitive());
+
+            // username/password
+            let password = "123!_@ABC";
+            let header = basic_auth(username, Some(password));
+
+            let reader = &header.as_ref()[BASIC.len()..];
+            let mut decoder = DecoderReader::new(reader, &BASE64_STANDARD);
+            let mut result = Vec::new();
+            decoder.read_to_end(&mut result).unwrap();
+            assert_eq!(b"metrics:123!_@ABC", &result[..]);
+            assert!(header.is_sensitive());
         }
     }
-    let mut header = HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");
-    header.set_sensitive(true);
-    header
 }
 
 #[cfg(test)]
+#[allow(clippy::approx_constant)]
 mod tests {
     use std::time::Duration;
 
@@ -1091,41 +1315,5 @@ mod tests {
         let expected_counter = "# HELP yee_haw:lets_go \"Simplë stuff.\\nRëally.\"\n# TYPE yee_haw:lets_go counter\nyee_haw:lets_go{foo_=\"foo\",_hno=\"\\\"yeet\\nies\\\"\"} 1\n\n";
 
         assert_eq!(rendered, expected_counter);
-    }
-}
-
-#[cfg(all(test, feature = "push-gateway"))]
-mod push_gateway_tests {
-    use crate::builder::basic_auth;
-
-    #[test]
-    pub fn test_basic_auth() {
-        use base64::prelude::BASE64_STANDARD;
-        use base64::read::DecoderReader;
-        use std::io::Read;
-
-        const BASIC: &str = "Basic ";
-
-        // username only
-        let username = "metrics";
-        let header = basic_auth(username, None);
-
-        let reader = &header.as_ref()[BASIC.len()..];
-        let mut decoder = DecoderReader::new(reader, &BASE64_STANDARD);
-        let mut result = Vec::new();
-        decoder.read_to_end(&mut result).unwrap();
-        assert_eq!(b"metrics:", &result[..]);
-        assert!(header.is_sensitive());
-
-        // username/password
-        let password = "123!_@ABC";
-        let header = basic_auth(username, Some(password));
-
-        let reader = &header.as_ref()[BASIC.len()..];
-        let mut decoder = DecoderReader::new(reader, &BASE64_STANDARD);
-        let mut result = Vec::new();
-        decoder.read_to_end(&mut result).unwrap();
-        assert_eq!(b"metrics:123!_@ABC", &result[..]);
-        assert!(header.is_sensitive());
     }
 }

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -4,9 +4,8 @@ use std::convert::TryFrom;
 use std::future::Future;
 #[cfg(feature = "http-listener")]
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::num::NonZeroU32;
 #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
-use std::pin::Pin;
+use std::num::NonZeroU32;
 #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 use std::sync::RwLock;
 #[cfg(any(feature = "http-listener", feature = "push-gateway"))]

--- a/metrics-exporter-prometheus/src/exporter/builder.rs
+++ b/metrics-exporter-prometheus/src/exporter/builder.rs
@@ -1,4 +1,3 @@
-
 use std::collections::HashMap;
 #[cfg(feature = "push-gateway")]
 use std::convert::TryFrom;
@@ -186,7 +185,7 @@ impl PrometheusBuilder {
         self.quantiles = parse_quantiles(quantiles);
         Ok(self)
     }
-    
+
     /// Sets the bucket width when using summaries.
     ///
     /// Summaries are rolling, which means that they are divided into buckets of a fixed duration

--- a/metrics-exporter-prometheus/src/exporter/builder.rs
+++ b/metrics-exporter-prometheus/src/exporter/builder.rs
@@ -29,7 +29,9 @@ use crate::recorder::{Inner, PrometheusRecorder};
 use crate::registry::AtomicStorage;
 use crate::{common::BuildError, PrometheusHandle};
 
-use super::{ExporterConfig, ExporterFuture};
+use super::ExporterConfig;
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+use super::ExporterFuture;
 
 /// Builder for creating and installing a Prometheus recorder/exporter.
 pub struct PrometheusBuilder {

--- a/metrics-exporter-prometheus/src/exporter/http_listener.rs
+++ b/metrics-exporter-prometheus/src/exporter/http_listener.rs
@@ -1,0 +1,131 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
+
+use http_body_util::Full;
+use hyper::{
+    body::{self, Bytes, Incoming},
+    server::conn::http1::Builder as HyperHttpBuilder,
+    service::service_fn,
+    Request, Response, StatusCode,
+};
+use hyper_util::rt::TokioIo;
+use ipnet::IpNet;
+use tokio::net::{TcpListener, TcpStream};
+use tracing::warn;
+
+use crate::{common::BuildError, ExporterFuture, PrometheusHandle};
+
+struct HttpListeningExporter {
+    inner: Arc<Inner>,
+}
+#[derive(Clone)]
+struct Inner {
+    handle: PrometheusHandle,
+    allowed_addresses: Option<Vec<IpNet>>,
+}
+
+impl HttpListeningExporter {
+    async fn serve(&self, listener: std::net::TcpListener) -> Result<(), hyper::Error> {
+        // TODO - address panic possibility
+        let listener = TcpListener::from_std(listener).unwrap();
+
+        loop {
+            let stream = match listener.accept().await {
+                Ok((stream, _)) => stream,
+                Err(e) => {
+                    warn!("Error accepting connection. Ignoring request. Error: {:?}", e);
+                    continue;
+                }
+            };
+
+            let remote_addr = match stream.peer_addr() {
+                Ok(remote_address) => remote_address.ip(),
+                Err(e) => {
+                    warn!("Error obtaining remote address. Ignoring request. Error: {:?}", e);
+                    continue;
+                }
+            };
+
+            self.process_stream(stream, remote_addr).await;
+        }
+    }
+
+    async fn process_stream(&self, stream: TcpStream, remote_address: IpAddr) {
+        let inner = self.inner.clone();
+        let service = service_fn(move |req: Request<body::Incoming>| {
+            let inner = inner.clone();
+            async move { Self::handle_http_request(&inner, remote_address, &req) }
+        });
+
+        tokio::task::spawn(async move {
+            if let Err(err) =
+                HyperHttpBuilder::new().serve_connection(TokioIo::new(stream), service).await
+            {
+                warn!("Error serving connection.  Error: {:?}", err);
+            };
+        });
+    }
+
+    fn handle_http_request(
+        inner: &Arc<Inner>,
+        remote_address: IpAddr,
+        req: &Request<Incoming>,
+    ) -> Result<Response<Full<Bytes>>, hyper::Error> {
+        let is_allowed = match &inner.allowed_addresses {
+            Some(addresses) => addresses.iter().any(|address| address.contains(&remote_address)),
+            None => true,
+        };
+
+        if is_allowed {
+            Ok(Response::new(match req.uri().path() {
+                "/health" => "OK".into(),
+                _ => inner.handle.render().into(),
+            }))
+        } else {
+            Self::new_forbidden_response()
+        }
+    }
+
+    fn new_forbidden_response() -> Result<Response<Full<Bytes>>, hyper::Error> {
+        // This unwrap should not fail because we don't use any function that
+        // can assign an Err to it's inner such as `Builder::header``. A unit test
+        // will have to suffice to detect if this fails to hold true.
+        Ok(Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .body(Full::<Bytes>::default())
+            .unwrap())
+    }
+}
+
+/// Creates an `ExporterFuture` implementing a http listener that servies prometheus metrics.
+///
+/// # Errors
+/// Will return Err if it cannot bind to the listen address
+pub(crate) fn new_http_listener(
+    handle: PrometheusHandle,
+    listen_address: SocketAddr,
+    allowed_addresses: Option<Vec<IpNet>>,
+) -> Result<ExporterFuture, BuildError> {
+    let listener = std::net::TcpListener::bind(listen_address)
+        .and_then(|listener| {
+            listener.set_nonblocking(true)?;
+            Ok(listener)
+        })
+        .map_err(|e| BuildError::FailedToCreateHTTPListener(e.to_string()))?;
+
+    let exporter = HttpListeningExporter { inner: Arc::new(Inner { handle, allowed_addresses }) };
+
+    Ok(Box::pin(async move { exporter.serve(listener).await }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::exporter::http_listener::HttpListeningExporter;
+
+    #[test]
+    fn new_forbidden_response_always_succeeds() {
+        assert!(HttpListeningExporter::new_forbidden_response().is_ok()); // and doesn't panic
+    }
+}

--- a/metrics-exporter-prometheus/src/exporter/mod.rs
+++ b/metrics-exporter-prometheus/src/exporter/mod.rs
@@ -1,8 +1,10 @@
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 use std::future::Future;
 #[cfg(feature = "http-listener")]
 use std::net::SocketAddr;
 #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 use std::pin::Pin;
+#[cfg(feature = "push-gateway")]
 use std::time::Duration;
 
 #[cfg(feature = "push-gateway")]

--- a/metrics-exporter-prometheus/src/exporter/mod.rs
+++ b/metrics-exporter-prometheus/src/exporter/mod.rs
@@ -1,0 +1,54 @@
+use std::future::Future;
+#[cfg(feature = "http-listener")]
+use std::net::SocketAddr;
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+use std::pin::Pin;
+use std::time::Duration;
+
+#[cfg(feature = "push-gateway")]
+use hyper::Uri;
+
+/// Convenience type for Future implementing an exporter.
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+pub type ExporterFuture = Pin<Box<dyn Future<Output = Result<(), hyper::Error>> + Send + 'static>>;
+
+#[derive(Clone)]
+enum ExporterConfig {
+    // Run an HTTP listener on the given `listen_address`.
+    #[cfg(feature = "http-listener")]
+    HttpListener { listen_address: SocketAddr },
+
+    // Run a push gateway task sending to the given `endpoint` after `interval` time has elapsed,
+    // infinitely.
+    #[cfg(feature = "push-gateway")]
+    PushGateway {
+        endpoint: Uri,
+        interval: Duration,
+        username: Option<String>,
+        password: Option<String>,
+    },
+
+    #[allow(dead_code)]
+    Unconfigured,
+}
+
+impl ExporterConfig {
+    #[cfg_attr(not(any(feature = "http-listener", feature = "push-gateway")), allow(dead_code))]
+    fn as_type_str(&self) -> &'static str {
+        match self {
+            #[cfg(feature = "http-listener")]
+            Self::HttpListener { .. } => "http-listener",
+            #[cfg(feature = "push-gateway")]
+            Self::PushGateway { .. } => "push-gateway",
+            Self::Unconfigured => "unconfigured,",
+        }
+    }
+}
+
+#[cfg(feature = "http-listener")]
+mod http_listener;
+
+#[cfg(feature = "push-gateway")]
+mod push_gateway;
+
+pub(crate) mod builder;

--- a/metrics-exporter-prometheus/src/exporter/push_gateway.rs
+++ b/metrics-exporter-prometheus/src/exporter/push_gateway.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use http_body_util::{BodyExt, Collected, Full};
-use hyper::body::{Buf, Bytes};
+use hyper::body::Bytes;
 use hyper::{header::HeaderValue, Method, Request, Uri};
 use hyper_tls::HttpsConnector;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
@@ -54,11 +54,9 @@ pub(super) fn new_push_gateway(
                             .into_body()
                             .collect()
                             .await
-                            .map(Collected::aggregate)
+                            .map(Collected::to_bytes)
                             .map_err(|_| ())
-                            .map(|mut b| b.copy_to_bytes(b.remaining()))
-                            .map(|b| b[..].to_vec())
-                            .and_then(|s| String::from_utf8(s).map_err(|_| ()))
+                            .and_then(|b| String::from_utf8(b[..].to_vec()).map_err(|_| ()))
                             .unwrap_or_else(|()| String::from("<failed to read response body>"));
                         error!(
                             message = "unexpected status after pushing metrics to push gateway",

--- a/metrics-exporter-prometheus/src/exporter/push_gateway.rs
+++ b/metrics-exporter-prometheus/src/exporter/push_gateway.rs
@@ -1,0 +1,136 @@
+use std::time::Duration;
+
+use hyper::{header::HeaderValue, Uri};
+use tracing::error;
+
+use super::ExporterFuture;
+use crate::PrometheusHandle;
+
+// Creates an ExporterFuture implementing a push gateway.
+pub(super) fn new_push_gateway(
+    endpoint: Uri,
+    interval: Duration,
+    username: Option<String>,
+    password: Option<String>,
+    handle: PrometheusHandle,
+) -> ExporterFuture {
+    use http_body_util::{BodyExt, Collected, Full};
+    use hyper::body::{Buf, Bytes};
+    use hyper::{Method, Request};
+    use hyper_tls::HttpsConnector;
+    use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+
+    Box::pin(async move {
+        let https = HttpsConnector::new();
+        let client: Client<_, Full<Bytes>> = Client::builder(TokioExecutor::new())
+            .pool_idle_timeout(Duration::from_secs(30))
+            .build(https);
+
+        let auth = username.as_ref().map(|name| basic_auth(name, password.as_deref()));
+
+        loop {
+            // Sleep for `interval` amount of time, and then do a push.
+            tokio::time::sleep(interval).await;
+
+            let mut builder = Request::builder();
+            if let Some(auth) = &auth {
+                builder = builder.header("authorization", auth.clone());
+            }
+
+            let output = handle.render();
+            let result =
+                builder.method(Method::PUT).uri(endpoint.clone()).body(Full::from(output));
+            let req = match result {
+                Ok(req) => req,
+                Err(e) => {
+                    error!("failed to build push gateway request: {}", e);
+                    continue;
+                }
+            };
+
+            match client.request(req).await {
+                Ok(response) => {
+                    if !response.status().is_success() {
+                        let status = response.status();
+                        let status =
+                            status.canonical_reason().unwrap_or_else(|| status.as_str());
+                        let body = response
+                            .into_body()
+                            .collect()
+                            .await
+                            .map(Collected::aggregate)
+                            .map_err(|_| ())
+                            .map(|mut b| b.copy_to_bytes(b.remaining()))
+                            .map(|b| b[..].to_vec())
+                            .and_then(|s| String::from_utf8(s).map_err(|_| ()))
+                            .unwrap_or_else(|()| {
+                                String::from("<failed to read response body>")
+                            });
+                        error!(
+                            message = "unexpected status after pushing metrics to push gateway",
+                            status,
+                            %body,
+                        );
+                    }
+                }
+                Err(e) => error!("error sending request to push gateway: {:?}", e),
+            }
+        }
+    })
+}
+
+#[cfg(feature = "push-gateway")]
+fn basic_auth(username: &str, password: Option<&str>) -> HeaderValue {
+    use base64::prelude::BASE64_STANDARD;
+    use base64::write::EncoderWriter;
+    use std::io::Write;
+
+    let mut buf = b"Basic ".to_vec();
+    {
+        let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
+        write!(encoder, "{username}:").expect("should not fail to encode username");
+        if let Some(password) = password {
+            write!(encoder, "{password}").expect("should not fail to encode password");
+        }
+    }
+    let mut header = HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");
+    header.set_sensitive(true);
+    header
+}
+
+#[cfg(all(test))]
+mod tests {
+    use super::basic_auth;
+
+    #[test]
+    #[allow(clippy::similar_names)] // reader vs header, sheesh clippy
+    pub fn test_basic_auth() {
+        use base64::prelude::BASE64_STANDARD;
+        use base64::read::DecoderReader;
+        use std::io::Read;
+
+        const BASIC: &str = "Basic ";
+
+        // username only
+        let username = "metrics";
+        let header = basic_auth(username, None);
+
+        let reader = &header.as_ref()[BASIC.len()..];
+        let mut decoder = DecoderReader::new(reader, &BASE64_STANDARD);
+        let mut result = Vec::new();
+        decoder.read_to_end(&mut result).unwrap();
+        assert_eq!(b"metrics:", &result[..]);
+        assert!(header.is_sensitive());
+
+        // username/password
+        let password = "123!_@ABC";
+        let header = basic_auth(username, Some(password));
+
+        let reader = &header.as_ref()[BASIC.len()..];
+        let mut decoder = DecoderReader::new(reader, &BASE64_STANDARD);
+        let mut result = Vec::new();
+        decoder.read_to_end(&mut result).unwrap();
+        assert_eq!(b"metrics:123!_@ABC", &result[..]);
+        assert!(header.is_sensitive());
+    }
+}

--- a/metrics-exporter-prometheus/src/lib.rs
+++ b/metrics-exporter-prometheus/src/lib.rs
@@ -108,6 +108,7 @@ pub use distribution::{Distribution, DistributionBuilder};
 
 mod exporter;
 pub use self::exporter::builder::PrometheusBuilder;
+#[cfg(any(feature = "http-listener", feature = "push-gateway"))]
 pub use self::exporter::ExporterFuture;
 
 pub mod formatting;

--- a/metrics-exporter-prometheus/src/lib.rs
+++ b/metrics-exporter-prometheus/src/lib.rs
@@ -106,8 +106,9 @@ pub use self::common::{BuildError, Matcher};
 mod distribution;
 pub use distribution::{Distribution, DistributionBuilder};
 
-mod builder;
-pub use self::builder::PrometheusBuilder;
+mod exporter;
+pub use self::exporter::builder::PrometheusBuilder;
+pub use self::exporter::ExporterFuture;
 
 pub mod formatting;
 mod recorder;

--- a/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
+++ b/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
@@ -1,0 +1,91 @@
+use http_body_util::{BodyExt, Collected, Empty};
+use hyper::{
+    body::{Buf, Bytes},
+    Request, StatusCode, Uri,
+};
+use hyper_util::client::legacy::{connect::HttpConnector, Client};
+use metrics::{Key, Label, Recorder};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+static METADATA: metrics::Metadata =
+    metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
+
+#[cfg(all(test, feature = "http-listener"))]
+#[test]
+fn test_http_listener() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|e| panic!("Failed to create test runtime: {:?}", e));
+
+    runtime.block_on(async {        
+        let port = find_available_port().unwrap();
+        let socket_address = SocketAddr::from(([127, 0, 0, 1], port));
+
+        let (recorder, exporter) = {
+            PrometheusBuilder::new()
+                .with_http_listener(socket_address)
+                .build()
+                .unwrap_or_else(|e| {
+                    panic!("failed to create Prometheus recorder and http listener: {:?}", e)
+                })
+        };
+
+        let labels = vec![Label::new("wutang", "forever")];
+        let key = Key::from_parts("basic_gauge", labels);
+        let gauge = recorder.register_gauge(&key, &METADATA);
+        gauge.set(-3.14);
+
+        runtime.spawn(exporter); //async { exporter.await});
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let uri = format!("http://{socket_address}")
+            .parse::<Uri>()
+            .unwrap_or_else(|e| panic!("Error parsing URI: {:?}", e));
+
+        let (status, body) = read_from(uri).await;
+
+        println!("Status: {status}");
+        println!("Body:");
+        println!("{body}");
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("basic_gauge{wutang=\"forever\"} -3.14"));
+    });
+}
+
+async fn read_from(endpoint: Uri) -> (StatusCode, String) {
+    let client = Client::builder(hyper_util::rt::TokioExecutor::new()).build(HttpConnector::new());
+
+    let req = Request::builder()
+        .uri(endpoint.to_string())
+        .body(Empty::<Bytes>::new())
+        .unwrap_or_else(|e| panic!("Failed building request: {:?}", e));
+
+    let response = client
+        .request(req)
+        .await
+        .unwrap_or_else(|e| panic!("Failed requesting data from {endpoint}: {:?}", e));
+
+    let status = response.status();
+    let mut body = response
+        .into_body()
+        .collect()
+        .await
+        .map(Collected::aggregate)
+        .unwrap_or_else(|e| panic!("Error reading response: {:?}", e));
+
+    let body_string = String::from_utf8(body.copy_to_bytes(body.remaining()).to_vec())
+        .unwrap_or_else(|e| panic!("Error decoding response body: {:?}", e));
+
+    (status, body_string)
+}
+
+fn find_available_port() -> Option<u16> {
+    (25000_u16..26000).find(|&port| match std::net::TcpListener::bind(("localhost", port)) {
+        Ok(_) => true,
+        Err(_) => false,
+    })
+}

--- a/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
+++ b/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
@@ -53,9 +53,12 @@ mod http_listener_test {
     }
 
     async fn get_available_port(listen_address: [u8; 4]) -> u16 {
-        TcpListener::bind(SocketAddr::from((listen_address, 0)))
+        let socket_address = SocketAddr::from((listen_address, 0));
+        TcpListener::bind(socket_address)
             .await
-            .unwrap_or_else(|| panic!("Unable to bind to an available port on address {listen_address}"))
+            .unwrap_or_else(|e| {
+                panic!("Unable to bind to an available port on address {socket_address}: {:?}", e);
+            })
             .local_addr()
             .expect("Unable to obtain local address from TcpListener")
             .port()

--- a/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
+++ b/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
@@ -52,16 +52,13 @@ mod http_listener_test {
         });
     }
 
-    async fn get_available_port(local: [u8; 4]) -> u16 {
-        let port = {
-            TcpListener::bind(SocketAddr::from((local, 0)))
-                .await
-                .expect("Unable to bind any available port")
-                .local_addr()
-                .expect("Unable to obtain local address from TcpListener")
-                .port()
-        };
-        port
+    async fn get_available_port(listen_address: [u8; 4]) -> u16 {
+        TcpListener::bind(SocketAddr::from((listen_address, 0)))
+            .await
+            .unwrap_or_else(|| panic!("Unable to bind to an available port on address {listen_address}"))
+            .local_addr()
+            .expect("Unable to obtain local address from TcpListener")
+            .port()
     }
 
     async fn read_from(endpoint: Uri) -> (StatusCode, String) {

--- a/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
+++ b/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
@@ -1,91 +1,91 @@
-use http_body_util::{BodyExt, Collected, Empty};
-use hyper::{
-    body::{Buf, Bytes},
-    Request, StatusCode, Uri,
-};
-use hyper_util::client::legacy::{connect::HttpConnector, Client};
-use metrics::{Key, Label, Recorder};
-use metrics_exporter_prometheus::PrometheusBuilder;
-use std::net::SocketAddr;
-use std::time::Duration;
-
-static METADATA: metrics::Metadata =
-    metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
-
 #[cfg(all(test, feature = "http-listener"))]
-#[test]
-fn test_http_listener() {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap_or_else(|e| panic!("Failed to create test runtime: {:?}", e));
+mod http_listener_test {
+    use http_body_util::{BodyExt, Collected, Empty};
+    use hyper::{
+        body::{Buf, Bytes},
+        Request, StatusCode, Uri,
+    };
+    use hyper_util::client::legacy::{connect::HttpConnector, Client};
+    use metrics::{Key, Label, Recorder};
+    use metrics_exporter_prometheus::PrometheusBuilder;
+    use std::net::SocketAddr;
+    use std::time::Duration;
 
-    runtime.block_on(async {        
-        let port = find_available_port().unwrap();
-        let socket_address = SocketAddr::from(([127, 0, 0, 1], port));
+    static METADATA: metrics::Metadata =
+        metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
 
-        let (recorder, exporter) = {
-            PrometheusBuilder::new()
-                .with_http_listener(socket_address)
-                .build()
-                .unwrap_or_else(|e| {
-                    panic!("failed to create Prometheus recorder and http listener: {:?}", e)
-                })
-        };
+    #[test]
+    fn test_http_listener() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap_or_else(|e| panic!("Failed to create test runtime: {:?}", e));
 
-        let labels = vec![Label::new("wutang", "forever")];
-        let key = Key::from_parts("basic_gauge", labels);
-        let gauge = recorder.register_gauge(&key, &METADATA);
-        gauge.set(-3.14);
+        runtime.block_on(async {
+            let port = find_available_port().unwrap();
+            let socket_address = SocketAddr::from(([127, 0, 0, 1], port));
 
-        runtime.spawn(exporter); //async { exporter.await});
-        tokio::time::sleep(Duration::from_millis(200)).await;
+            let (recorder, exporter) = {
+                PrometheusBuilder::new().with_http_listener(socket_address).build().unwrap_or_else(
+                    |e| panic!("failed to create Prometheus recorder and http listener: {:?}", e),
+                )
+            };
 
-        let uri = format!("http://{socket_address}")
-            .parse::<Uri>()
-            .unwrap_or_else(|e| panic!("Error parsing URI: {:?}", e));
+            let labels = vec![Label::new("wutang", "forever")];
+            let key = Key::from_parts("basic_gauge", labels);
+            let gauge = recorder.register_gauge(&key, &METADATA);
+            gauge.set(-3.14);
 
-        let (status, body) = read_from(uri).await;
+            runtime.spawn(exporter); //async { exporter.await});
+            tokio::time::sleep(Duration::from_millis(200)).await;
 
-        println!("Status: {status}");
-        println!("Body:");
-        println!("{body}");
+            let uri = format!("http://{socket_address}")
+                .parse::<Uri>()
+                .unwrap_or_else(|e| panic!("Error parsing URI: {:?}", e));
 
-        assert_eq!(status, StatusCode::OK);
-        assert!(body.contains("basic_gauge{wutang=\"forever\"} -3.14"));
-    });
-}
+            let (status, body) = read_from(uri).await;
 
-async fn read_from(endpoint: Uri) -> (StatusCode, String) {
-    let client = Client::builder(hyper_util::rt::TokioExecutor::new()).build(HttpConnector::new());
+            println!("Status: {status}");
+            println!("Body:");
+            println!("{body}");
 
-    let req = Request::builder()
-        .uri(endpoint.to_string())
-        .body(Empty::<Bytes>::new())
-        .unwrap_or_else(|e| panic!("Failed building request: {:?}", e));
+            assert_eq!(status, StatusCode::OK);
+            assert!(body.contains("basic_gauge{wutang=\"forever\"} -3.14"));
+        });
+    }
 
-    let response = client
-        .request(req)
-        .await
-        .unwrap_or_else(|e| panic!("Failed requesting data from {endpoint}: {:?}", e));
+    async fn read_from(endpoint: Uri) -> (StatusCode, String) {
+        let client =
+            Client::builder(hyper_util::rt::TokioExecutor::new()).build(HttpConnector::new());
 
-    let status = response.status();
-    let mut body = response
-        .into_body()
-        .collect()
-        .await
-        .map(Collected::aggregate)
-        .unwrap_or_else(|e| panic!("Error reading response: {:?}", e));
+        let req = Request::builder()
+            .uri(endpoint.to_string())
+            .body(Empty::<Bytes>::new())
+            .unwrap_or_else(|e| panic!("Failed building request: {:?}", e));
 
-    let body_string = String::from_utf8(body.copy_to_bytes(body.remaining()).to_vec())
-        .unwrap_or_else(|e| panic!("Error decoding response body: {:?}", e));
+        let response = client
+            .request(req)
+            .await
+            .unwrap_or_else(|e| panic!("Failed requesting data from {endpoint}: {:?}", e));
 
-    (status, body_string)
-}
+        let status = response.status();
+        let mut body = response
+            .into_body()
+            .collect()
+            .await
+            .map(Collected::aggregate)
+            .unwrap_or_else(|e| panic!("Error reading response: {:?}", e));
 
-fn find_available_port() -> Option<u16> {
-    (25000_u16..26000).find(|&port| match std::net::TcpListener::bind(("localhost", port)) {
-        Ok(_) => true,
-        Err(_) => false,
-    })
+        let body_string = String::from_utf8(body.copy_to_bytes(body.remaining()).to_vec())
+            .unwrap_or_else(|e| panic!("Error decoding response body: {:?}", e));
+
+        (status, body_string)
+    }
+
+    fn find_available_port() -> Option<u16> {
+        (25000_u16..26000).find(|&port| match std::net::TcpListener::bind(("localhost", port)) {
+            Ok(_) => true,
+            Err(_) => false,
+        })
+    }
 }


### PR DESCRIPTION
  - update to hyper 1.1
  - factor large `PrometheusBuilder`.`build` function into separate functions 
  - move those functions into separate modules to reduce some of the feature driven uses
  - add an http-listener integration test