### PR TITLE
Remove unix datagram length-prefix for `metrics-exporter-dogstatsd`

### DIFF
--- a/metrics-exporter-dogstatsd/src/forwarder/mod.rs
+++ b/metrics-exporter-dogstatsd/src/forwarder/mod.rs
@@ -118,7 +118,7 @@ impl ForwarderConfiguration {
             #[cfg(unix)]
             RemoteAddr::Unix(_) => true,
             #[cfg(unix)]
-            RemoteAddr::Unixgram(_) => true,
+            RemoteAddr::Unixgram(_) => false,
         }
     }
 }


### PR DESCRIPTION
The protocol for unix datagram should be the same as UDP, no length prefix. The prefix is only needed for "stream" sockets.