### PR TITLE
refactor: use hyper-rustls

### DIFF
--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -22,7 +22,7 @@ async-runtime = ["tokio", "hyper-util/tokio"]
 http-listener = ["async-runtime", "ipnet", "tracing", "_hyper-server"]
 push-gateway = ["async-runtime", "tracing", "_hyper-client"]
 _hyper-server = ["http-body-util", "hyper/server", "hyper-util/server-auto"]
-_hyper-client = ["http-body-util", "hyper/client", "hyper-util/client", "hyper-util/http1", "hyper-util/client-legacy", "hyper-tls"]
+_hyper-client = ["http-body-util", "hyper/client", "hyper-util/client", "hyper-util/http1", "hyper-util/client-legacy", "hyper-rustls"]
 
 [dependencies]
 metrics = { version = "^0.23", path = "../metrics" }
@@ -39,7 +39,7 @@ http-body-util = { version = "0.1.0", optional = true }
 ipnet = { version = "2", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time", "rt-multi-thread"], optional = true }
 tracing = { version = "0.1.26", optional = true }
-hyper-tls = { version = "0.6.0", optional = true }
+hyper-rustls = { version = "0.27.2", optional = true }
 
 [dev-dependencies]
 tracing = "0.1"

--- a/metrics-exporter-prometheus/src/exporter/push_gateway.rs
+++ b/metrics-exporter-prometheus/src/exporter/push_gateway.rs
@@ -21,7 +21,7 @@ pub(super) fn new_push_gateway(
         let https = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
             .expect("no native root CA certificates found")
-            .https_only()
+            .https_or_http()
             .enable_http1()
             .build();
         let client: Client<_, Full<Bytes>> = Client::builder(TokioExecutor::new())


### PR DESCRIPTION
From https://github.com/metrics-rs/metrics/pull/420#discussion_r1435328304:

> After doing some reading, it seems like we should probably just switch to using `rustls` entirely.
> 
> I don't think the initial implementor choose to use `hyper-tls` specifically for the OS-backed/dynamically-linked aspect, and I don't personally care about esoteric SSL/TLS setups or FIPS compliance or any of that... so I'd rather go with a single solution than force users to have to spend time understanding which one they ought to choose.

This PR switches to `hyper-rustls`.