### PR TITLE
prometheus: run metrics render in a tokio blocking thread

### DIFF
--- a/metrics-exporter-prometheus/src/exporter/push_gateway.rs
+++ b/metrics-exporter-prometheus/src/exporter/push_gateway.rs
@@ -41,7 +41,8 @@ pub(super) fn new_push_gateway(
                 builder = builder.header("authorization", auth.clone());
             }
 
-            let output = handle.render();
+            let handle = handle.clone();
+            let output = tokio::task::spawn_blocking(move || handle.render()).await.unwrap();
             let result =
                 builder.method(http_method.clone()).uri(endpoint.clone()).body(Full::from(output));
             let req = match result {


### PR DESCRIPTION
Applications with large traffic and large cardinality can expect to have a lot of metrics to render. All the rendering code is sync, never yielding to runtime even once. For such large applications, the impact is clear: the tokio runtime has one of its worker thread blocked for as long as the rendering takes. The net result is latency spikes every time the process is scraped (we observed up to 15s for large production apps).

This has an additional footgun: the exporter can be installed from within a Tokio runtime, using it, or from outside of one, creating its own in a dedicated thread. This is not clear when using the exporter.

The code itself does not lend itself well to cooperative multitasking, relying on pure sync constructs, preventing an actual yield implementation.

Thus this commit moves the rendering to a tokio blocking thread, and fixes the exporter for everyone. Async stuff stays in tokio worker threads, and CPU-intesive work gets sent to dedicated threads.