### PR TITLE
chore: big round of dep updates + use cargo-autoinherit to move to workspace deps + MSRV bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,13 @@ jobs:
     name: Test ${{ matrix.rust_version }}
     runs-on: ubuntu-latest
     strategy:
-      # 1.70 is the MSRV for the project, which currently does not match the version specified in
+      # 1.71.1 is the MSRV for the project, which currently does not match the version specified in
       # the rust-toolchain.toml file as metrics-observer requires 1.74 to build. See
       # https://github.com/metrics-rs/metrics/pull/505#discussion_r1724092556 for more information.
       matrix:
-        rust_version: ['stable', 'nightly', '1.70']
+        rust_version: ['stable', 'nightly', '1.71.1']
         include:
-          - rust_version: '1.70'
+          - rust_version: '1.71.1'
             exclude-packages: '--exclude metrics-observer'
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ itoa = { version = "1", default-features = false }
 lockfree-object-pool = { version = "0.1", default-features = false }
 log = { version = "0.4", default-features = false }
 mio = { version = "1.0", default-features = false }
-mockall = { version = "0.13", default-features = false }
+mockall = { version = "0.12", default-features = false }
 ndarray = { version = "0.16", default-features = false }
 ndarray-stats = { version = "0.6", default-features = false }
 noisy_float = { version = "0.2", default-features = false }
@@ -44,8 +44,9 @@ once_cell = { version = "1", default-features = false, features = ["std"] }
 ordered-float = { version = "4.2", default-features = false }
 parking_lot = { version = "0.12", default-features = false }
 portable-atomic = { version = "1", default-features = false }
