### PR TITLE
"Consume" counters and gauge on snapshot

### DIFF
--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -106,9 +106,7 @@ impl Snapshotter {
         for (ck, _) in seen.into_iter() {
             let value = match ck.kind() {
                 MetricKind::Counter => counters.get(ck.key()).map(|c| {
-                    let counter = DebugValue::Counter(c.load(Ordering::SeqCst));
-                    c.swap(0, Ordering::Relaxed);
-                    counter
+                    DebugValue::Counter(c.swap(0, Ordering::SeqCst))
                 }),
                 MetricKind::Gauge => gauges.get(ck.key()).map(|g| {
                     let value = f64::from_bits(g.load(Ordering::SeqCst));

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -105,9 +105,9 @@ impl Snapshotter {
 
         for (ck, _) in seen.into_iter() {
             let value = match ck.kind() {
-                MetricKind::Counter => counters.get(ck.key()).map(|c| {
-                    DebugValue::Counter(c.swap(0, Ordering::SeqCst))
-                }),
+                MetricKind::Counter => {
+                    counters.get(ck.key()).map(|c| DebugValue::Counter(c.swap(0, Ordering::SeqCst)))
+                }
                 MetricKind::Gauge => gauges.get(ck.key()).map(|g| {
                     let value = f64::from_bits(g.swap(0, Ordering::SeqCst));
                     DebugValue::Gauge(value.into())

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -109,8 +109,7 @@ impl Snapshotter {
                     DebugValue::Counter(c.swap(0, Ordering::SeqCst))
                 }),
                 MetricKind::Gauge => gauges.get(ck.key()).map(|g| {
-                    let value = f64::from_bits(g.load(Ordering::SeqCst));
-                    g.swap(0, Ordering::Relaxed);
+                    let value = f64::from_bits(g.swap(0, Ordering::SeqCst));
                     DebugValue::Gauge(value.into())
                 }),
                 MetricKind::Histogram => histograms.get(ck.key()).map(|h| {


### PR DESCRIPTION
## Summary

This commit modifies the behavior of the snapshot to consume (or reset) the observed counters and gauges. The motivation is to make them behave in a similar way to histograms whose values are cleared from the backing storage during snapshot. The counters and gauges are set to 0 as it is their initial values at creation time.

## Tests

[x] unit tests