### PR TITLE
Update home dependency

### DIFF
--- a/metrics-exporter-tcp/Cargo.toml
+++ b/metrics-exporter-tcp/Cargo.toml
@@ -27,7 +27,7 @@ tracing = { version = "0.1", default-features = false, features = ["attributes"]
 
 [build-dependencies]
 prost-build = "0.12"
-home = "=0.5.5"
+home = "0.5.9"
 
 [dev-dependencies]
 quanta = "0.12"

--- a/metrics-observer/Cargo.toml
+++ b/metrics-observer/Cargo.toml
@@ -28,4 +28,4 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [build-dependencies]
 prost-build = "0.12"
-home = "=0.5.5"
+home = "0.5.9"


### PR DESCRIPTION
Updates the dependency so it is more compatible with latest packages (e.g. `which` crate). 

fixes #526

