### PR TITLE
Bump thiserror to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rand = { version = "0.9", default-features = false, features = [ "thread_rng" ] 
 rand_xoshiro = { version = "0.7", default-features = false }
 ratatui = { version = "0.28", default-features = false }
 sketches-ddsketch = { version = "0.3", default-features = false }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt", "net", "time", "rt-multi-thread"] }
 tracing = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1", default-features = false }


### PR DESCRIPTION
The automatic PR to do this failed: https://github.com/metrics-rs/metrics/pull/544. I can't tell why though, logs are gone. Whatever happened, things seem to work now. None of the [release notes](https://github.com/dtolnay/thiserror/releases/tag/2.0.0) apply to the usages in mertrics-rs
