### PR TITLE
enhancement: expose `with_recorder` in the docs

### DIFF
--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `set_global_recorder` now requires that the recorder is `Sync`.
   ([#511](https://github.com/metrics-rs/metrics/pull/511))
 - Bump MSRV to 1.71.1. ([#530](https://github.com/metrics-rs/metrics/pull/530))
+- `with_recorder` is no longer hidden in the docs.
 
 ## [0.23.0] - 2024-05-27
 

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `set_global_recorder` now requires that the recorder is `Sync`.
   ([#511](https://github.com/metrics-rs/metrics/pull/511))
 - Bump MSRV to 1.71.1. ([#530](https://github.com/metrics-rs/metrics/pull/530))
-- `with_recorder` is no longer hidden in the docs.
+- `with_recorder` is no longer hidden in the docs. ([#532](https://github.com/metrics-rs/metrics/pull/532))
 
 ## [0.23.0] - 2024-05-27
 

--- a/metrics/src/recorder/mod.rs
+++ b/metrics/src/recorder/mod.rs
@@ -225,9 +225,8 @@ pub fn with_local_recorder<T>(recorder: &dyn Recorder, f: impl FnOnce() -> T) ->
 /// If a local recorder has been set, it will be used. Otherwise, the global recorder will be used.
 /// If neither a local recorder or global recorder have been set, a no-op recorder will be used.
 ///
-/// This is used primarily by the generated code from the convenience macros used to record metrics.
-/// It should typically not be necessary to call this function directly.
-#[doc(hidden)]
+/// It should typically not be necessary to call this function directly, as it is used primarily by generated code. You
+/// should prefer working with the macros provided by `metrics` instead: `counter!`, `gauge!`, `histogram!`, etc.
 pub fn with_recorder<T>(f: impl FnOnce(&dyn Recorder) -> T) -> T {
     LOCAL_RECORDER.with(|local_recorder| {
         if let Some(recorder) = local_recorder.get() {


### PR DESCRIPTION
## Context

This PR exposes `with_recorder` in the documentation. It was always accessible, since it needs to be in order to be used by the macros... but some users expressed a desire to want it to be more visible because they preferred interacting with it directly instead of using the macros.

Closes #473.