### PR TITLE
fix(dogstatsd): fix reversed aggregation mode logic

### DIFF
--- a/metrics-exporter-dogstatsd/src/state.rs
+++ b/metrics-exporter-dogstatsd/src/state.rs
@@ -65,10 +65,10 @@ impl State {
 
     fn get_aggregation_timestamp(&self) -> Option<u64> {
         match self.config.agg_mode {
-            AggregationMode::Conservative => {
+            AggregationMode::Aggressive => {
                 SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).ok().map(|d| d.as_secs())
             }
-            AggregationMode::Aggressive => None,
+            AggregationMode::Conservative => None,
         }
     }
 


### PR DESCRIPTION
## Context

This PR fixes an issue with how `metrics-exporter-dogstatsd` handles the two possible aggregation modes. The expected logic is that in "conservative" aggregation mode, we don't send a timestamped metric because the Agent is expected to handle aggregation: we do some aggregation locally between flushes but we don't handle _all_ aggregation. On the other side, "aggressive" aggregation mode should lead to us using a longer interval (matching the Datadog Agent's normal aggregation interval) and the emission of timestamped payloads, such that the Agent simply passes those metrics through and doesn't waste resources (re)aggregating them.

This logic, however, is reversed in the current code: we emit timestamps when in conservative mode, but not in aggressive mode. This PR simply reverses the logic to fix the glitch.