### PR TITLE
fix(dogstatsd): properly pack multiple metrics into each payload up to the configured limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -1528,15 +1528,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -2258,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.5.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.6"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
+checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77926887776171ced7d662120a75998e444d3750c951abfe07f90da130514b1f"
+checksum = "b9f7720b74ed28ca77f90769a71fd8c637a0137f6fae4ae947e1050229cff57f"
 dependencies = [
  "bindgen",
  "cc",
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "jobserver",
  "libc",
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -534,9 +534,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -568,9 +568,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fragile"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fs_extra"
@@ -639,14 +639,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -840,6 +840,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -849,14 +850,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -878,9 +880,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -975,10 +977,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -1028,9 +1031,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -1050,9 +1053,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
@@ -1237,9 +1240,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1395,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
@@ -1510,14 +1513,14 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -1525,15 +1528,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1551,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn 2.0.100",
@@ -1679,6 +1682,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,7 +1716,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1745,7 +1754,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -1824,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -1910,22 +1919,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1955,9 +1964,9 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2143,15 +2152,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2227,14 +2236,14 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.2",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -2249,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"
@@ -2304,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2518,9 +2527,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -2638,18 +2647,62 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2735,18 +2788,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -2762,11 +2815,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -2782,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/metrics-exporter-dogstatsd/proptest-regressions/forwarder/writer.txt
+++ b/metrics-exporter-dogstatsd/proptest-regressions/forwarder/writer.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 996294ee8ec0a637930c95346f0165bbaba2cbf701d321de8d713d7f723f0ff0 # shrinks to payload_limit = 43, inputs = [Histogram(Key { name: KeyName("A0AA0A0A"), labels: [], hashed: true, hash: 18423047812237334005 }, [-0.0, 3.1748022040256364e164], 10000000)]

--- a/metrics-exporter-dogstatsd/proptest-regressions/writer.txt
+++ b/metrics-exporter-dogstatsd/proptest-regressions/writer.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc ecafaadc4a51995b06f20080248f4e17c818026dc20e29e2a2dd233393af6773 # shrinks to payload_limit = 27, inputs = [Histogram(Key { name: KeyName("aAAaAa0a"), labels: [Label("aaaaa", "")], hashed: true, hash: 4563833112871895604 }, [-0.0]), Histogram(Key { name: KeyName("0AA0AaaA"), labels: [], hashed: true, hash: 13699395814728153738 }, [-0.0])]
+cc 8d5fca863d5e68150df55ff75e9718f6491d27dfd598e53b29fd0583a5e05a66 # shrinks to payload_limit = 0, inputs = [Counter(Key { name: KeyName("aaAAAAaa"), labels: [], hashed: true, hash: 15261619708481900111 }, 0, None)]

--- a/metrics-exporter-dogstatsd/proptest-regressions/writer.txt
+++ b/metrics-exporter-dogstatsd/proptest-regressions/writer.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ecafaadc4a51995b06f20080248f4e17c818026dc20e29e2a2dd233393af6773 # shrinks to payload_limit = 27, inputs = [Histogram(Key { name: KeyName("aAAaAa0a"), labels: [Label("aaaaa", "")], hashed: true, hash: 4563833112871895604 }, [-0.0]), Histogram(Key { name: KeyName("0AA0AaaA"), labels: [], hashed: true, hash: 13699395814728153738 }, [-0.0])]

--- a/metrics-exporter-dogstatsd/src/builder.rs
+++ b/metrics-exporter-dogstatsd/src/builder.rs
@@ -347,7 +347,6 @@ impl DogStatsDBuilder {
             histogram_sampling: self.histogram_sampling,
             histogram_reservoir_size: self.histogram_reservoir_size,
             histograms_as_distributions: self.histograms_as_distributions,
-            global_labels: self.global_labels,
             global_prefix: self.global_prefix,
         };
 
@@ -367,6 +366,7 @@ impl DogStatsDBuilder {
             max_payload_len,
             flush_interval,
             write_timeout: self.write_timeout,
+            global_labels: self.global_labels,
         };
 
         if self.synchronous {

--- a/metrics-exporter-dogstatsd/src/forwarder/mod.rs
+++ b/metrics-exporter-dogstatsd/src/forwarder/mod.rs
@@ -6,6 +6,8 @@ use std::{
     time::Duration,
 };
 
+use metrics::Label;
+
 pub mod sync;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -105,9 +107,20 @@ fn unknown_scheme_error_str(scheme: &str) -> String {
 #[derive(Clone)]
 pub(crate) struct ForwarderConfiguration {
     pub remote_addr: RemoteAddr,
+
+    /// Maximum size, in bytes, for an individual payload.
+    ///
+    /// Payloads may contain multiple metrics.
     pub max_payload_len: usize,
+
+    /// Duration to wait between flushing metrics.
     pub flush_interval: Duration,
+
+    /// Timeout for writing to the socket.
     pub write_timeout: Duration,
+
+    /// Global labels to attach to all metrics.
+    pub global_labels: Vec<Label>,
 }
 
 impl ForwarderConfiguration {

--- a/metrics-exporter-dogstatsd/src/forwarder/sync.rs
+++ b/metrics-exporter-dogstatsd/src/forwarder/sync.rs
@@ -146,7 +146,8 @@ impl Forwarder {
     pub fn run(mut self) {
         let mut flush_state = FlushState::default();
         let mut writer =
-            PayloadWriter::new(self.config.max_payload_len, self.config.is_length_prefixed());
+            PayloadWriter::new(self.config.max_payload_len, self.config.is_length_prefixed())
+                .with_global_labels(&self.config.global_labels);
         let mut telemetry_update = TelemetryUpdate::default();
 
         let mut next_flush = Instant::now() + self.config.flush_interval;

--- a/metrics-exporter-dogstatsd/src/state.rs
+++ b/metrics-exporter-dogstatsd/src/state.rs
@@ -62,10 +62,10 @@ impl State {
 
     fn get_aggregation_timestamp(&self) -> Option<u64> {
         match self.config.agg_mode {
-            AggregationMode::Conservative => None,
-            AggregationMode::Aggressive => {
+            AggregationMode::Conservative => {
                 SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).ok().map(|d| d.as_secs())
             }
+            AggregationMode::Aggressive => None,
         }
     }
 

--- a/metrics-exporter-dogstatsd/src/state.rs
+++ b/metrics-exporter-dogstatsd/src/state.rs
@@ -62,10 +62,10 @@ impl State {
 
     fn get_aggregation_timestamp(&self) -> Option<u64> {
         match self.config.agg_mode {
-            AggregationMode::Conservative => {
+            AggregationMode::Conservative => None,
+            AggregationMode::Aggressive => {
                 SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).ok().map(|d| d.as_secs())
             }
-            AggregationMode::Aggressive => None,
         }
     }
 

--- a/metrics-exporter-dogstatsd/src/writer.rs
+++ b/metrics-exporter-dogstatsd/src/writer.rs
@@ -618,6 +618,9 @@ mod tests {
     use metrics::{Key, Label};
     use proptest::{collection::vec as arb_vec, prelude::*, prop_oneof, proptest};
 
+    use crate::writer::SMALLEST_VALID_PAYLOAD;
+    const SMALLEST_VALID_PAYLOAD_LEN: usize = SMALLEST_VALID_PAYLOAD.len();
+
     use super::PayloadWriter;
 
     #[derive(Debug)]
@@ -960,7 +963,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn property_test_gauntlet(payload_limit in 0..16384usize, inputs in arb_vec(arb_metric(), 1..128)) {
+        fn property_test_gauntlet(payload_limit in SMALLEST_VALID_PAYLOAD_LEN..16384usize, inputs in arb_vec(arb_metric(), 1..128)) {
             // TODO: Parameterize reservoir size so we can exercise the sample rate stuff.
 
             let mut writer = PayloadWriter::new(payload_limit, false);

--- a/metrics-exporter-dogstatsd/src/writer.rs
+++ b/metrics-exporter-dogstatsd/src/writer.rs
@@ -1,6 +1,52 @@
-use std::slice::Iter;
+use std::{
+    ops::{Deref, DerefMut},
+    vec::Drain,
+};
 
 use metrics::{Key, Label};
+
+const SMALLEST_VALID_PAYLOAD: &[u8] = b"a:0|c\n";
+
+enum MetricType {
+    Counter,
+    Gauge,
+    Histogram,
+    Distribution,
+}
+
+impl MetricType {
+    fn as_bytes(&self) -> &'static [u8] {
+        match self {
+            MetricType::Counter => b"|c",
+            MetricType::Gauge => b"|g",
+            MetricType::Histogram => b"|h",
+            MetricType::Distribution => b"|d",
+        }
+    }
+}
+
+enum MetricValue {
+    Integer(u64),
+    FloatingPoint(f64),
+}
+
+struct MetricValueFormatter {
+    int_writer: itoa::Buffer,
+    float_writer: ryu::Buffer,
+}
+
+impl MetricValueFormatter {
+    fn new() -> Self {
+        Self { int_writer: itoa::Buffer::new(), float_writer: ryu::Buffer::new() }
+    }
+
+    fn format(&mut self, value: MetricValue) -> &str {
+        match value {
+            MetricValue::Integer(v) => self.int_writer.format(v),
+            MetricValue::FloatingPoint(v) => self.float_writer.format(v),
+        }
+    }
+}
 
 pub struct WriteResult {
     payloads_written: u64,
@@ -28,6 +74,10 @@ impl WriteResult {
         self.points_dropped += 1;
     }
 
+    fn increment_points_dropped_by(&mut self, count: u64) {
+        self.points_dropped += count;
+    }
+
     pub const fn any_failures(&self) -> bool {
         self.points_dropped != 0
     }
@@ -41,16 +91,31 @@ impl WriteResult {
     }
 }
 
+/// Writes payloads into larger buffers for more efficient network I/O.
+///
+/// DogStatsD metrics are always newline delimited, which means that multiple metrics can be sent in a single "payload",
+/// and then trivially split apart by the remote server. This helps save on the number of system calls required to send
+/// the metrics over the network, ultimately making writes more efficient.
+///
+/// A maximum payload length must be specified, which configures the writer's behavior around how it emits the
+/// payloads. When iterating over the payloads, byte slices are returned containing the raw metrics. Each payload will
+/// present a slice that contains one or more complete metrics while not exceeding the maximum payload length.
 pub(super) struct PayloadWriter {
     max_payload_len: usize,
-    buf: Vec<u8>,
-    trailer_buf: Vec<u8>,
+    payloads_buf: Vec<u8>,
     offsets: Vec<usize>,
+    header_buf: Vec<u8>,
+    values_buf: Vec<u8>,
+    trailer_buf: Vec<u8>,
     with_length_prefix: bool,
+    global_tags: Vec<Label>,
 }
 
 impl PayloadWriter {
     /// Creates a new `PayloadWriter` with the given maximum payload length.
+    ///
+    /// When `with_length_prefix` is `true`, the writer will prefix each payload with a 4-byte length prefix. This
+    /// prefix does not count towards the payload length.
     pub fn new(max_payload_len: usize, with_length_prefix: bool) -> Self {
         // NOTE: This should also be handled in the builder, but we want to just double check here that we're getting a
         // properly sanitized value.
@@ -58,30 +123,52 @@ impl PayloadWriter {
             u32::try_from(max_payload_len).is_ok(),
             "maximum payload length must be less than 2^32 bytes"
         );
+        assert!(
+            max_payload_len >= SMALLEST_VALID_PAYLOAD.len(),
+            "maximum payload length is too small to allow any metrics to be written (must be {} or greater)",
+            SMALLEST_VALID_PAYLOAD.len()
+        );
 
         let mut writer = Self {
             max_payload_len,
-            buf: Vec::new(),
-            trailer_buf: Vec::new(),
+            payloads_buf: Vec::new(),
             offsets: Vec::new(),
+            header_buf: Vec::new(),
+            values_buf: Vec::new(),
+            trailer_buf: Vec::new(),
             with_length_prefix,
+            global_tags: Vec::new(),
         };
 
         writer.prepare_for_write();
         writer
     }
 
+    /// Sets the global labels to apply to all metrics.
+    pub fn with_global_labels(mut self, global_labels: &[Label]) -> Self {
+        self.global_tags = global_labels.to_vec();
+        self
+    }
+
     fn last_offset(&self) -> usize {
         self.offsets.last().copied().unwrap_or(0)
     }
 
-    fn current_len(&self) -> usize {
+    /// Returns the number of bytes in the current payload.
+    fn current_payload_len(&self) -> usize {
         // Figure out the last metric's offset, which we use to calculate the current uncommitted length.
         //
         // If there aren't any committed metrics, then the last offset is simply zero.
         let last_offset = self.last_offset();
         let maybe_length_prefix_len = if self.with_length_prefix { 4 } else { 0 };
-        self.buf.len() - last_offset - maybe_length_prefix_len
+        self.payloads_buf.len() - last_offset - maybe_length_prefix_len
+    }
+
+    /// Returns the number of uncommitted bytes.
+    ///
+    /// Uncommitted bytes are the bytes that have been written to the buffers but not yet committed to a payload.
+    fn uncommitted_len(&self) -> usize {
+        self.header_buf.len() + self.values_buf.len() + self.trailer_buf.len()
     }
 
     fn prepare_for_write(&mut self) {
@@ -89,42 +176,252 @@ impl PayloadWriter {
             // If we're adding length prefixes, we need to write the length of the payload first.
             //
             // We write a dummy length of zero for now, and then we'll go back and fill it in later.
-            self.buf.extend_from_slice(&[0, 0, 0, 0]);
+            self.payloads_buf.extend_from_slice(&[0, 0, 0, 0]);
         }
     }
 
-    fn commit(&mut self) -> bool {
-        let current_last_offset = self.last_offset();
-        let current_len = self.current_len();
-        if current_len > self.max_payload_len {
-            // If the current metric is too long, we need to truncate everything we just wrote to get us back to the end
-            // of the last metric, since the previous parts of the buffer are still valid and could be flushed.
-            self.buf.truncate(self.last_offset());
+    /// Finalizes the current payload and starts a new one.
+    ///
+    /// This handles writing the length prefix if we're using them, tracking the necessary metadata about the current
+    /// payload, and preparing the buffer for the next payload.
+    ///
+    /// If the current payload is empty, this method does nothing.
+    fn finalize_current_payload(&mut self) {
+        // If the current payload is empty, there's nothing to do.
+        let current_payload_len = self.current_payload_len();
+        if current_payload_len == 0 {
+            return;
+        }
 
+        // If we're using length prefixes, we need to go back and fill in the length of the payload.
+        if self.with_length_prefix {
+            let current_last_offset = self.last_offset();
+
+            // NOTE: We unwrap the conversion here because we know that `self.max_payload_len` is less than 2^32, and we
+            // check above that `current_len` is less than or equal to `self.max_payload_len`.
+            let current_payload_len_buf = u32::try_from(current_payload_len).unwrap().to_le_bytes();
+            self.payloads_buf[current_last_offset..current_last_offset + 4]
+                .copy_from_slice(&current_payload_len_buf[..]);
+        }
+
+        // Track the offset of the payload we just finalized.
+        self.offsets.push(self.payloads_buf.len());
+
+        // Initialize the buffer to start a new payload.
+        self.prepare_for_write();
+    }
+
+    /// Commits the uncommitted metric to the current payload.
+    ///
+    /// If the uncommitted metric is larger than the maximum payload length, it will be discarded. If the current
+    /// payload cannot fit the uncommitted metric without exceeding the maximum payload length, the current payload will
+    /// first be finalized and a new one started before writing the uncommitted metric.
+    ///
+    /// Returns `true` if the uncommitted metric was successfully committed, or `false` if it was discarded.
+    fn commit(&mut self) -> bool {
+        // Make sure the uncommitted metric isn't larger than the maximum payload length by itself.
+        //
+        // If it is, then it has to be discarded regardless of whether or not the current payload is empty.
+        let uncommitted_len = self.uncommitted_len();
+        if uncommitted_len > self.max_payload_len {
             return false;
         }
 
-        // Track the new offset.
-        self.offsets.push(self.buf.len());
-
-        // If we're dealing with length-delimited payloads, go back to the beginning of this payload and fill in the
-        // length of it.
-        if self.with_length_prefix {
-            // NOTE: We unwrap the conversion here because we know that `self.max_payload_len` is less than 2^32, and we
-            // check above that `current_len` is less than or equal to `self.max_payload_len`.
-            let current_len_buf = u32::try_from(current_len).unwrap().to_le_bytes();
-            self.buf[current_last_offset..current_last_offset + 4]
-                .copy_from_slice(&current_len_buf[..]);
+        // Check if writing the uncommitted metric to the current payload would cause us to exceed the maximum payload
+        // length. If so, then we'll first finalize the current payload and start a new one before continuing.
+        let current_payload_len = self.current_payload_len();
+        if current_payload_len + uncommitted_len > self.max_payload_len {
+            self.finalize_current_payload();
         }
 
-        // Initialize the buffer for the next payload.
-        self.prepare_for_write();
+        // Write the uncommitted metric into the payload buffer.
+        self.payloads_buf.extend_from_slice(&self.header_buf);
+        self.payloads_buf.extend_from_slice(&self.values_buf);
+        self.payloads_buf.extend_from_slice(&self.trailer_buf);
+
+        // Clear out the value buffer since we don't want to double write, but leave the header/trailer because we might
+        // be reusing it in a multi-value write.
+        self.values_buf.clear();
 
         true
     }
 
-    fn write_trailing(&mut self, key: &Key, timestamp: Option<u64>, global_labels: &[Label]) {
-        write_metric_trailer(key, timestamp, &mut self.buf, None, global_labels.iter());
+    /// Returns `true` if `len` bytes could be written to the uncommitted metric without exceeding the maximum payload
+    /// length.
+    fn would_write_exceed_limit(&self, len: usize) -> bool {
+        self.uncommitted_len() + len > self.max_payload_len
+    }
+
+    fn write_metric_header(&mut self, prefix: Option<&str>, key: &Key) {
+        self.header_buf.clear();
+
+        if let Some(prefix) = prefix {
+            self.header_buf.extend_from_slice(prefix.as_bytes());
+            self.header_buf.push(b'.');
+        }
+
+        self.header_buf.extend_from_slice(key.name().as_bytes());
+    }
+
+    fn write_metric_trailer(
+        &mut self,
+        key: &Key,
+        metric_type: MetricType,
+        maybe_timestamp: Option<u64>,
+        maybe_sample_rate: Option<f64>,
+    ) {
+        self.trailer_buf.clear();
+
+        self.trailer_buf.extend_from_slice(metric_type.as_bytes());
+
+        // Write the sample rate if it's not 1.0, as that is the implied default.
+        if let Some(sample_rate) = maybe_sample_rate {
+            let mut float_writer = ryu::Buffer::new();
+            let sample_rate_str = float_writer.format(sample_rate);
+
+            self.trailer_buf.extend_from_slice(b"|@");
+            self.trailer_buf.extend_from_slice(sample_rate_str.as_bytes());
+        }
+
+        // Write any tags that are present on the key first, and then additionally write any global tags.
+        let tags = key.labels();
+        let mut wrote_tag = false;
+        for tag in tags.chain(self.global_tags.iter()) {
+            // If we haven't written a tag yet, write out the tags prefix first.
+            //
+            // Otherwise, write a tag separator.
+            if wrote_tag {
+                self.trailer_buf.push(b',');
+            } else {
+                self.trailer_buf.extend_from_slice(b"|#");
+                wrote_tag = true;
+            }
+
+            write_tag(&mut self.trailer_buf, tag);
+        }
+
+        if let Some(timestamp) = maybe_timestamp {
+            let mut int_writer = itoa::Buffer::new();
+            let ts_str = int_writer.format(timestamp);
+
+            self.trailer_buf.extend_from_slice(b"|T");
+            self.trailer_buf.extend_from_slice(ts_str.as_bytes());
+        }
+
+        // We always add a trailing newline, regardless of whether or not we're using a length prefix.
+        self.trailer_buf.push(b'\n');
+    }
+
+    fn try_write_single(
+        &mut self,
+        key: &Key,
+        metric_value: MetricValue,
+        metric_type: MetricType,
+        maybe_timestamp: Option<u64>,
+        prefix: Option<&str>,
+    ) -> WriteResult {
+        // Write our metric header and trailer.
+        self.write_metric_header(prefix, key);
+        self.write_metric_trailer(key, metric_type, maybe_timestamp, None);
+
+        let mut formatter = MetricValueFormatter::new();
+        let metric_value_str = formatter.format(metric_value);
+
+        // Check if the full metric length exceeds the maximum payload length.
+        //
+        // If it does, we return early.
+        if self.would_write_exceed_limit(metric_value_str.len() + 1) {
+            return WriteResult::failure(1);
+        }
+
+        // Write our value, and then commit the overall metric.
+        self.values_buf.clear();
+        self.values_buf.push(b':');
+        self.values_buf.extend_from_slice(metric_value_str.as_bytes());
+
+        if self.commit() {
+            WriteResult::success(1)
+        } else {
+            WriteResult::failure(1)
+        }
+    }
+
+    fn try_write_multiple<'a, I>(
+        &mut self,
+        key: &Key,
+        mut metric_values: I,
+        metric_type: MetricType,
+        maybe_sample_rate: Option<f64>,
+        prefix: Option<&str>,
+    ) -> WriteResult
+    where
+        I: Iterator<Item = MetricValue> + ExactSizeIterator,
+    {
+        // Write our metric header and trailer.
+        self.write_metric_header(prefix, key);
+        self.write_metric_trailer(key, metric_type, None, maybe_sample_rate);
+
+        // Check if the full metric length exceeds the maximum payload length. Since we're dealing with multiple values,
+        // we check this based on the smallest possible valid value: zero (`:0`).
+        //
+        // If zero would not fit, then nothing else will either, and we return early.
+        if self.would_write_exceed_limit(2) {
+            return WriteResult::failure(metric_values.len() as u64);
+        }
+
+        let mut result = WriteResult::new();
+        let mut formatter = MetricValueFormatter::new();
+
+        // Iterate over all of the values, trying to write each of them.
+        //
+        // We keep track of the overall size of the payload as we go, and if writing the current value would cause us to
+        // exceed the maximum payload length, we commit what we have so far, and then move on. This allows us to
+        // basically keep writing until we're done, while letting `commit` figure out where to separate things.
+        let mut uncommitted_points = 0;
+        while let Some(metric_value) = metric_values.next() {
+            let metric_value_str = formatter.format(metric_value);
+
+            // Do a sanity check to see if writing this value by itself would create a payload that exceeds the maximum
+            // payload length, and skip it if so.
+            if self.header_buf.len() + metric_value_str.len() + 1 + self.trailer_buf.len()
+                > self.max_payload_len
+            {
+                result.increment_points_dropped();
+                continue;
+            }
+
+            // See if we can write the value into our current values buffer without exceeding the maximum payload
+            // length. If we can't, we'll commit what we have so far before continuing.
+            if self.would_write_exceed_limit(metric_value_str.len() + 1) {
+                // Try committing to the current payload.
+                //
+                // Reset the values buffer and our uncommitted points count no matter what.
+                if self.commit() {
+                    result.increment_payloads_written();
+                } else {
+                    result.increment_points_dropped_by(uncommitted_points);
+                }
+
+                uncommitted_points = 0;
+            }
+
+            // Write the value.
+            self.values_buf.push(b':');
+            self.values_buf.extend_from_slice(metric_value_str.as_bytes());
+
+            uncommitted_points += 1;
+        }
+
+        // Commit any remaining uncommitted points.
+        if uncommitted_points > 0 {
+            if self.commit() {
+                result.increment_payloads_written();
+            } else {
+                result.increment_points_dropped_by(uncommitted_points);
+            }
+        }
+
+        result
     }
 
     /// Writes a counter payload.
@@ -134,27 +431,14 @@ impl PayloadWriter {
         value: u64,
         timestamp: Option<u64>,
         prefix: Option<&str>,
-        global_labels: &[Label],
     ) -> WriteResult {
-        let mut int_writer = itoa::Buffer::new();
-        let value_str = int_writer.format(value);
-
-        if let Some(prefix) = prefix {
-            self.buf.extend_from_slice(prefix.as_bytes());
-            self.buf.push(b'.');
-        }
-        self.buf.extend_from_slice(key.name().as_bytes());
-        self.buf.push(b':');
-        self.buf.extend_from_slice(value_str.as_bytes());
-        self.buf.extend_from_slice(b"|c");
-
-        self.write_trailing(key, timestamp, global_labels);
-
-        if self.commit() {
-            WriteResult::success(1)
-        } else {
-            WriteResult::failure(1)
-        }
+        self.try_write_single(
+            key,
+            MetricValue::Integer(value),
+            MetricType::Counter,
+            timestamp,
+            prefix,
+        )
     }
 
     /// Writes a gauge payload.
@@ -164,27 +448,14 @@ impl PayloadWriter {
         value: f64,
         timestamp: Option<u64>,
         prefix: Option<&str>,
-        global_labels: &[Label],
     ) -> WriteResult {
-        let mut float_writer = ryu::Buffer::new();
-        let value_str = float_writer.format(value);
-
-        if let Some(prefix) = prefix {
-            self.buf.extend_from_slice(prefix.as_bytes());
-            self.buf.push(b'.');
-        }
-        self.buf.extend_from_slice(key.name().as_bytes());
-        self.buf.push(b':');
-        self.buf.extend_from_slice(value_str.as_bytes());
-        self.buf.extend_from_slice(b"|g");
-
-        self.write_trailing(key, timestamp, global_labels);
-
-        if self.commit() {
-            WriteResult::success(1)
-        } else {
-            WriteResult::failure(1)
-        }
+        self.try_write_single(
+            key,
+            MetricValue::FloatingPoint(value),
+            MetricType::Gauge,
+            timestamp,
+            prefix,
+        )
     }
 
     /// Writes a histogram payload.
@@ -194,13 +465,19 @@ impl PayloadWriter {
         values: I,
         maybe_sample_rate: Option<f64>,
         prefix: Option<&str>,
-        global_labels: &[Label],
     ) -> WriteResult
     where
         I: IntoIterator<Item = f64>,
         I::IntoIter: ExactSizeIterator,
     {
-        self.write_hist_dist_inner(key, values, b'h', maybe_sample_rate, prefix, global_labels)
+        let metric_values = values.into_iter().map(|v| MetricValue::FloatingPoint(v));
+        self.try_write_multiple(
+            key,
+            metric_values,
+            MetricType::Histogram,
+            maybe_sample_rate,
+            prefix,
+        )
     }
 
     /// Writes a distribution payload.
@@ -210,121 +487,19 @@ impl PayloadWriter {
         values: I,
         maybe_sample_rate: Option<f64>,
         prefix: Option<&str>,
-        global_labels: &[Label],
     ) -> WriteResult
     where
         I: IntoIterator<Item = f64>,
         I::IntoIter: ExactSizeIterator,
     {
-        self.write_hist_dist_inner(key, values, b'd', maybe_sample_rate, prefix, global_labels)
-    }
-
-    fn write_hist_dist_inner<I>(
-        &mut self,
-        key: &Key,
-        values: I,
-        metric_type: u8,
-        maybe_sample_rate: Option<f64>,
-        prefix: Option<&str>,
-        global_labels: &[Label],
-    ) -> WriteResult
-    where
-        I: IntoIterator<Item = f64>,
-        I::IntoIter: ExactSizeIterator,
-    {
-        let mut float_writer = ryu::Buffer::new();
-        let mut result = WriteResult::new();
-        let values = values.into_iter();
-
-        // Pre-render our metric trailer, which includes the timestamp and tags.
-        //
-        // We do this for efficiency reasons, but also to calculate the minimum payload length.
-        self.trailer_buf.clear();
-        write_metric_trailer(
+        let metric_values = values.into_iter().map(|v| MetricValue::FloatingPoint(v));
+        self.try_write_multiple(
             key,
-            None,
-            &mut self.trailer_buf,
+            metric_values,
+            MetricType::Distribution,
             maybe_sample_rate,
-            global_labels.iter(),
-        );
-
-        // Calculate the minimum payload length, which is the key name, the metric trailer, and the metric type
-        // substring (`|<metric type>`). This is the minimum amount of space we need to write out the metric without
-        // including the value itself.
-        //
-        // If the minimum payload length exceeds the maximum payload length, we can't write the metric at all, so we
-        // return an error.
-        let minimum_payload_len = key.name().len() + self.trailer_buf.len() + 2;
-        if minimum_payload_len + 2 > self.max_payload_len {
-            // The extra two we add above simulates the smallest possible value string, which would be `:0`.
-            return WriteResult::failure(values.len() as u64);
-        }
-
-        // Iterate over each value, writing it out to the buffer in a streaming fashion.
-        //
-        // We track a shadow "current length" because we want to make sure we don't write an additional value if it
-        // would cause the payload to exceed the maximum payload length... but since we have to write values in the
-        // middle of the payload, rather than just at the end... we can't use `current_len()` since we haven't yet
-        // written tags, the timestamp, etc.
-        let mut needs_name = true;
-        let mut current_len = minimum_payload_len;
-        for value in values {
-            let value_str = float_writer.format(value);
-
-            // Skip the value if it's not even possible to fit it by itself.
-            if minimum_payload_len + value_str.len() + 1 > self.max_payload_len {
-                result.increment_points_dropped();
-                continue;
-            }
-
-            // Figure out if we can write the value to the current metric payload.
-            //
-            // If we can't fit it into the current buffer, then we have to first commit our current buffer.
-            if current_len + value_str.len() + 1 > self.max_payload_len {
-                // Write the metric type and then the trailer.
-                self.buf.push(b'|');
-                self.buf.push(metric_type);
-                self.buf.extend_from_slice(&self.trailer_buf);
-
-                assert!(self.commit(), "should not fail to commit histogram metric at this stage");
-
-                result.increment_payloads_written();
-
-                // Reset the current length to the minimum payload length, since we're starting a new metric.
-                needs_name = true;
-                current_len = minimum_payload_len;
-            }
-
-            // Write the metric name if it hasn't been written yet.
-            if needs_name {
-                if let Some(prefix) = prefix {
-                    self.buf.extend_from_slice(prefix.as_bytes());
-                    self.buf.push(b'.');
-                }
-                self.buf.extend_from_slice(key.name().as_bytes());
-                needs_name = false;
-            }
-
-            // Write the value.
-            self.buf.push(b':');
-            self.buf.extend_from_slice(value_str.as_bytes());
-
-            // Track the length of the value we just wrote.
-            current_len += value_str.len() + 1;
-        }
-
-        // If we have any remaining uncommitted values, finalize them and commit.
-        if self.current_len() != 0 {
-            self.buf.push(b'|');
-            self.buf.push(metric_type);
-            self.buf.extend_from_slice(&self.trailer_buf);
-
-            assert!(self.commit(), "should not fail to commit histogram metric at this stage");
-
-            result.increment_payloads_written();
-        }
-
-        result
+            prefix,
+        )
     }
 
     /// Returns a consuming iterator over all payloads written by this writer.
@@ -332,18 +507,35 @@ impl PayloadWriter {
     /// The iterator will yield payloads in the order they were written, and the payloads will be cleared from the
     /// writer when the iterator is dropped.
     pub fn payloads(&mut self) -> Payloads<'_> {
-        Payloads { buf: &mut self.buf, start: 0, offsets: self.offsets.drain(..) }
+        // Finalize the current payload, and clear the intermediate buffers.
+        //
+        // Between this method, and the logic in `Payloads`, the writer should be completely cleared out after
+        // `Payloads` is dropped.
+        self.finalize_current_payload();
+        self.header_buf.clear();
+        self.values_buf.clear();
+        self.trailer_buf.clear();
+
+        Payloads::new(&mut self.payloads_buf, &mut self.offsets)
     }
 }
 
 /// Iterator over all payloads written by a `PayloadWriter`.
 pub struct Payloads<'a> {
-    buf: &'a mut Vec<u8>,
+    payloads_buf: ConsumingBufferSwap<'a, u8>,
     start: usize,
-    offsets: std::vec::Drain<'a, usize>,
+    offsets: Drain<'a, usize>,
 }
 
 impl<'a> Payloads<'a> {
+    fn new(payload_buf: &'a mut Vec<u8>, offsets: &'a mut Vec<usize>) -> Self {
+        Self {
+            payloads_buf: ConsumingBufferSwap::new(payload_buf),
+            start: 0,
+            offsets: offsets.drain(..),
+        }
+    }
+
     /// Returns the number of remaining payloads.
     pub fn len(&self) -> usize {
         self.offsets.len()
@@ -355,83 +547,74 @@ impl<'a> Payloads<'a> {
     pub fn next_payload(&mut self) -> Option<&[u8]> {
         let offset = self.offsets.next()?;
 
-        let offset_buf = &self.buf[self.start..offset];
+        let offset_buf = &self.payloads_buf[self.start..offset];
         self.start = offset;
 
         Some(offset_buf)
     }
 }
 
-impl<'a> Drop for Payloads<'a> {
-    fn drop(&mut self) {
-        self.buf.clear();
+// Helper type for "pre-pooping our pants".
+//
+// This type is used when a `Vec<T>` is meant to be drained during an operation, such that the buffer is entirely empty
+// after the operation is finished. Since it's safe to "forget" a value and not have its drop logic called, how do we
+// ensure that we don't leave the buffer in an indeterminate state without drop logic? We pre-poop our pants.
+//
+// By swapping out the buffer with an empty one, we ensure that the end state -- the buffer is cleared -- is established
+// as soon as we create `ConsumingBufferSwap`. When the drop logic is called, we replace the original buffer, which lets
+// use reuse the allocation. At worst, if the drop logic doesn't run, then the buffer is still empty.
+//
+// https://faultlore.com/blah/everyone-poops/
+struct ConsumingBufferSwap<'a, T> {
+    source: &'a mut Vec<T>,
+    original: Vec<T>,
+}
+
+impl<'a, T> ConsumingBufferSwap<'a, T> {
+    fn new(source: &'a mut Vec<T>) -> Self {
+        let original = std::mem::take(source);
+        Self { source, original }
     }
 }
 
-fn write_metric_trailer(
-    key: &Key,
-    maybe_timestamp: Option<u64>,
-    buf: &mut Vec<u8>,
-    maybe_sample_rate: Option<f64>,
-    global_labels: Iter<Label>,
-) {
-    // Write the sample rate if it's not 1.0, as that is the implied default.
-    if let Some(sample_rate) = maybe_sample_rate {
-        let mut float_writer = ryu::Buffer::new();
-        let sample_rate_str = float_writer.format(sample_rate);
+impl<'a, T> Drop for ConsumingBufferSwap<'a, T> {
+    fn drop(&mut self) {
+        // Clear out the original buffer to reset it, and then return it to the source.
+        self.original.clear();
+        std::mem::swap(self.source, &mut self.original);
+    }
+}
 
-        buf.extend_from_slice(b"|@");
-        buf.extend_from_slice(sample_rate_str.as_bytes());
+impl<'a, T> Deref for ConsumingBufferSwap<'a, T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.original
+    }
+}
+
+impl<'a, T> DerefMut for ConsumingBufferSwap<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.original
+    }
+}
+
+fn write_tag(buf: &mut Vec<u8>, label: &Label) {
+    // If the label value is empty, we treat it as a bare label. This means all we write is something like
+    // `label_name`, instead of a more naive form, like `label_name:`.
+    buf.extend_from_slice(label.key().as_bytes());
+    if label.value().is_empty() {
+        return;
     }
 
-    // Write the metric tags first.
-    let tags = key.labels();
-    let mut wrote_tag = false;
-    for tag in global_labels.chain(tags) {
-        // If we haven't written a tag yet, write out the tags prefix first.
-        //
-        // Otherwise, write a tag separator.
-        if wrote_tag {
-            buf.push(b',');
-        } else {
-            buf.extend_from_slice(b"|#");
-            wrote_tag = true;
-        }
-
-        // Write the tag.
-        //
-        // If the tag value is empty, we treat it as a bare tag, which means we only write something like `tag_name`
-        // instead of `tag_name:`.
-        buf.extend_from_slice(tag.key().as_bytes());
-        if tag.value().is_empty() {
-            continue;
-        }
-
-        buf.push(b':');
-        buf.extend_from_slice(tag.value().as_bytes());
-    }
-
-    // Write the timestamp if present.
-    if let Some(timestamp) = maybe_timestamp {
-        let mut int_writer = itoa::Buffer::new();
-        let ts_str = int_writer.format(timestamp);
-
-        buf.extend_from_slice(b"|T");
-        buf.extend_from_slice(ts_str.as_bytes());
-    }
-
-    // Finally, add the newline.
-    buf.push(b'\n');
+    buf.push(b':');
+    buf.extend_from_slice(label.value().as_bytes());
 }
 
 #[cfg(test)]
 mod tests {
     use metrics::{Key, Label};
-    use proptest::{
-        collection::vec as arb_vec,
-        prelude::{any, Strategy},
-        prop_oneof, proptest,
-    };
+    use proptest::{collection::vec as arb_vec, prelude::*, prop_oneof, proptest};
 
     use super::PayloadWriter;
 
@@ -529,7 +712,7 @@ mod tests {
                 Some(234567),
                 None,
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
-                "test_counter:777|c|#gfoo:bar,gbaz:quux,foo:bar,baz:quux|T234567\n",
+                "test_counter:777|c|#foo:bar,baz:quux,gfoo:bar,gbaz:quux|T234567\n",
             ),
             (
                 Key::from_parts("test_counter", &[("foo", "bar"), ("baz", "quux")]),
@@ -537,13 +720,13 @@ mod tests {
                 Some(234567),
                 Some("server1"),
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
-                "server1.test_counter:777|c|#gfoo:bar,gbaz:quux,foo:bar,baz:quux|T234567\n",
+                "server1.test_counter:777|c|#foo:bar,baz:quux,gfoo:bar,gbaz:quux|T234567\n",
             ),
         ];
 
         for (key, value, ts, prefix, global_labels, expected) in cases {
-            let mut writer = PayloadWriter::new(8192, false);
-            let result = writer.write_counter(&key, value, ts, prefix, global_labels);
+            let mut writer = PayloadWriter::new(8192, false).with_global_labels(global_labels);
+            let result = writer.write_counter(&key, value, ts, prefix);
             assert_eq!(result.payloads_written(), 1);
 
             let actual = string_from_writer(&mut writer);
@@ -594,7 +777,7 @@ mod tests {
                 Some(234567),
                 None,
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
-                "test_gauge:3.13232|g|#gfoo:bar,gbaz:quux,foo:bar,baz:quux|T234567\n",
+                "test_gauge:3.13232|g|#foo:bar,baz:quux,gfoo:bar,gbaz:quux|T234567\n",
             ),
             (
                 Key::from_parts("test_gauge", &[("foo", "bar"), ("baz", "quux")]),
@@ -602,13 +785,13 @@ mod tests {
                 Some(234567),
                 Some("server1"),
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
-                "server1.test_gauge:3.13232|g|#gfoo:bar,gbaz:quux,foo:bar,baz:quux|T234567\n",
+                "server1.test_gauge:3.13232|g|#foo:bar,baz:quux,gfoo:bar,gbaz:quux|T234567\n",
             ),
         ];
 
         for (key, value, ts, prefix, global_labels, expected) in cases {
-            let mut writer = PayloadWriter::new(8192, false);
-            let result = writer.write_gauge(&key, value, ts, prefix, global_labels);
+            let mut writer = PayloadWriter::new(8192, false).with_global_labels(global_labels);
+            let result = writer.write_gauge(&key, value, ts, prefix);
             assert_eq!(result.payloads_written(), 1);
 
             let actual = string_from_writer(&mut writer);
@@ -654,21 +837,20 @@ mod tests {
                 &[88.0, 66.6, 123.4][..],
                 None,
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
-                "test_histogram:88.0:66.6:123.4|h|#gfoo:bar,gbaz:quux,foo:bar,baz:quux\n",
+                "test_histogram:88.0:66.6:123.4|h|#foo:bar,baz:quux,gfoo:bar,gbaz:quux\n",
             ),
             (
                 Key::from_parts("test_histogram", &[("foo", "bar"), ("baz", "quux")]),
                 &[88.0, 66.6, 123.4][..],
                 Some("server1"),
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
-                "server1.test_histogram:88.0:66.6:123.4|h|#gfoo:bar,gbaz:quux,foo:bar,baz:quux\n",
+                "server1.test_histogram:88.0:66.6:123.4|h|#foo:bar,baz:quux,gfoo:bar,gbaz:quux\n",
             ),
         ];
 
         for (key, values, prefix, global_labels, expected) in cases {
-            let mut writer = PayloadWriter::new(8192, false);
-            let result =
-                writer.write_histogram(&key, values.iter().copied(), None, prefix, global_labels);
+            let mut writer = PayloadWriter::new(8192, false).with_global_labels(global_labels);
+            let result = writer.write_histogram(&key, values.iter().copied(), None, prefix);
             assert_eq!(result.payloads_written(), 1);
 
             let actual = string_from_writer(&mut writer);
@@ -714,26 +896,20 @@ mod tests {
                 &[88.0, 66.6, 123.4][..],
                 None,
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
-                "test_distribution:88.0:66.6:123.4|d|#gfoo:bar,gbaz:quux,foo:bar,baz:quux\n",
+                "test_distribution:88.0:66.6:123.4|d|#foo:bar,baz:quux,gfoo:bar,gbaz:quux\n",
             ),
             (
                 Key::from_parts("test_distribution", &[("foo", "bar"), ("baz", "quux")]),
                 &[88.0, 66.6, 123.4][..],
                 Some("server1"),
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
-                "server1.test_distribution:88.0:66.6:123.4|d|#gfoo:bar,gbaz:quux,foo:bar,baz:quux\n",
+                "server1.test_distribution:88.0:66.6:123.4|d|#foo:bar,baz:quux,gfoo:bar,gbaz:quux\n",
             ),
         ];
 
         for (key, values, prefix, global_labels, expected) in cases {
-            let mut writer = PayloadWriter::new(8192, false);
-            let result = writer.write_distribution(
-                &key,
-                values.iter().copied(),
-                None,
-                prefix,
-                global_labels,
-            );
+            let mut writer = PayloadWriter::new(8192, false).with_global_labels(global_labels);
+            let result = writer.write_distribution(&key, values.iter().copied(), None, prefix);
             assert_eq!(result.payloads_written(), 1);
 
             let actual = string_from_writer(&mut writer);
@@ -772,7 +948,7 @@ mod tests {
 
         for (key, values, expected) in cases {
             let mut writer = PayloadWriter::new(8192, true);
-            let result = writer.write_distribution(&key, values.iter().copied(), None, None, &[]);
+            let result = writer.write_distribution(&key, values.iter().copied(), None, None);
             assert_eq!(result.payloads_written(), 1);
 
             let actual = buf_from_writer(&mut writer);
@@ -783,7 +959,7 @@ mod tests {
     proptest! {
         #[test]
         fn property_test_gauntlet(payload_limit in 0..16384usize, inputs in arb_vec(arb_metric(), 1..128)) {
-            // TODO: Parameterize reservoir size so we can exercise the sample rate stuff.[]
+            // TODO: Parameterize reservoir size so we can exercise the sample rate stuff.
 
             let mut writer = PayloadWriter::new(payload_limit, false);
             let mut total_input_points: u64 = 0;
@@ -795,21 +971,21 @@ mod tests {
                     InputMetric::Counter(key, value, ts) => {
                         total_input_points += 1;
 
-                        let result = writer.write_counter(&key, value, ts, None, Default::default());
+                        let result = writer.write_counter(&key, value, ts, None);
                         payloads_written += result.payloads_written();
                         points_dropped += result.points_dropped();
                     },
                     InputMetric::Gauge(key, value, ts) => {
                         total_input_points += 1;
 
-                        let result = writer.write_gauge(&key, value, ts, None, Default::default());
+                        let result = writer.write_gauge(&key, value, ts, None);
                         payloads_written += result.payloads_written();
                         points_dropped += result.points_dropped();
                     },
                     InputMetric::Histogram(key, values) => {
                         total_input_points += values.len() as u64;
 
-                        let result = writer.write_histogram(&key, values, None, None, Default::default());
+                        let result = writer.write_histogram(&key, values, None, None);
                         payloads_written += result.payloads_written();
                         points_dropped += result.points_dropped();
                     },
@@ -847,8 +1023,8 @@ mod tests {
                 }
             }
 
-            assert_eq!(payloads_written, payloads_emitted);
-            assert_eq!(total_input_points, points_dropped + points_emitted);
+            prop_assert_eq!(payloads_written, payloads_emitted);
+            prop_assert_eq!(total_input_points, points_dropped + points_emitted);
         }
     }
 }


### PR DESCRIPTION
## Context

Prior to this PR, the writer logic ensured we didn't write metrics that exceeded the maximum payload size... but it didn't actually pack multiple metrics into a payload. This is inefficient because we often have the opportunity to send many metrics in a single write operation while still obeying the maximum payload limit.

This PR refactors `PayloadWriter` to properly pack multiple metrics into each payload up to the configured limit. We did a lot of deduplication and overly-verbose method naming as the code can otherwise be a little terse/hard to easily understand. We might want to revisit the multiple buffers approach in the future, but for right now, this should be good enough while still getting the job done.