### PR TITLE
Replace num_cpus::get with std::thread::available_parallelism

### DIFF
--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -56,7 +56,6 @@ quanta = { version = "0.12", default-features = false, optional = true }
 sketches-ddsketch = { version = "0.2", default-features = false, optional = true }
 radix_trie = { version = "0.2", default-features = false, optional = true }
 ordered-float = { version = "4.2", default-features = false, optional = true }
-num_cpus = { version = "1", default-features = false, optional = true }
 ahash = { version = "0.8.8", default-features = false, optional = true }
 hashbrown = { version = "0.14", default-features = false, optional = true, features = ["ahash"] }
 
@@ -90,4 +89,4 @@ layer-filter = ["aho-corasick"]
 layer-router = ["radix_trie"]
 summary = ["sketches-ddsketch"]
 recency = ["registry", "quanta"]
-registry = ["crossbeam-epoch", "crossbeam-utils", "handles", "hashbrown", "num_cpus"]
+registry = ["crossbeam-epoch", "crossbeam-utils", "handles", "hashbrown"]

--- a/metrics-util/src/registry/mod.rs
+++ b/metrics-util/src/registry/mod.rs
@@ -56,10 +56,14 @@ where
     storage: S,
 }
 
+fn shard_count() -> usize {
+    std::thread::available_parallelism().map(|x| x.get()).unwrap_or(1).next_power_of_two()
+}
+
 impl Registry<Key, AtomicStorage> {
     /// Creates a new `Registry` using a regular [`Key`] and atomic storage.
     pub fn atomic() -> Self {
-        let shard_count = std::cmp::max(1, num_cpus::get()).next_power_of_two();
+        let shard_count = shard_count();
         let shard_mask = shard_count - 1;
         let counters =
             repeat(()).take(shard_count).map(|_| RwLock::new(RegistryHashMap::default())).collect();
@@ -78,7 +82,7 @@ where
 {
     /// Creates a new `Registry`.
     pub fn new(storage: S) -> Self {
-        let shard_count = std::cmp::max(1, num_cpus::get()).next_power_of_two();
+        let shard_count = shard_count();
         let shard_mask = shard_count - 1;
         let counters =
             repeat(()).take(shard_count).map(|_| RwLock::new(RegistryHashMap::default())).collect();


### PR DESCRIPTION
[std::thread::available_parallelism](https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html) was stabilized in rust 1.59, so there should be no problem in using it in this crate with an MSRV of 1.70

To remain consistent with the existing usage of `num_cpus::get` we default to a value of 1 if info on parallelism is inaccessible for whatever reason.
The old implementation did a `std::cmp::max(1, ..)` but that was not needed with num_cpus since it was documented to return a max of 1, and its not needed now since we handle an error by using 1.