### PR TITLE
chore: correct gibibyte spelling

### DIFF
--- a/metrics-observer/src/main.rs
+++ b/metrics-observer/src/main.rs
@@ -211,7 +211,7 @@ fn f64_data_to_displayable(value: f64, unit: Unit) -> String {
     let offset = match unit {
         Unit::Kibibytes => 1,
         Unit::Mebibytes => 2,
-        Unit::Gigibytes => 3,
+        Unit::Gibibytes => 3,
         Unit::Tebibytes => 4,
         _ => 0,
     };

--- a/metrics/src/common.rs
+++ b/metrics/src/common.rs
@@ -84,12 +84,12 @@ pub enum Unit {
     Nanoseconds,
     /// Tebibytes.
     ///
-    /// One tebibyte is equal to 1024 gigibytes.
+    /// One tebibyte is equal to 1024 gibibytes.
     Tebibytes,
-    /// Gigibytes.
+    /// Gibibytes.
     ///
-    /// One gigibyte is equal to 1024 mebibytes.
-    Gigibytes,
+    /// One gibibyte is equal to 1024 mebibytes.
+    Gibibytes,
     /// Mebibytes.
     ///
     /// One mebibyte is equal to 1024 kibibytes.
@@ -133,7 +133,7 @@ impl Unit {
             Unit::Microseconds => "microseconds",
             Unit::Nanoseconds => "nanoseconds",
             Unit::Tebibytes => "tebibytes",
-            Unit::Gigibytes => "gigibytes",
+            Unit::Gibibytes => "gibibytes",
             Unit::Mebibytes => "mebibytes",
             Unit::Kibibytes => "kibibytes",
             Unit::Bytes => "bytes",
@@ -161,7 +161,7 @@ impl Unit {
             Unit::Microseconds => "μs",
             Unit::Nanoseconds => "ns",
             Unit::Tebibytes => "TiB",
-            Unit::Gigibytes => "GiB",
+            Unit::Gibibytes => "GiB",
             Unit::Mebibytes => "MiB",
             Unit::Kibibytes => "KiB",
             Unit::Bytes => "B",
@@ -186,7 +186,7 @@ impl Unit {
             "microseconds" => Some(Unit::Microseconds),
             "nanoseconds" => Some(Unit::Nanoseconds),
             "tebibytes" => Some(Unit::Tebibytes),
-            "gigibytes" => Some(Unit::Gigibytes),
+            "gibibytes" => Some(Unit::Gibibytes),
             "mebibytes" => Some(Unit::Mebibytes),
             "kibibytes" => Some(Unit::Kibibytes),
             "bytes" => Some(Unit::Bytes),
@@ -210,7 +210,7 @@ impl Unit {
         matches!(
             self,
             Unit::Tebibytes
-                | Unit::Gigibytes
+                | Unit::Gibibytes
                 | Unit::Mebibytes
                 | Unit::Kibibytes
                 | Unit::Bytes
@@ -294,7 +294,7 @@ mod tests {
             Unit::Microseconds,
             Unit::Nanoseconds,
             Unit::Tebibytes,
-            Unit::Gigibytes,
+            Unit::Gibibytes,
             Unit::Mebibytes,
             Unit::Kibibytes,
             Unit::Bytes,


### PR DESCRIPTION
## What's change intention?
correct the typo `Gigibyte → Gibibyte`

## Refer to a related PR or issue link 
https://github.com/metrics-rs/metrics/issues/497
