### PR TITLE
Add blanket implementations of `Recorder` for some pointer-like types

### DIFF
--- a/metrics-util/src/layers/router.rs
+++ b/metrics-util/src/layers/router.rs
@@ -166,7 +166,7 @@ mod tests {
         predicate::{always, eq},
         Sequence,
     };
-    use std::{borrow::Cow, rc::Rc};
+    use std::{borrow::Cow, sync::Arc};
 
     use super::RouterBuilder;
     use crate::MetricKindMask;
@@ -299,7 +299,7 @@ mod tests {
             .with(eq(default_counter.clone()), always())
             .returning(|_, _| Counter::noop());
 
-        let foo_bar_mock = Rc::new(foo_bar_mock);
+        let foo_bar_mock = Arc::new(foo_bar_mock);
 
         let mut builder = RouterBuilder::from_recorder(default_mock);
         builder.add_route(MetricKindMask::COUNTER, "foo", foo_bar_mock.clone());

--- a/metrics-util/src/layers/router.rs
+++ b/metrics-util/src/layers/router.rs
@@ -166,7 +166,7 @@ mod tests {
         predicate::{always, eq},
         Sequence,
     };
-    use std::borrow::Cow;
+    use std::{borrow::Cow, rc::Rc};
 
     use super::RouterBuilder;
     use crate::MetricKindMask;
@@ -264,5 +264,50 @@ mod tests {
         let _ = recorder.register_counter(&override_counter, &METADATA);
         let _ = recorder.register_counter(&all_override, &METADATA);
         let _ = recorder.register_histogram(&all_override, &METADATA);
+    }
+
+    #[test]
+    fn test_same_recorder_multiple_routes() {
+        let default_counter: Key = "default".into();
+        let foo_counter: Key = "foo.counter".into();
+        let bar_counter: Key = "bar.counter".into();
+
+        let mut default_mock = MockTestRecorder::new();
+        let mut foo_bar_mock = MockTestRecorder::new();
+
+        let mut seq = Sequence::new();
+
+        static METADATA: metrics::Metadata =
+            metrics::Metadata::new(module_path!(), metrics::Level::INFO, Some(module_path!()));
+
+        foo_bar_mock
+            .expect_register_counter()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(eq(foo_counter.clone()), always())
+            .returning(|_, _| Counter::noop());
+        foo_bar_mock
+            .expect_register_counter()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(eq(bar_counter.clone()), always())
+            .returning(|_, _| Counter::noop());
+        default_mock
+            .expect_register_counter()
+            .times(1)
+            .in_sequence(&mut seq)
+            .with(eq(default_counter.clone()), always())
+            .returning(|_, _| Counter::noop());
+
+        let foo_bar_mock = Rc::new(foo_bar_mock);
+
+        let mut builder = RouterBuilder::from_recorder(default_mock);
+        builder.add_route(MetricKindMask::COUNTER, "foo", foo_bar_mock.clone());
+        builder.add_route(MetricKindMask::COUNTER, "bar", foo_bar_mock);
+        let recorder = builder.build();
+
+        let _ = recorder.register_counter(&foo_counter, &METADATA);
+        let _ = recorder.register_counter(&bar_counter, &METADATA);
+        let _ = recorder.register_counter(&default_counter, &METADATA);
     }
 }

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Blanket implementations of `Recorder` over smart pointer representations (i.e. `Arc<T> where T: Recorder`). ([#512](https://github.com/metrics-rs/metrics/pull/512))
+
 ## [0.23.0] - 2024-05-27
 
 ### Added

--- a/metrics/src/recorder/mod.rs
+++ b/metrics/src/recorder/mod.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, ops::Deref, ptr::NonNull, sync::Arc};
+use std::{cell::Cell, ptr::NonNull};
 
 mod cell;
 use self::cell::RecorderOnceCell;
@@ -70,7 +70,7 @@ macro_rules! impl_recorder {
                 unit: Option<$crate::Unit>,
                 description: $crate::SharedString,
             ) {
-                Deref::deref(self).describe_counter(key, unit, description)
+                std::ops::Deref::deref(self).describe_counter(key, unit, description)
             }
 
             fn describe_gauge(
@@ -79,7 +79,7 @@ macro_rules! impl_recorder {
                 unit: Option<$crate::Unit>,
                 description: $crate::SharedString,
             ) {
-                Deref::deref(self).describe_gauge(key, unit, description)
+                std::ops::Deref::deref(self).describe_gauge(key, unit, description)
             }
 
             fn describe_histogram(
@@ -88,7 +88,7 @@ macro_rules! impl_recorder {
                 unit: Option<$crate::Unit>,
                 description: $crate::SharedString,
             ) {
-                Deref::deref(self).describe_histogram(key, unit, description)
+                std::ops::Deref::deref(self).describe_histogram(key, unit, description)
             }
 
             fn register_counter(
@@ -96,7 +96,7 @@ macro_rules! impl_recorder {
                 key: &$crate::Key,
                 metadata: &$crate::Metadata<'_>,
             ) -> $crate::Counter {
-                Deref::deref(self).register_counter(key, metadata)
+                std::ops::Deref::deref(self).register_counter(key, metadata)
             }
 
             fn register_gauge(
@@ -104,7 +104,7 @@ macro_rules! impl_recorder {
                 key: &$crate::Key,
                 metadata: &$crate::Metadata<'_>,
             ) -> $crate::Gauge {
-                Deref::deref(self).register_gauge(key, metadata)
+                std::ops::Deref::deref(self).register_gauge(key, metadata)
             }
 
             fn register_histogram(
@@ -112,7 +112,7 @@ macro_rules! impl_recorder {
                 key: &$crate::Key,
                 metadata: &$crate::Metadata<'_>,
             ) -> $crate::Histogram {
-                Deref::deref(self).register_histogram(key, metadata)
+                std::ops::Deref::deref(self).register_histogram(key, metadata)
             }
         }
     };
@@ -120,8 +120,8 @@ macro_rules! impl_recorder {
 
 impl_recorder!(T, &T);
 impl_recorder!(T, &mut T);
-impl_recorder!(T, Box<T>);
-impl_recorder!(T, Arc<T>);
+impl_recorder!(T, std::boxed::Box<T>);
+impl_recorder!(T, std::sync::Arc<T>);
 
 /// Guard for setting a local recorder.
 ///


### PR DESCRIPTION
(I messed up the remote branch in #507 and it was just easier to fix it by making a new branch and PR.)

`Rc`, `Arc`, and `Box`.

Closes #506.