-predicates-core = { version = "1", default-features = false }
-predicates-tree = { version = "1", default-features = false }
+predicates = { version = "=3.1.0", default-features = false }
+predicates-core = { version = "=1.0.6", default-features = false }
+predicates-tree = { version = "=1.0.9", default-features = false }
 pretty_env_logger = { version = "0.5", default-features = false }
 proptest = { version = "1", default-features = false, features = ["std"] }
 prost = { version = "0.13", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,67 @@
 [workspace]
 members = [
   "metrics",
-  "metrics-util",
-  "metrics-exporter-tcp",
-  "metrics-exporter-prometheus",
-  "metrics-tracing-context",
-  "metrics-observer",
   "metrics-benchmark",
+  "metrics-exporter-prometheus",
+  "metrics-exporter-tcp",
+  "metrics-observer",
+  "metrics-tracing-context",
+  "metrics-util",
 ]
+
+[workspace.dependencies]
+ahash = { version = "0.8", default-features = false }
+aho-corasick = { version = "1", default-features = false }
+approx = { version = "0.5", default-features = false }
+base64 = { version = "0.22", default-features = false, features = ["std"] }
+bytes = { version = "1", default-features = false }
+chrono = { version = "0.4", default-features = false }
+criterion = { version = "=0.3.3", default-features = false }
+crossbeam-channel = { version = "0.5", default-features = false }
+crossbeam-epoch = { version = "0.9", default-features = false }
+crossbeam-queue = { version = "0.3", default-features = false, features = ["std"] }
+crossbeam-utils = { version = "0.8", default-features = false }
+getopts = { version = "0.2", default-features = false }
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "raw-entry"] }
+hdrhistogram = { version = "7.2", default-features = false }
+home = { version = "0.5", default-features = false }
+http-body-util = { version = "0.1", default-features = false }
+hyper = { version = "1.1", default-features = false, features = ["server", "client"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http1", "rustls-native-certs"] }
+hyper-util = { version = "0.1", default-features = false, features = ["tokio", "service", "client", "client-legacy", "http1"] }
+indexmap = { version = "2.6", default-features = false, features = ["std"] }
+ipnet = { version = "2", default-features = false, features = ["std"] }
+itertools = { version = "0.13.0", default-features = false }
+itoa = { version = "1", default-features = false }
+lockfree-object-pool = { version = "0.1", default-features = false }
+log = { version = "0.4", default-features = false }
+mio = { version = "1.0", default-features = false }
+mockall = { version = "0.13", default-features = false }
+ndarray = { version = "0.16", default-features = false }
+ndarray-stats = { version = "0.6", default-features = false }
+noisy_float = { version = "0.2", default-features = false }
+once_cell = { version = "1", default-features = false, features = ["std"] }
+ordered-float = { version = "4.2", default-features = false }
+parking_lot = { version = "0.12", default-features = false }
+portable-atomic = { version = "1", default-features = false }
+predicates-core = { version = "1", default-features = false }
+predicates-tree = { version = "1", default-features = false }
+pretty_env_logger = { version = "0.5", default-features = false }
+proptest = { version = "1", default-features = false, features = ["std"] }
+prost = { version = "0.13", default-features = false, features = ["derive"] }
+prost-build = { version = "0.13", default-features = false }
+prost-types = { version = "0.13", default-features = false }
+quanta = { version = "0.12", default-features = false }
+quickcheck = { version = "1", default-features = false }
+quickcheck_macros = { version = "1", default-features = false }
+radix_trie = { version = "0.2", default-features = false }
+rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
+rand_distr = { version = "0.4", default-features = false }
+ratatui = { version = "0.28", default-features = false }
+sketches-ddsketch = { version = "0.3", default-features = false }
+thiserror = { version = "1", default-features = false }
+tokio = { version = "1", default-features = false, features = ["rt", "net", "time", "rt-multi-thread"] }
+tracing = { version = "0.1", default-features = false }
+tracing-core = { version = "0.1", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false }
+trybuild = { version = "1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Additionally, here are some learning resource(s) to help you get started:
 
 ## MSRV and MSRV policy
 
-Minimum supported Rust version (MSRV) is currently **1.70.0**, enforced by CI.
+Minimum supported Rust version (MSRV) is currently **1.71.1**, enforced by CI.
 
 `metrics` will always support _at least_ the latest four versions of stable Rust, based on minor
 version releases, and excluding patch versions. Overall, we strive to support older versions where

--- a/metrics-benchmark/Cargo.toml
+++ b/metrics-benchmark/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-benchmark"
 version = "0.1.1-alpha.5"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.70.0"
+rust-version = "1.71.1"
 publish = false
 
 [dependencies]

--- a/metrics-benchmark/Cargo.toml
+++ b/metrics-benchmark/Cargo.toml
@@ -7,11 +7,11 @@ rust-version = "1.70.0"
 publish = false
 
 [dependencies]
-log = "0.4"
-pretty_env_logger = "0.5"
-getopts = "0.2"
-hdrhistogram = { version = "7.2", default-features = false }
-quanta = "0.12"
-portable-atomic = { version = "1", default-features = false, features = ["fallback"] }
+getopts = { workspace = true }
+hdrhistogram = { workspace = true }
+log = { workspace = true }
 metrics = { version = "^0.23", path = "../metrics" }
 metrics-util = { version = "^0.17", path = "../metrics-util" }
+portable-atomic = { workspace = true, features = ["fallback"] }
+pretty_env_logger = { workspace = true }
+quanta = { workspace = true }

--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a number of Clippy lints. ([#510](https://github.com/metrics-rs/metrics/pull/510))
+- Bump MSRV to 1.71.1. ([#530](https://github.com/metrics-rs/metrics/pull/530))
 
 ## [0.15.3] - 2024-07-13
 

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-exporter-prometheus"
 version = "0.15.3"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.70.0"
+rust-version = "1.71.1"
 
 license = "MIT"
 

--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -33,42 +33,31 @@ _hyper-client = [
 ]
 
 [dependencies]
+base64 = { workspace = true }
+http-body-util = { workspace = true, optional = true }
+
+# Optional
+hyper = { workspace = true, optional = true }
+hyper-rustls = { workspace = true, optional = true }
+hyper-util = { workspace = true, optional = true }
+indexmap = { workspace = true }
+ipnet = { workspace = true, optional = true }
 metrics = { version = "^0.23", path = "../metrics" }
 metrics-util = { version = "^0.17", path = "../metrics-util", default-features = false, features = [
     "recency",
     "registry",
     "summary",
 ] }
-thiserror = { version = "1", default-features = false }
-quanta = { version = "0.12", default-features = false }
-indexmap = { version = "2.1", default-features = false, features = ["std"] }
-base64 = { version = "0.22.0", default-features = false, features = ["std"] }
-
-# Optional
-hyper = { version = "1.1", features = ["server", "client"], optional = true }
-hyper-util = { version = "0.1.3", features = [
-    "tokio",
-    "service",
-    "client",
-    "client-legacy",
-    "http1",
-], optional = true }
-http-body-util = { version = "0.1.0", optional = true }
-ipnet = { version = "2", optional = true }
-tokio = { version = "1", features = [
-    "rt",
-    "net",
-    "time",
-    "rt-multi-thread",
-], optional = true }
-tracing = { version = "0.1.26", optional = true }
-hyper-rustls = { version = "0.27.2", optional = true }
+quanta = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
-tracing = "0.1"
-tracing-subscriber = "0.3"
-rand = "0.8"
-proptest = "1"
+proptest = { workspace = true }
+rand = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 [[example]]
 name = "prometheus_push_gateway"

--- a/metrics-exporter-tcp/CHANGELOG.md
+++ b/metrics-exporter-tcp/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated `mio` to `1.0`.
+- Bump MSRV to 1.71.1. ([#530](https://github.com/metrics-rs/metrics/pull/530))
 
 ## [0.10.0] - 2024-05-27
 

--- a/metrics-exporter-tcp/Cargo.toml
+++ b/metrics-exporter-tcp/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-exporter-tcp"
 version = "0.10.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.70.0"
+rust-version = "1.71.1"
 
 license = "MIT"
 

--- a/metrics-exporter-tcp/Cargo.toml
+++ b/metrics-exporter-tcp/Cargo.toml
@@ -17,20 +17,20 @@ categories = ["development-tools::debugging"]
 keywords = ["metrics", "telemetry", "tcp"]
 
 [dependencies]
+bytes = { workspace = true }
+crossbeam-channel = { workspace = true, features = ["std"] }
 metrics = { version = "^0.23", path = "../metrics" }
-bytes = { version = "1", default-features = false }
-crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
-prost = { version = "0.12", default-features = false }
-prost-types = { version = "0.12", default-features = false, features = ["std"] }
-mio = { version = "1.0", default-features = false, features = ["os-poll", "net"] }
-tracing = { version = "0.1", default-features = false, features = ["attributes"] }
+mio = { workspace = true, features = ["os-poll", "net"] }
+prost = { workspace = true }
+prost-types = { workspace = true, features = ["std"] }
+tracing = { workspace = true, features = ["attributes"] }
 
 [build-dependencies]
-prost-build = "0.12"
-home = "0.5.9"
+home = { workspace = true }
+prost-build = { workspace = true }
 
 [dev-dependencies]
-quanta = "0.12"
-tracing = "0.1"
-tracing-subscriber = "0.3"
-rand = "0.8"
+quanta = { workspace = true }
+rand = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt"] }

--- a/metrics-observer/Cargo.toml
+++ b/metrics-observer/Cargo.toml
@@ -17,15 +17,15 @@ categories = ["development-tools::debugging"]
 keywords = ["metrics", "facade", "macros"]
 
 [dependencies]
+bytes = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
+crossbeam-channel = { workspace = true, features = ["std"] }
 metrics = { version = "^0.23", path = "../metrics", default-features = false }
 metrics-util = { version = "^0.17", path = "../metrics-util", default-features = false, features = ["summary"] }
-bytes = { version = "1", default-features = false }
-crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
-prost = { version = "0.12", default-features = false }
-prost-types = { version = "0.12", default-features = false }
-ratatui = { version = "0.28.0", default-features = false, features = ["crossterm"] }
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+prost = { workspace = true }
+prost-types = { workspace = true }
+ratatui = { workspace = true, features = ["crossterm"] }
 
 [build-dependencies]
-prost-build = "0.12"
-home = "0.5.9"
+home = { workspace = true }
+prost-build = { workspace = true }

--- a/metrics-tracing-context/CHANGELOG.md
+++ b/metrics-tracing-context/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed a number of Clippy lints. ([#510](https://github.com/metrics-rs/metrics/pull/510))
+- Bump MSRV to 1.71.1. ([#530](https://github.com/metrics-rs/metrics/pull/530))
 
 ## [0.16.0] - 2024-05-27
 

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-tracing-context"
 version = "0.16.0"
 authors = ["MOZGIII <mike-n@narod.ru>"]
 edition = "2018"
-rust-version = "1.70.0"
+rust-version = "1.71.1"
 
 license = "MIT"
 

--- a/metrics-tracing-context/Cargo.toml
+++ b/metrics-tracing-context/Cargo.toml
@@ -28,19 +28,19 @@ name = "layer"
 harness = false
 
 [dependencies]
-itoa = { version = "1", default-features = false }
+indexmap = { workspace = true }
+itoa = { workspace = true }
+lockfree-object-pool = { workspace = true }
 metrics = { version = "^0.23", path = "../metrics" }
 metrics-util = { version = "^0.17", path = "../metrics-util" }
-lockfree-object-pool = { version = "0.1.3", default-features = false }
-indexmap = { version = "2.1", default-features = false, features = ["std"] }
-once_cell = { version = "1", default-features = false, features = ["std"] }
-tracing = { version = "0.1.29", default-features = false }
-tracing-core = { version = "0.1.21", default-features = false }
-tracing-subscriber = { version = "0.3.1", default-features = false, features = ["std"] }
+once_cell = { workspace = true }
+tracing = { workspace = true }
+tracing-core = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-criterion = { version = "=0.3.3", default-features = false }
-parking_lot = { version = "0.12.1", default-features = false }
-tracing = { version = "0.1.29", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3.1", default-features = false, features = ["registry"] }
-itertools = { version = "0.12.0", default-features = false, features = ["use_std"] }
+criterion = { workspace = true }
+itertools = { workspace = true, features = ["use_std"] }
+parking_lot = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = { workspace = true, features = ["registry"] }

--- a/metrics-util/CHANGELOG.md
+++ b/metrics-util/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `num_cpus::get` with `std::thread::available_parallelism`.
   ([#500](https://github.com/metrics-rs/metrics/pull/500))
 - Fixed a number of Clippy lints. ([#510](https://github.com/metrics-rs/metrics/pull/510))
-- Added `Sync` constraint to generic parameter in `RecoverableRecorder` and `Stack`. ([#511](https://github.com/metrics-rs/metrics/pull/511))
+- Added `Sync` constraint to generic parameter in `RecoverableRecorder` and `Stack`.
+  ([#511](https://github.com/metrics-rs/metrics/pull/511))
+- Bump MSRV to 1.71.1. ([#530](https://github.com/metrics-rs/metrics/pull/530))
 
 ## [0.17.0] - 2024-05-27
 

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -47,38 +47,38 @@ name = "bucket-crusher"
 required-features = ["handles"]
 
 [dependencies]
+ahash = { workspace = true, optional = true }
+aho-corasick = { workspace = true, features = ["std"], optional = true }
+crossbeam-epoch = { workspace = true, features = ["alloc", "std"], optional = true }
+crossbeam-utils = { workspace = true, optional = true }
+hashbrown = { workspace = true, optional = true }
+indexmap = { workspace = true, optional = true }
 metrics = { version = "^0.23", path = "../metrics" }
-crossbeam-epoch = { version = "0.9.2", default-features = false, optional = true, features = ["alloc", "std"] }
-crossbeam-utils = { version = "0.8", default-features = false, optional = true }
-aho-corasick = { version = "1", default-features = false, optional = true, features = ["std"] }
-indexmap = { version = "2.1", default-features = false, features = ["std"], optional = true }
-quanta = { version = "0.12", default-features = false, optional = true }
-sketches-ddsketch = { version = "0.3", default-features = false, optional = true }
-radix_trie = { version = "0.2", default-features = false, optional = true }
-ordered-float = { version = "4.2", default-features = false, optional = true }
-ahash = { version = "0.8.8", default-features = false, optional = true }
-hashbrown = { version = "0.14", default-features = false, optional = true, features = ["ahash"] }
+ordered-float = { workspace = true, optional = true }
+quanta = { workspace = true, optional = true }
+radix_trie = { workspace = true, optional = true }
+sketches-ddsketch = { workspace = true, optional = true }
 
 [dev-dependencies]
-approx = "0.5"
-criterion = { version = "=0.3.3", default-features = false }
-rand = { version = "0.8", features = ["small_rng"] }
-rand_distr = "0.4"
-getopts = "0.2"
-hdrhistogram = { version = "7.2", default-features = false }
-sketches-ddsketch = "0.3"
-ndarray = "0.15"
-ndarray-stats = "0.5"
-noisy_float = "0.2"
-ordered-float = "4.2"
-predicates-core = "=1.0.5"
-predicates-tree = "=1.0.7"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi"] }
-crossbeam-queue = "0.3"
-quickcheck = "1"
-quickcheck_macros = "1"
-mockall = "0.11"
+approx = { workspace = true }
+criterion = { workspace = true }
+crossbeam-queue = { workspace = true }
+getopts = { workspace = true }
+hdrhistogram = { workspace = true }
+mockall = { workspace = true }
+ndarray = { workspace = true }
+ndarray-stats = { workspace = true }
+noisy_float = { workspace = true }
+ordered-float = { workspace = true }
+predicates-core = { workspace = true }
+predicates-tree = { workspace = true }
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
+rand = { workspace = true, features = ["small_rng"] }
+rand_distr = { workspace = true }
+sketches-ddsketch = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "ansi"] }
 
 [features]
 handles = ["crossbeam-epoch", "crossbeam-utils"]

--- a/metrics-util/Cargo.toml
+++ b/metrics-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-util"
 version = "0.17.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.70.0"
+rust-version = "1.71.1"
 
 license = "MIT"
 
@@ -70,6 +70,7 @@ ndarray = { workspace = true }
 ndarray-stats = { workspace = true }
 noisy_float = { workspace = true }
 ordered-float = { workspace = true }
+predicates = { workspace = true }
 predicates-core = { workspace = true }
 predicates-tree = { workspace = true }
 quickcheck = { workspace = true }

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#508](https://github.com/metrics-rs/metrics/pull/508))
 - Fixed a number of Clippy lints. ([#510](https://github.com/metrics-rs/metrics/pull/510))
 - Updated the documentation for `with_local_recorder` to better explain limitations.
-- `set_global_recorder` now requires that the recorder is `Sync`. ([#511](https://github.com/metrics-rs/metrics/pull/511))
+- `set_global_recorder` now requires that the recorder is `Sync`.
+  ([#511](https://github.com/metrics-rs/metrics/pull/511))
+- Bump MSRV to 1.71.1. ([#530](https://github.com/metrics-rs/metrics/pull/530))
 
 ## [0.23.0] - 2024-05-27
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics"
 version = "0.23.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
-rust-version = "1.70.0"
+rust-version = "1.71.1"
 
 license = "MIT"
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -24,7 +24,7 @@ name = "macros"
 harness = false
 
 [dependencies]
-ahash = { version = "0.8.8", default-features = false }
+ahash = { workspace = true }
 
 [target.'cfg(target_pointer_width = "32")'.dependencies]
 portable-atomic = { version = "1", default-features = false, features = [
@@ -32,7 +32,7 @@ portable-atomic = { version = "1", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-log = "0.4"
-criterion = { version = "=0.3.3", default-features = false }
-rand = "0.8"
-trybuild = "1"
+criterion = { workspace = true }
+log = { workspace = true }
+rand = { workspace = true }
+trybuild = { workspace = true }


### PR DESCRIPTION
## Context

Just a bunch of outstanding dependency updates that I've been dragging my feet on for various reasons. We've also switched to trying to work with a workspace-based dependency approach, where dependencies are centrally managed (version-wise) fro the workspace Cargo.toml, instead of in individual crates. This should hopefully make it easier to coordinate version bumps for cross-crate dependencies.

We're also bumping the MSRV to 1.71.1 which puts us at about the last ~year of Rust versions. We'll probably settle on this "last year of Rust versions" approach because it feels like it would would be conservative enough while minimizing the pain of updating dependencies and tracking _their_ MSRV bumps.