### PR TITLE
Use ratatui instead of tui-rs for the terminal UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,14 @@ jobs:
     name: Test ${{ matrix.rust_version }}
     runs-on: ubuntu-latest
     strategy:
+      # 1.70 is the MSRV for the project, which currently does not match the version specified in
+      # the rust-toolchain.toml file as metrics-observer requires 1.74 to build. See
+      # https://github.com/metrics-rs/metrics/pull/505#discussion_r1724092556 for more information.
       matrix:
-        rust_version: ['stable', 'nightly']
+        rust_version: ['stable', 'nightly', '1.70']
+        include:
+          - rust_version: '1.70'
+            exclude-packages: '--exclude metrics-observer'
     steps:
     - uses: actions/checkout@v3
     - name: Install Protobuf Compiler
@@ -53,7 +59,7 @@ jobs:
     - name: Install Rust ${{ matrix.rust_version }}
       run: rustup install ${{ matrix.rust_version }}
     - name: Run Tests
-      run: cargo +${{ matrix.rust_version }} test --all-features --workspace
+      run: cargo +${{ matrix.rust_version }} test --all-features --workspace ${{ matrix.exclude-packages }}
   docs:
     runs-on: ubuntu-latest
     env:

--- a/metrics-observer/Cargo.toml
+++ b/metrics-observer/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-observer"
 version = "0.4.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.70.0"
+rust-version = "1.74.0"
 
 license = "MIT"
 
@@ -23,8 +23,7 @@ bytes = { version = "1", default-features = false }
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
 prost = { version = "0.12", default-features = false }
 prost-types = { version = "0.12", default-features = false }
-tui = { version = "0.19", default-features = false, features = ["termion"] }
-termion = { version = "2", default-features = false }
+ratatui = { version = "0.28.0", default-features = false, features = ["crossterm"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [build-dependencies]

--- a/metrics-observer/src/input.rs
+++ b/metrics-observer/src/input.rs
@@ -1,37 +1,18 @@
 use std::io;
-use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{bounded, Receiver, RecvTimeoutError, TrySendError};
-use termion::event::Key;
-use termion::input::TermRead;
+use ratatui::crossterm::event::{self, Event, KeyEvent, KeyEventKind};
 
-pub struct InputEvents {
-    rx: Receiver<Key>,
-}
+pub struct InputEvents;
 
 impl InputEvents {
-    pub fn new() -> InputEvents {
-        let (tx, rx) = bounded(1);
-        thread::spawn(move || {
-            let stdin = io::stdin();
-            for key in stdin.keys().flatten() {
-                // If our queue is full, we don't care.  The user can just press the key again.
-                if let Err(TrySendError::Disconnected(_)) = tx.try_send(key) {
-                    eprintln!("input event channel disconnected");
-                    return;
-                }
+    pub fn next() -> io::Result<Option<KeyEvent>> {
+        if event::poll(Duration::from_secs(1))? {
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => return Ok(Some(key)),
+                _ => {}
             }
-        });
-
-        InputEvents { rx }
-    }
-
-    pub fn next(&mut self) -> Result<Option<Key>, RecvTimeoutError> {
-        match self.rx.recv_timeout(Duration::from_secs(1)) {
-            Ok(key) => Ok(Some(key)),
-            Err(RecvTimeoutError::Timeout) => Ok(None),
-            Err(e) => Err(e),
         }
+        Ok(None)
     }
 }

--- a/metrics-observer/src/selector.rs
+++ b/metrics-observer/src/selector.rs
@@ -1,4 +1,4 @@
-use tui::widgets::ListState;
+use ratatui::widgets::ListState;
 
 pub struct Selector(usize, ListState);
 

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -276,7 +276,7 @@ macro_rules! into_f64 {
     };
 }
 
-pub(self) use into_f64;
+use into_f64;
 
 #[cfg(test)]
 mod tests {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.74.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,5 @@
 [toolchain]
+# Note that this is greater than the MSRV of the workspace (1.70) due to metrics-observer needing
+# 1.74, while all the other crates only require 1.70. See
+# https://github.com/metrics-rs/metrics/pull/505#discussion_r1724092556 for more information.
 channel = "1.74.0"


### PR DESCRIPTION
Ratatui is a maintained fork of tui-rs. See https://ratatui.rs/ for more
information.

Changes the backend to use crossterm instead of termion. This makes it
possible to use the terminal UI on Windows.
