### PR TITLE
Derive Debug trait for all structs and enums

### DIFF
--- a/metrics-exporter-prometheus/src/common.rs
+++ b/metrics-exporter-prometheus/src/common.rs
@@ -80,6 +80,7 @@ pub enum BuildError {
     ZeroBucketDuration,
 }
 
+#[derive(Debug)]
 pub struct Snapshot {
     pub counters: HashMap<String, HashMap<Vec<String>, u64>>,
     pub gauges: HashMap<String, HashMap<Vec<String>, f64>>,

--- a/metrics-exporter-prometheus/src/distribution.rs
+++ b/metrics-exporter-prometheus/src/distribution.rs
@@ -15,7 +15,7 @@ const DEFAULT_SUMMARY_BUCKET_COUNT: NonZeroU32 = match NonZeroU32::new(3) {
 const DEFAULT_SUMMARY_BUCKET_DURATION: Duration = Duration::from_secs(20);
 
 /// Distribution type.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Distribution {
     /// A Prometheus histogram.
     ///
@@ -137,14 +137,14 @@ impl DistributionBuilder {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Bucket {
     begin: Instant,
     summary: Summary,
 }
 
 /// A `RollingSummary` manages a list of [Summary] so that old results can be expired.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RollingSummary {
     // Buckets are ordered with the latest buckets first.  The buckets are kept in alignment based
     // on the instant of the first added bucket and the bucket_duration.  There may be gaps in the

--- a/metrics-exporter-prometheus/src/exporter/builder.rs
+++ b/metrics-exporter-prometheus/src/exporter/builder.rs
@@ -33,6 +33,7 @@ use super::ExporterConfig;
 use super::ExporterFuture;
 
 /// Builder for creating and installing a Prometheus recorder/exporter.
+#[derive(Debug)]
 pub struct PrometheusBuilder {
     #[cfg_attr(not(any(feature = "http-listener", feature = "push-gateway")), allow(dead_code))]
     exporter_config: ExporterConfig,

--- a/metrics-exporter-prometheus/src/exporter/http_listener.rs
+++ b/metrics-exporter-prometheus/src/exporter/http_listener.rs
@@ -32,6 +32,7 @@ enum ListenerType {
 }
 
 /// Error type for HTTP listening.
+#[derive(Debug)]
 pub enum HttpListeningError {
     Hyper(hyper::Error),
     Io(std::io::Error),

--- a/metrics-exporter-prometheus/src/exporter/mod.rs
+++ b/metrics-exporter-prometheus/src/exporter/mod.rs
@@ -14,6 +14,7 @@ use hyper::Uri;
 
 /// Error types possible from an exporter
 #[cfg(any(feature = "http-listener", feature = "push-gateway"))]
+#[derive(Debug)]
 pub enum ExporterError {
     #[cfg(feature = "http-listener")]
     HttpListener(HttpListeningError),
@@ -24,14 +25,14 @@ pub enum ExporterError {
 pub type ExporterFuture = Pin<Box<dyn Future<Output = Result<(), ExporterError>> + Send + 'static>>;
 
 #[cfg(feature = "http-listener")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum ListenDestination {
     Tcp(SocketAddr),
     #[cfg(feature = "uds-listener")]
     Uds(std::path::PathBuf),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum ExporterConfig {
     // Run an HTTP listener on the given `listen_address`.
     #[cfg(feature = "http-listener")]

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -15,6 +15,7 @@ use crate::formatting::{
 };
 use crate::registry::GenerationalAtomicStorage;
 
+#[derive(Debug)]
 pub(crate) struct Inner {
     pub registry: Registry<Key, GenerationalAtomicStorage>,
     pub recency: Recency<Key>,
@@ -214,6 +215,7 @@ impl Inner {
 /// Most users will not need to interact directly with the recorder, and can simply deal with the
 /// builder methods on [`PrometheusBuilder`](crate::PrometheusBuilder) for building and installing
 /// the recorder/exporter.
+#[derive(Debug)]
 pub struct PrometheusRecorder {
     inner: Arc<Inner>,
 }
@@ -275,7 +277,7 @@ impl Recorder for PrometheusRecorder {
 /// handled directly by the HTTP listener, or push gateway background task.  [`PrometheusHandle`]
 /// allows rendering a snapshot of the current metrics stored by an installed [`PrometheusRecorder`]
 /// as a payload conforming to the Prometheus exposition format.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PrometheusHandle {
     inner: Arc<Inner>,
 }

--- a/metrics-exporter-prometheus/src/registry.rs
+++ b/metrics-exporter-prometheus/src/registry.rs
@@ -7,6 +7,7 @@ use quanta::Instant;
 pub type GenerationalAtomicStorage = GenerationalStorage<AtomicStorage>;
 
 /// Atomic metric storage for the prometheus exporter.
+#[derive(Debug)]
 pub struct AtomicStorage;
 
 impl<K> metrics_util::registry::Storage<K> for AtomicStorage {
@@ -28,6 +29,7 @@ impl<K> metrics_util::registry::Storage<K> for AtomicStorage {
 }
 
 /// An `AtomicBucket` newtype wrapper that tracks the time of value insertion.
+#[derive(Debug)]
 pub struct AtomicBucketInstant<T> {
     inner: AtomicBucket<(T, Instant)>,
 }

--- a/metrics-exporter-tcp/src/lib.rs
+++ b/metrics-exporter-tcp/src/lib.rs
@@ -137,6 +137,7 @@ impl std::error::Error for Error {
     }
 }
 
+#[derive(Debug)]
 struct State {
     client_count: AtomicUsize,
     should_send: AtomicBool,
@@ -188,6 +189,7 @@ impl State {
     }
 }
 
+#[derive(Debug)]
 struct Handle {
     key: Key,
     state: Arc<State>,
@@ -230,11 +232,13 @@ impl HistogramFn for Handle {
 }
 
 /// A TCP recorder.
+#[derive(Debug)]
 pub struct TcpRecorder {
     state: Arc<State>,
 }
 
 /// Builder for creating and installing a TCP recorder/exporter.
+#[derive(Debug)]
 pub struct TcpBuilder {
     listen_addr: SocketAddr,
     buffer_size: Option<usize>,

--- a/metrics-tracing-context/src/label_filter.rs
+++ b/metrics-tracing-context/src/label_filter.rs
@@ -1,6 +1,6 @@
 //! Label filtering.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::Debug};
 
 use metrics::{KeyName, Label};
 

--- a/metrics-tracing-context/src/label_filter.rs
+++ b/metrics-tracing-context/src/label_filter.rs
@@ -1,6 +1,6 @@
 //! Label filtering.
 
-use std::{collections::HashSet, fmt::Debug};
+use std::collections::HashSet;
 
 use metrics::{KeyName, Label};
 

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -114,6 +114,7 @@ use tracing_integration::Map;
 pub use tracing_integration::{Labels, MetricsLayer};
 
 /// [`TracingContextLayer`] provides an implementation of a [`Layer`] for [`TracingContext`].
+#[derive(Debug)]
 pub struct TracingContextLayer<F> {
     label_filter: F,
 }
@@ -156,6 +157,7 @@ where
 }
 
 /// [`TracingContext`] is a [`metrics::Recorder`] that injects labels from [`tracing::Span`]s.
+#[derive(Debug)]
 pub struct TracingContext<R, F> {
     inner: R,
     label_filter: F,

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -522,7 +522,7 @@ fn test_nested_spans() {
     );
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct OnlyUser;
 
 impl LabelFilter for OnlyUser {

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -36,6 +36,7 @@ impl CompositeKeyName {
 }
 
 /// A point-in-time snapshot of all metrics in [`DebuggingRecorder`].
+#[derive(Debug)]
 pub struct Snapshot(Vec<(CompositeKey, Option<Unit>, Option<SharedString>, DebugValue)>);
 
 impl Snapshot {
@@ -67,6 +68,7 @@ pub enum DebugValue {
     Histogram(Vec<OrderedFloat<f64>>),
 }
 
+#[derive(Debug)]
 struct Inner {
     registry: Registry<Key, AtomicStorage>,
     seen: Mutex<IndexMap<CompositeKey, ()>>,
@@ -84,7 +86,7 @@ impl Inner {
 }
 
 /// Captures point-in-time snapshots of [`DebuggingRecorder`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Snapshotter {
     inner: Arc<Inner>,
 }
@@ -138,6 +140,7 @@ impl Snapshotter {
 ///
 /// Callers can easily take snapshots of the metrics at any given time and get access
 /// to the raw values.
+#[derive(Debug)]
 pub struct DebuggingRecorder {
     inner: Arc<Inner>,
 }

--- a/metrics-util/src/layers/fanout.rs
+++ b/metrics-util/src/layers/fanout.rs
@@ -105,7 +105,9 @@ pub struct Fanout {
 
 impl fmt::Debug for Fanout {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Fanout").finish_non_exhaustive()
+        f.debug_struct("Fanout")
+            .field("recorders_len", &self.recorders.len())
+            .finish_non_exhaustive()
     }
 }
 
@@ -166,7 +168,9 @@ pub struct FanoutBuilder {
 
 impl fmt::Debug for FanoutBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FanoutBuilder").finish_non_exhaustive()
+        f.debug_struct("FanoutBuilder")
+            .field("recorders_len", &self.recorders.len())
+            .finish_non_exhaustive()
     }
 }
 

--- a/metrics-util/src/layers/fanout.rs
+++ b/metrics-util/src/layers/fanout.rs
@@ -1,10 +1,11 @@
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use metrics::{
     Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder,
     SharedString, Unit,
 };
 
+#[derive(Debug)]
 struct FanoutCounter {
     counters: Vec<Counter>,
 }
@@ -35,6 +36,7 @@ impl From<FanoutCounter> for Counter {
     }
 }
 
+#[derive(Debug)]
 struct FanoutGauge {
     gauges: Vec<Gauge>,
 }
@@ -71,6 +73,7 @@ impl From<FanoutGauge> for Gauge {
     }
 }
 
+#[derive(Debug)]
 struct FanoutHistogram {
     histograms: Vec<Histogram>,
 }
@@ -98,6 +101,12 @@ impl From<FanoutHistogram> for Histogram {
 /// Fans out metrics to multiple recorders.
 pub struct Fanout {
     recorders: Vec<Box<dyn Recorder>>,
+}
+
+impl fmt::Debug for Fanout {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Fanout").finish_non_exhaustive()
+    }
 }
 
 impl Recorder for Fanout {
@@ -153,6 +162,12 @@ impl Recorder for Fanout {
 #[derive(Default)]
 pub struct FanoutBuilder {
     recorders: Vec<Box<dyn Recorder>>,
+}
+
+impl fmt::Debug for FanoutBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FanoutBuilder").finish_non_exhaustive()
+    }
 }
 
 impl FanoutBuilder {

--- a/metrics-util/src/layers/filter.rs
+++ b/metrics-util/src/layers/filter.rs
@@ -5,6 +5,7 @@ use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, Share
 /// Filters and discards metrics matching certain name patterns.
 ///
 /// More information on the behavior of the layer can be found in [`FilterLayer`].
+#[derive(Debug)]
 pub struct Filter<R> {
     inner: R,
     automaton: AhoCorasick,
@@ -73,7 +74,7 @@ impl<R: Recorder> Recorder for Filter<R> {
 /// DFA, or case sensitivity.
 ///
 /// [ahocorasick]: https://en.wikipedia.org/wiki/Aho–Corasick_algorithm
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct FilterLayer {
     patterns: Vec<String>,
     case_insensitive: bool,

--- a/metrics-util/src/layers/mod.rs
+++ b/metrics-util/src/layers/mod.rs
@@ -12,7 +12,7 @@
 //! # use metrics::NoopRecorder as BasicRecorder;
 //! # use metrics_util::layers::{Layer, Stack, PrefixLayer};
 //! // A simple layer that denies any metrics that have "stairway" or "heaven" in their name.
-//! #[derive(Default)]
+//! #[derive(Default, Debug)]
 //! pub struct StairwayDeny<R>(pub(crate) R);
 //!
 //! impl<R> StairwayDeny<R> {
@@ -75,7 +75,7 @@
 //!     }
 //! }
 //!
-//! #[derive(Default)]
+//! #[derive(Debug, Default)]
 //! pub struct StairwayDenyLayer;
 //!
 //! impl<R> Layer<R> for StairwayDenyLayer {
@@ -137,6 +137,7 @@ pub trait Layer<R> {
 }
 
 /// Builder for composing layers together in a top-down/inside-out order.
+#[derive(Debug)]
 pub struct Stack<R> {
     inner: R,
 }

--- a/metrics-util/src/layers/prefix.rs
+++ b/metrics-util/src/layers/prefix.rs
@@ -4,6 +4,7 @@ use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, Share
 /// Applies a prefix to every metric key.
 ///
 /// Keys will be prefixed in the format of `<prefix>.<remaining>`.
+#[derive(Debug)]
 pub struct Prefix<R> {
     prefix: SharedString,
     inner: R,
@@ -64,6 +65,7 @@ impl<R: Recorder> Recorder for Prefix<R> {
 /// A layer for applying a prefix to every metric key.
 ///
 /// More information on the behavior of the layer can be found in [`Prefix`].
+#[derive(Debug)]
 pub struct PrefixLayer(&'static str);
 
 impl PrefixLayer {

--- a/metrics-util/src/layers/router.rs
+++ b/metrics-util/src/layers/router.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
 use radix_trie::{Trie, TrieCommon};
 
@@ -15,6 +17,16 @@ pub struct Router {
     histogram_routes: Trie<String, usize>,
 }
 
+impl fmt::Debug for Router {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Router")
+            .field("global_mask", &self.global_mask)
+            .field("counter_routes", &self.counter_routes)
+            .field("gauge_routes", &self.gauge_routes)
+            .field("histogram_routes", &self.histogram_routes)
+            .finish_non_exhaustive()
+    }
+}
 impl Router {
     fn route(
         &self,
@@ -85,6 +97,17 @@ pub struct RouterBuilder {
     counter_routes: Trie<String, usize>,
     gauge_routes: Trie<String, usize>,
     histogram_routes: Trie<String, usize>,
+}
+
+impl fmt::Debug for RouterBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RouterBuilder")
+            .field("global_mask", &self.global_mask)
+            .field("counter_routes", &self.counter_routes)
+            .field("gauge_routes", &self.gauge_routes)
+            .field("histogram_routes", &self.histogram_routes)
+            .finish_non_exhaustive()
+    }
 }
 
 impl RouterBuilder {
@@ -175,6 +198,7 @@ mod tests {
     };
 
     mock! {
+        #[derive(Debug)]
         pub TestRecorder {
         }
 

--- a/metrics-util/src/layers/router.rs
+++ b/metrics-util/src/layers/router.rs
@@ -21,6 +21,7 @@ impl fmt::Debug for Router {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Router")
             .field("global_mask", &self.global_mask)
+            .field("targets_len", &self.targets.len())
             .field("counter_routes", &self.counter_routes)
             .field("gauge_routes", &self.gauge_routes)
             .field("histogram_routes", &self.histogram_routes)
@@ -103,6 +104,7 @@ impl fmt::Debug for RouterBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RouterBuilder")
             .field("global_mask", &self.global_mask)
+            .field("targets_len", &self.targets.len())
             .field("counter_routes", &self.counter_routes)
             .field("gauge_routes", &self.gauge_routes)
             .field("histogram_routes", &self.histogram_routes)

--- a/metrics-util/src/recoverable.rs
+++ b/metrics-util/src/recoverable.rs
@@ -5,6 +5,7 @@ use metrics::{
     Unit,
 };
 
+#[derive(Debug)]
 pub struct RecoveryHandle<R> {
     handle: Arc<R>,
 }
@@ -51,6 +52,7 @@ impl<R> RecoveryHandle<R> {
 /// This allows using `RecoveryHandle<R>` as a drop guard, ensuring that by dropping it, the
 /// recorder itself will be dropped, and any finalization logic implemented for the recorder will be
 /// run.
+#[derive(Debug)]
 pub struct RecoverableRecorder<R> {
     handle: Arc<R>,
 }
@@ -88,6 +90,7 @@ impl<R: Recorder + 'static> RecoverableRecorder<R> {
     }
 }
 
+#[derive(Debug)]
 struct WeakRecorder<R> {
     recorder: Weak<R>,
 }
@@ -149,8 +152,13 @@ mod tests {
     use super::*;
     use metrics::{atomics::AtomicU64, CounterFn, GaugeFn, HistogramFn, Key, Recorder};
 
+    #[derive(Debug)]
     struct CounterWrapper(AtomicU64);
+
+    #[derive(Debug)]
     struct GaugeWrapper(AtomicU64);
+
+    #[derive(Debug)]
     struct HistogramWrapper(AtomicU64);
 
     impl CounterWrapper {
@@ -201,6 +209,7 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
     struct TestRecorder {
         dropped: Arc<AtomicBool>,
         counter: Arc<CounterWrapper>,

--- a/metrics-util/src/registry/mod.rs
+++ b/metrics-util/src/registry/mod.rs
@@ -45,6 +45,7 @@ type RegistryHashMap<K, V> = HashMap<K, V, BuildHasherDefault<RegistryHasher>>;
 /// ## Performance
 ///
 /// `Registry` is optimized for reads.
+#[derive(Debug)]
 pub struct Registry<K, S>
 where
     S: Storage<K>,

--- a/metrics-util/src/registry/recency.rs
+++ b/metrics-util/src/registry/recency.rs
@@ -54,7 +54,7 @@ pub struct Generation(usize);
 /// again at a later point in time, it could have changed in between the two observations.  It also
 /// may not have changed, and thus `Generational` provides a way to determine if either of these
 /// events occurred.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Generational<T> {
     inner: T,
     gen: Arc<AtomicUsize>,
@@ -157,6 +157,7 @@ where
 ///
 /// Tracks the "generation" of a metric, which is used to detect updates to metrics where the value
 /// otherwise would not be sufficient to be used as an indicator.
+#[derive(Debug)]
 pub struct GenerationalStorage<S> {
     inner: S,
 }
@@ -215,6 +216,7 @@ impl GenerationalAtomicStorage {
 ///
 /// [`Recency`] is separate from [`Registry`] specifically to avoid imposing any slowdowns when
 /// tracking recency does not matter, despite their otherwise tight coupling.
+#[derive(Debug)]
 pub struct Recency<K> {
     mask: MetricKindMask,
     #[allow(clippy::type_complexity)]

--- a/metrics-util/src/registry/storage.rs
+++ b/metrics-util/src/registry/storage.rs
@@ -29,6 +29,7 @@ pub trait Storage<K> {
 ///
 /// Utilizes atomics for storing the value(s) of a given metric.  Shared access to the actual atomic
 /// is handling via `Arc`.
+#[derive(Debug)]
 pub struct AtomicStorage;
 
 impl<K> Storage<K> for AtomicStorage {

--- a/metrics-util/src/summary.rs
+++ b/metrics-util/src/summary.rs
@@ -45,6 +45,13 @@ pub struct Summary {
     sketch: DDSketch,
 }
 
+impl fmt::Debug for Summary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // manual implementation because DDSketch does not implement Debug
+        f.debug_struct("Summary").finish_non_exhaustive()
+    }
+}
+
 impl Summary {
     /// Creates a new [`Summary`].
     ///

--- a/metrics-util/src/test_util.rs
+++ b/metrics-util/src/test_util.rs
@@ -5,7 +5,7 @@ use mockall::{
     Predicate,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum RecorderOperation {
     DescribeCounter(KeyName, Option<Unit>, SharedString),
     DescribeGauge(KeyName, Option<Unit>, SharedString),
@@ -67,6 +67,7 @@ impl RecorderOperation {
 }
 
 mock! {
+    #[derive(Debug)]
     pub BasicRecorder {}
 
     impl Recorder for BasicRecorder {

--- a/metrics/benches/macros.rs
+++ b/metrics/benches/macros.rs
@@ -8,6 +8,7 @@ use metrics::{
 };
 use rand::{thread_rng, Rng};
 
+#[derive(Debug)]
 struct TestRecorder;
 
 impl Recorder for TestRecorder {

--- a/metrics/examples/basic.rs
+++ b/metrics/examples/basic.rs
@@ -13,6 +13,7 @@ use metrics::{
 };
 use metrics::{Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, Recorder, Unit};
 
+#[derive(Clone, Debug)]
 struct PrintHandle(Key);
 
 impl CounterFn for PrintHandle {
@@ -45,6 +46,7 @@ impl HistogramFn for PrintHandle {
     }
 }
 
+#[derive(Debug)]
 struct PrintRecorder;
 
 impl Recorder for PrintRecorder {

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -23,7 +23,7 @@ pub type SharedString = Cow<'static, str>;
 ///
 /// For any use-case within a `metrics`-owned or adjacent crate, where hashing of a key is required,
 /// this is the hasher that will be used.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct KeyHasher(AHasher);
 
 impl Hasher for KeyHasher {

--- a/metrics/src/cow.rs
+++ b/metrics/src/cow.rs
@@ -412,7 +412,7 @@ unsafe impl<T: Cowable + Sync + ?Sized> Sync for Cow<'_, T> {}
 unsafe impl<T: Cowable + Send + ?Sized> Send for Cow<'_, T> {}
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Metadata(usize, usize);
 
 impl Metadata {

--- a/metrics/src/handles.rs
+++ b/metrics/src/handles.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
 use crate::IntoF64;
 
@@ -45,6 +45,12 @@ pub struct Counter {
     inner: Option<Arc<dyn CounterFn + Send + Sync>>,
 }
 
+impl Debug for Counter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Counter").finish_non_exhaustive()
+    }
+}
+
 /// A gauge.
 #[derive(Clone)]
 #[must_use = "gauges do nothing unless you use them"]
@@ -52,11 +58,23 @@ pub struct Gauge {
     inner: Option<Arc<dyn GaugeFn + Send + Sync>>,
 }
 
+impl Debug for Gauge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Gauge").finish_non_exhaustive()
+    }
+}
+
 /// A histogram.
 #[derive(Clone)]
 #[must_use = "histograms do nothing unless you use them"]
 pub struct Histogram {
     inner: Option<Arc<dyn HistogramFn + Send + Sync>>,
+}
+
+impl Debug for Histogram {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Histogram").finish_non_exhaustive()
+    }
 }
 
 impl Counter {

--- a/metrics/src/recorder/cell.rs
+++ b/metrics/src/recorder/cell.rs
@@ -14,6 +14,7 @@ const INITIALIZING: usize = 1;
 const INITIALIZED: usize = 2;
 
 /// An specialized version of `OnceCell` for `Recorder`.
+#[derive(Debug)]
 pub struct RecorderOnceCell {
     recorder: UnsafeCell<Option<&'static dyn Recorder>>,
     state: AtomicUsize,

--- a/metrics/src/recorder/mod.rs
+++ b/metrics/src/recorder/mod.rs
@@ -154,6 +154,7 @@ mod tests {
         // This test simply ensures that if a boxed recorder is handed to us to install, and another
         // recorder has already been installed, that we drop th new boxed recorder instead of
         // leaking it.
+        #[derive(Debug)]
         struct TrackOnDropRecorder(Arc<AtomicBool>);
 
         impl TrackOnDropRecorder {

--- a/metrics/src/recorder/noop.rs
+++ b/metrics/src/recorder/noop.rs
@@ -4,6 +4,7 @@ use crate::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedS
 ///
 /// Used as the default recorder when one has not been installed yet.  Useful for acting as the root
 /// recorder when testing layers.
+#[derive(Debug)]
 pub struct NoopRecorder;
 
 impl Recorder for NoopRecorder {


### PR DESCRIPTION
This allows all the structs and enums to easily be placed in a struct
which derives Debug itself.

The metrics::recorder::Recorder and metrics_tracing_context::LabelFilter
traits now also extend Debug.
