### PR TITLE
dogstatsd: reset client state on connection failure

### DIFF
--- a/metrics-exporter-dogstatsd/src/forwarder/sync.rs
+++ b/metrics-exporter-dogstatsd/src/forwarder/sync.rs
@@ -91,7 +91,7 @@ impl ClientState {
                         *self = ClientState::Disconnected(config);
                         return Err(e);
                     }
-                }
+                },
                 ClientState::Ready(config, mut client) => {
                     let result = client.send(payload);
                     if result.is_ok() {

--- a/metrics-exporter-dogstatsd/src/forwarder/sync.rs
+++ b/metrics-exporter-dogstatsd/src/forwarder/sync.rs
@@ -85,9 +85,12 @@ impl ClientState {
             let old_state = std::mem::replace(self, ClientState::Inconsistent);
             match old_state {
                 ClientState::Inconsistent => unreachable!("transitioned _from_ inconsistent state"),
-                ClientState::Disconnected(config) => {
-                    let client = Client::from_forwarder_config(&config)?;
-                    *self = ClientState::Ready(config, client);
+                ClientState::Disconnected(config) => match Client::from_forwarder_config(&config) {
+                    Ok(client) => *self = ClientState::Ready(config, client),
+                    Err(e) => {
+                        *self = ClientState::Disconnected(config);
+                        return Err(e);
+                    }
                 }
                 ClientState::Ready(config, mut client) => {
                     let result = client.send(payload);


### PR DESCRIPTION
## Context

When the synchronous forwarder tries to transition from a disconnected to a connected state, it creates a new `Client` via `Client::from_forwarder_config`, which creates the underlying socket, connects to the remote server, and configures things like write timeouts.

In the case of UDP, "connect" is sort of a misnomer because UDP is connectionless... and so in case of trying to "connect" to a UDP address where nothing is listening, we only get an error to that effect when we try to _send_ on the socket. For UDS, however, the connection error comes immediately within `Client::from_forwarder_config`.

Unfortunately, the current code did not properly handle this case, which left the forwarder client in an inconsistent state: literally, `ClientState::Inconsistent`.

## Solution

This PR updates `ClientState::try_send` to properly reset the state back to "disconnected" when we fail to create our `Client`.

Prior to this PR, trying to connect to a non-existent UDS socket -- datagram or stream -- would immediately panic when trying to send the first payload. With this PR, it properly manifests as a connection error.