### PR TITLE
Add Sync bound for set_global_recorder

### DIFF
--- a/metrics-util/src/layers/mod.rs
+++ b/metrics-util/src/layers/mod.rs
@@ -153,7 +153,7 @@ impl<R> Stack<R> {
     }
 }
 
-impl<R: Recorder + 'static> Stack<R> {
+impl<R: Recorder + Sync + 'static> Stack<R> {
     /// Installs this stack as the global recorder.
     ///
     /// An error will be returned if there's an issue with installing the stack as the global recorder.

--- a/metrics-util/src/recoverable.rs
+++ b/metrics-util/src/recoverable.rs
@@ -55,7 +55,7 @@ pub struct RecoverableRecorder<R> {
     handle: Arc<R>,
 }
 
-impl<R: Recorder + 'static> RecoverableRecorder<R> {
+impl<R: Recorder + Sync + Send + 'static> RecoverableRecorder<R> {
     /// Creates a new `RecoverableRecorder` from the given recorder.
     pub fn new(recorder: R) -> Self {
         Self { handle: Arc::new(recorder) }

--- a/metrics/src/recorder/mod.rs
+++ b/metrics/src/recorder/mod.rs
@@ -104,7 +104,7 @@ impl Drop for LocalRecorderGuard {
 /// An error is returned if a recorder has already been set.
 pub fn set_global_recorder<R>(recorder: R) -> Result<(), SetRecorderError<R>>
 where
-    R: Recorder + 'static,
+    R: Recorder + Sync + 'static,
 {
     GLOBAL_RECORDER.set(recorder)
 }


### PR DESCRIPTION
global recorder is shared between threads and must be sync

closes https://github.com/metrics-rs/metrics/issues/511