### PR TITLE
chore: bump MSRV to 1.70.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Additionally, here are some learning resource(s) to help you get started:
 
 ## MSRV and MSRV policy
 
-Minimum supported Rust version (MSRV) is currently **1.65.0**, enforced by CI.
+Minimum supported Rust version (MSRV) is currently **1.70.0**, enforced by CI.
 
 `metrics` will always support _at least_ the latest four versions of stable Rust, based on minor
 version releases, and excluding patch versions. Overall, we strive to support older versions where

--- a/metrics-benchmark/Cargo.toml
+++ b/metrics-benchmark/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-benchmark"
 version = "0.1.1-alpha.5"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 publish = false
 
 [dependencies]

--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Bump MSRV to 1.70.0.
+
 ## [0.14.0] - 2024-03-16
 
 ### Added

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-exporter-prometheus"
 version = "0.14.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 license = "MIT"
 

--- a/metrics-exporter-tcp/CHANGELOG.md
+++ b/metrics-exporter-tcp/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Bump MSRV to 1.70.0.
+
 ## [0.9.0] - 2023-12-24
 
 ### Changed

--- a/metrics-exporter-tcp/Cargo.toml
+++ b/metrics-exporter-tcp/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-exporter-tcp"
 version = "0.9.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 license = "MIT"
 

--- a/metrics-observer/CHANGELOG.md
+++ b/metrics-observer/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Bump MSRV to 1.70.0.
+
 ## [0.3.0] - 2023-12-24
 
 ### Fixed

--- a/metrics-observer/Cargo.toml
+++ b/metrics-observer/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-observer"
 version = "0.3.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 license = "MIT"
 

--- a/metrics-tracing-context/CHANGELOG.md
+++ b/metrics-tracing-context/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Bump MSRV to 1.70.0.
+
 ## [0.15.0] - 2023-12-24
 
 ### Added

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-tracing-context"
 version = "0.15.0"
 authors = ["MOZGIII <mike-n@narod.ru>"]
 edition = "2018"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 license = "MIT"
 

--- a/metrics-util/CHANGELOG.md
+++ b/metrics-util/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Bump MSRV to 1.70.0.
+
 ## [0.16.3] - 2024-03-16
 
 ### Added

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-util"
 version = "0.16.3"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 license = "MIT"
 

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Bump MSRV to 1.70.0.
+
 ## [0.22.3] - 2024-03-16
 
 ### Added

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics"
 version = "0.22.3"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 license = "MIT"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.70.0"


### PR DESCRIPTION
As stated in the title.

This puts us at supporting the last seven releases, or just about the last years worth, give or take a month or two. Try as I might, people love to keep bumping MSRV in patch versions and it's annoying so I'm just going with the flow here. 🍃 