### PR TITLE
fix: Fixed Prometheus export unit formatting

### DIFF
--- a/metrics-exporter-prometheus/src/formatting.rs
+++ b/metrics-exporter-prometheus/src/formatting.rs
@@ -77,14 +77,8 @@ pub fn write_metric_line<T, T2>(
 
     match unit {
         Some(Unit::Count) | None => {}
-        Some(Unit::Percent) => {
-            buffer.push('_');
-            buffer.push_str("ratio");
-        }
-        Some(unit) => {
-            buffer.push('_');
-            buffer.push_str(unit.as_str());
-        }
+        Some(Unit::Percent) => add_unit(buffer, "ratio"),
+        Some(unit) => add_unit(buffer, unit.as_str()),
     }
 
     if !labels.is_empty() || additional_label.is_some() {
@@ -116,6 +110,29 @@ pub fn write_metric_line<T, T2>(
     buffer.push(' ');
     buffer.push_str(value.to_string().as_str());
     buffer.push('\n');
+}
+
+fn add_unit(buffer: &mut String, unit: &str) {
+    const SUM_SUFFIX: &str = "_sum";
+    const COUNT_SUFFIX: &str = "_count";
+    const BUCKET_SUFFIX: &str = "_bucket";
+
+    if buffer.ends_with(SUM_SUFFIX) {
+        let suffix_pos = buffer.len() - SUM_SUFFIX.len();
+        buffer.insert(suffix_pos, '_');
+        buffer.insert_str(suffix_pos + 1, unit);
+    } else if buffer.ends_with(COUNT_SUFFIX) {
+        let suffix_pos = buffer.len() - COUNT_SUFFIX.len();
+        buffer.insert(suffix_pos, '_');
+        buffer.insert_str(suffix_pos + 1, unit);
+    } else if buffer.ends_with(BUCKET_SUFFIX) {
+        let suffix_pos = buffer.len() - BUCKET_SUFFIX.len();
+        buffer.insert(suffix_pos, '_');
+        buffer.insert_str(suffix_pos + 1, unit);
+    } else {
+        buffer.push('_');
+        buffer.push_str(unit);
+    }
 }
 
 /// Sanitizes a metric name to be valid under the Prometheus [data model].


### PR DESCRIPTION
This commit fixes improperly formatted metrics when `PrometheusBuilder::new().set_enable_unit_suffix(true)` is enabled.

Previously histogram metrics would have been formatted as:
* `<name>-sum-<unit>`
* `<name>-count-<unit>`
* `<name>-bucket-<unit>`

However the correct formatting is:
* `<name>-<unit>-sum`
* `<name>-<unit>-count`
* `<name>-<unit>-bucket`

You can see some example metric names in the Prometheus [histogram best practices page](https://prometheus.io/docs/practices/histograms/)

fixes #553