### PR TITLE
enhancement: add new `record_many` method for histograms

### DIFF
--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `Debug` derive to numerous types. ([#504](https://github.com/metrics-rs/metrics/pull/504))
-- Blanket implementations of `Recorder` over smart pointer representations (i.e. `Arc<T> where T: Recorder`). ([#512](https://github.com/metrics-rs/metrics/pull/512))
+- Blanket implementations of `Recorder` over smart pointer representations (i.e. `Arc<T> where T: Recorder`).
+  ([#512](https://github.com/metrics-rs/metrics/pull/512))
+- Added a new method, `record_many`, to `Histogram` and `HistogramFn`, for recording a single value multiple times. This
+  method is backwards compatible as `HistogramFn` provides a default implementation.
 
 ### Changed
 

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Blanket implementations of `Recorder` over smart pointer representations (i.e. `Arc<T> where T: Recorder`).
   ([#512](https://github.com/metrics-rs/metrics/pull/512))
 - Added a new method, `record_many`, to `Histogram` and `HistogramFn`, for recording a single value multiple times. This
-  method is backwards compatible as `HistogramFn` provides a default implementation.
+  method is backwards compatible as `HistogramFn` provides a default implementation. ([#531](https://github.com/metrics-rs/metrics/pull/531))
 
 ### Changed
 

--- a/metrics/src/handles.rs
+++ b/metrics/src/handles.rs
@@ -36,6 +36,13 @@ pub trait GaugeFn {
 pub trait HistogramFn {
     /// Records a value into the histogram.
     fn record(&self, value: f64);
+
+    /// Records a value into the histogram multiple times.
+    fn record_many(&self, value: f64, count: usize) {
+        for _ in 0..count {
+            self.record(value);
+        }
+    }
 }
 
 /// A counter.
@@ -156,10 +163,17 @@ impl Histogram {
         Self { inner: Some(a) }
     }
 
-    /// Records a value in the histogram.
+    /// Records a value into the histogram.
     pub fn record<T: IntoF64>(&self, value: T) {
         if let Some(ref inner) = self.inner {
             inner.record(value.into_f64())
+        }
+    }
+
+    /// Records a value into the histogram multiple times.
+    pub fn record_many<T: IntoF64>(&self, value: T, count: usize) {
+        if let Some(ref inner) = self.inner {
+            inner.record_many(value.into_f64(), count)
         }
     }
 }


### PR DESCRIPTION
## Context

We've added a new method for recording to histograms: `record_many`. This is exposed on both `Histogram` and `HistogramFn`, with a default implementation provided on `HistogramFn` to make it backwards compatible.

It allows recording a single value multiple times, which can be a common use case when translating from bucketed histograms to histograms in `metrics`, as bucketed histograms may simply provide a single value for a bucket and the count of that value... so representing such a bucket in `metrics` requires recording that value `count` times.

Closes #509.