### PR TITLE
feat: add capability to purge old histogram data

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-lines-threshold = 150

--- a/metrics-exporter-prometheus/src/builder.rs
+++ b/metrics-exporter-prometheus/src/builder.rs
@@ -437,7 +437,7 @@ impl PrometheusBuilder {
             let purger = async move {
                 loop {
                     tokio::time::sleep(purge_timeout).await;
-                    let _output = recorder_handle.render();
+                    recorder_handle.purge();
                 }
             };
 

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -56,6 +56,9 @@ impl Inner {
             *entry = value;
         }
 
+        // Update distributions
+        self.drain_histograms_to_distributions();
+        // Remove expired histograms
         let histogram_handles = self.registry.get_histogram_handles();
         for (key, histogram) in histogram_handles {
             let gen = histogram.get_generation();
@@ -66,7 +69,7 @@ impl Inner {
                 let (name, labels) = key_to_parts(&key, Some(&self.global_labels));
                 let mut wg = self.distributions.write().unwrap_or_else(PoisonError::into_inner);
                 let delete_by_name = if let Some(by_name) = wg.get_mut(&name) {
-                    by_name.remove(&labels);
+                    by_name.swap_remove(&labels);
                     by_name.is_empty()
                 } else {
                     false
@@ -80,7 +83,18 @@ impl Inner {
 
                 continue;
             }
+        }
 
+        let distributions =
+            self.distributions.read().unwrap_or_else(PoisonError::into_inner).clone();
+
+        Snapshot { counters, gauges, distributions }
+    }
+
+    /// Drains histogram samples into distribution.
+    fn drain_histograms_to_distributions(&self) {
+        let histogram_handles = self.registry.get_histogram_handles();
+        for (key, histogram) in histogram_handles {
             let (name, labels) = key_to_parts(&key, Some(&self.global_labels));
 
             let mut wg = self.distributions.write().unwrap_or_else(PoisonError::into_inner);
@@ -92,11 +106,6 @@ impl Inner {
 
             histogram.get_inner().clear_with(|samples| entry.record_samples(samples));
         }
-
-        let distributions =
-            self.distributions.read().unwrap_or_else(PoisonError::into_inner).clone();
-
-        Snapshot { counters, gauges, distributions }
     }
 
     fn render(&self) -> String {
@@ -194,6 +203,11 @@ impl Inner {
 
         output
     }
+
+    /// Performs upkeep tasks for the metrics registry.
+    fn run_upkeep(&self) {
+        self.drain_histograms_to_distributions();
+    }
 }
 
 /// A Prometheus recorder.
@@ -272,5 +286,11 @@ impl PrometheusHandle {
     /// the Prometheus exposition format.
     pub fn render(&self) -> String {
         self.inner.render()
+    }
+
+    /// Purges registry's histogram data by draining it into the distribution. This should be
+    /// called periodically to prevent the accumulation of histogram samples.
+    pub fn purge(&self) {
+        self.inner.run_upkeep();
     }
 }

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -204,7 +204,6 @@ impl Inner {
         output
     }
 
-    /// Performs upkeep tasks for the metrics registry.
     fn run_upkeep(&self) {
         self.drain_histograms_to_distributions();
     }
@@ -288,9 +287,9 @@ impl PrometheusHandle {
         self.inner.render()
     }
 
-    /// Purges registry's histogram data by draining it into the distribution. This should be
-    /// called periodically to prevent the accumulation of histogram samples.
-    pub fn purge(&self) {
+    /// Performs upkeeping operations to ensure metrics held by recorder are up-to-date and do not
+    /// grow unboundedly.
+    pub fn run_upkeep(&self) {
         self.inner.run_upkeep();
     }
 }


### PR DESCRIPTION
Copy of #451 

---

# What

- add purge_timeout option to PrometheusBuilder
- run a purger that purges based on the purge_timeout

Implements third way as [prescribed here](https://github.com/metrics-rs/metrics/issues/245#issuecomment-974155299) to purge old histogram data:
> - update the builder to generate a future which both drives the Hyper server future as well as a call to get_recent_metrics on an interval

Fixes https://github.com/metrics-rs/metrics/issues/245