### PR TITLE
Annotate metric types with must_use

### DIFF
--- a/metrics/src/handles.rs
+++ b/metrics/src/handles.rs
@@ -40,18 +40,21 @@ pub trait HistogramFn {
 
 /// A counter.
 #[derive(Clone)]
+#[must_use = "counters do nothing unless you use them"]
 pub struct Counter {
     inner: Option<Arc<dyn CounterFn + Send + Sync>>,
 }
 
 /// A gauge.
 #[derive(Clone)]
+#[must_use = "gauges do nothing unless you use them"]
 pub struct Gauge {
     inner: Option<Arc<dyn GaugeFn + Send + Sync>>,
 }
 
 /// A histogram.
 #[derive(Clone)]
+#[must_use = "histograms do nothing unless you use them"]
 pub struct Histogram {
     inner: Option<Arc<dyn HistogramFn + Send + Sync>>,
 }

--- a/metrics/tests/macros/02_trailing_comma.rs
+++ b/metrics/tests/macros/02_trailing_comma.rs
@@ -12,9 +12,9 @@ fn no_trailing_comma() {
 
 #[allow(dead_code)]
 fn with_trailing_comma() {
-    counter!("qwe",);
+    counter!("qwe",).increment(1);
     counter!(
-        "qwe", 
+        "qwe",
         "foo" => "bar",
     ).increment(1);
     counter!("qwe", vec![],).increment(1);

--- a/metrics/tests/macros/03_mod_aliasing.rs
+++ b/metrics/tests/macros/03_mod_aliasing.rs
@@ -13,7 +13,7 @@ use framework::*; // This exposes mod `framework::metrics`.
 
 #[inline]
 pub fn register_metrics() {
-    ::metrics::counter!(
+    let _ = ::metrics::counter!(
         metrics::UPLOAD_METRIC_NAME,
         &[
             (metrics::UPLOAD_METRIC_LABEL_PROCESS_TYPE, ""),


### PR DESCRIPTION
Happened to me just now, I created a counter and never incremented it and was wondering where my metric is going or if that piece of code was ever ran.

Annotate the metric types with must use and let the compiler warn us if they are never used.