### PR TITLE
feat: get_recent_metrics as method from PrometheusHandle

### DIFF
--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -287,6 +287,11 @@ impl PrometheusHandle {
         self.inner.render()
     }
 
+    /// Takes only the snapshot and uses it as you want.
+    pub fn get_recent_metrics(&self) -> Snapshot {
+        self.inner.get_recent_metrics()
+    }
+
     /// Performs upkeeping operations to ensure metrics held by recorder are up-to-date and do not
     /// grow unboundedly.
     pub fn run_upkeep(&self) {


### PR DESCRIPTION
If we choose to only uses the Recorder, I think with that implementation we could achieve a lot of implementations, like translate to otlp, request a rest api, print to stdout and some other things.