### PR TITLE
Prometheus: Add setting for recommended metric names

### DIFF
--- a/metrics-exporter-prometheus/src/formatting.rs
+++ b/metrics-exporter-prometheus/src/formatting.rs
@@ -70,15 +70,16 @@ pub fn write_metric_line<T, T2>(
     T2: std::fmt::Display,
 {
     buffer.push_str(name);
-    if let Some(suffix) = suffix {
-        buffer.push('_');
-        buffer.push_str(suffix);
-    }
 
     match unit {
         Some(Unit::Count) | None => {}
         Some(Unit::Percent) => add_unit(buffer, "ratio"),
         Some(unit) => add_unit(buffer, unit.as_str()),
+    }
+
+    if let Some(suffix) = suffix {
+        buffer.push('_');
+        buffer.push_str(suffix);
     }
 
     if !labels.is_empty() || additional_label.is_some() {

--- a/metrics-exporter-prometheus/src/formatting.rs
+++ b/metrics-exporter-prometheus/src/formatting.rs
@@ -29,9 +29,13 @@ pub fn key_to_parts(
 /// Writes a help (description) line in the Prometheus [exposition format].
 ///
 /// [exposition format]: https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-format-details
-pub fn write_help_line(buffer: &mut String, name: &str, desc: &str) {
+pub fn write_help_line(buffer: &mut String, name: &str, unit: Option<Unit>, desc: &str) {
     buffer.push_str("# HELP ");
     buffer.push_str(name);
+    if let Some(unit) = unit {
+        buffer.push('_');
+        buffer.push_str(unit.as_str());
+    }
     buffer.push(' ');
     let desc = sanitize_description(desc);
     buffer.push_str(&desc);
@@ -41,9 +45,13 @@ pub fn write_help_line(buffer: &mut String, name: &str, desc: &str) {
 /// Writes a metric type line in the Prometheus [exposition format].
 ///
 /// [exposition format]: https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-format-details
-pub fn write_type_line(buffer: &mut String, name: &str, metric_type: &str) {
+pub fn write_type_line(buffer: &mut String, name: &str, unit: Option<Unit>, metric_type: &str) {
     buffer.push_str("# TYPE ");
     buffer.push_str(name);
+    if let Some(unit) = unit {
+        buffer.push('_');
+        buffer.push_str(unit.as_str());
+    }
     buffer.push(' ');
     buffer.push_str(metric_type);
     buffer.push('\n');

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -119,11 +119,12 @@ impl Inner {
 
         for (name, mut by_labels) in counters.drain() {
             let unit = descriptions.get(name.as_str()).and_then(|(desc, unit)| {
-                write_help_line(&mut output, name.as_str(), desc);
-                *unit
+                let unit = unit.filter(|_| self.enable_unit_suffix);
+                write_help_line(&mut output, name.as_str(), unit, desc);
+                unit
             });
 
-            write_type_line(&mut output, name.as_str(), "counter");
+            write_type_line(&mut output, name.as_str(), unit, "counter");
             for (labels, value) in by_labels.drain() {
                 write_metric_line::<&str, u64>(
                     &mut output,
@@ -132,7 +133,7 @@ impl Inner {
                     &labels,
                     None,
                     value,
-                    unit.filter(|_| self.enable_unit_suffix),
+                    unit,
                 );
             }
             output.push('\n');
@@ -140,11 +141,12 @@ impl Inner {
 
         for (name, mut by_labels) in gauges.drain() {
             let unit = descriptions.get(name.as_str()).and_then(|(desc, unit)| {
-                write_help_line(&mut output, name.as_str(), desc);
-                *unit
+                let unit = unit.filter(|_| self.enable_unit_suffix);
+                write_help_line(&mut output, name.as_str(), unit, desc);
+                unit
             });
 
-            write_type_line(&mut output, name.as_str(), "gauge");
+            write_type_line(&mut output, name.as_str(), unit, "gauge");
             for (labels, value) in by_labels.drain() {
                 write_metric_line::<&str, f64>(
                     &mut output,
@@ -153,7 +155,7 @@ impl Inner {
                     &labels,
                     None,
                     value,
-                    unit.filter(|_| self.enable_unit_suffix),
+                    unit,
                 );
             }
             output.push('\n');
@@ -161,12 +163,13 @@ impl Inner {
 
         for (name, mut by_labels) in distributions.drain() {
             let unit = descriptions.get(name.as_str()).and_then(|(desc, unit)| {
-                write_help_line(&mut output, name.as_str(), desc);
-                *unit
+                let unit = unit.filter(|_| self.enable_unit_suffix);
+                write_help_line(&mut output, name.as_str(), unit, desc);
+                unit
             });
 
             let distribution_type = self.distribution_builder.get_distribution_type(name.as_str());
-            write_type_line(&mut output, name.as_str(), distribution_type);
+            write_type_line(&mut output, name.as_str(), unit, distribution_type);
             for (labels, distribution) in by_labels.drain(..) {
                 let (sum, count) = match distribution {
                     Distribution::Summary(summary, quantiles, sum) => {
@@ -180,7 +183,7 @@ impl Inner {
                                 &labels,
                                 Some(("quantile", quantile.value())),
                                 value,
-                                unit.filter(|_| self.enable_unit_suffix),
+                                unit,
                             );
                         }
 
@@ -195,7 +198,7 @@ impl Inner {
                                 &labels,
                                 Some(("le", le)),
                                 count,
-                                unit.filter(|_| self.enable_unit_suffix),
+                                unit,
                             );
                         }
                         write_metric_line(
@@ -205,7 +208,7 @@ impl Inner {
                             &labels,
                             Some(("le", "+Inf")),
                             histogram.count(),
-                            unit.filter(|_| self.enable_unit_suffix),
+                            unit,
                         );
 
                         (histogram.sum(), histogram.count())
@@ -219,7 +222,7 @@ impl Inner {
                     &labels,
                     None,
                     sum,
-                    unit.filter(|_| self.enable_unit_suffix),
+                    unit,
                 );
                 write_metric_line::<&str, u64>(
                     &mut output,
@@ -228,7 +231,7 @@ impl Inner {
                     &labels,
                     None,
                     count,
-                    unit.filter(|_| self.enable_unit_suffix),
+                    unit,
                 );
             }
 

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -24,7 +24,7 @@ pub(crate) struct Inner {
     pub descriptions: RwLock<HashMap<String, (SharedString, Option<Unit>)>>,
     pub global_labels: IndexMap<String, String>,
     pub enable_unit_suffix: bool,
-    pub enable_compat_counter_names: bool,
+    pub counter_suffix: Option<&'static str>,
 }
 
 impl Inner {
@@ -129,7 +129,7 @@ impl Inner {
                 write_metric_line::<&str, u64>(
                     &mut output,
                     &name,
-                    Some("total").filter(|_| self.enable_compat_counter_names),
+                    self.counter_suffix,
                     &labels,
                     None,
                     value,

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -24,6 +24,7 @@ pub(crate) struct Inner {
     pub descriptions: RwLock<HashMap<String, (SharedString, Option<Unit>)>>,
     pub global_labels: IndexMap<String, String>,
     pub enable_unit_suffix: bool,
+    pub enable_compat_counter_names: bool,
 }
 
 impl Inner {
@@ -127,7 +128,7 @@ impl Inner {
                 write_metric_line::<&str, u64>(
                     &mut output,
                     &name,
-                    None,
+                    Some("total").filter(|_| self.enable_compat_counter_names),
                     &labels,
                     None,
                     value,


### PR DESCRIPTION
This commit adds a setting to PrometheusBuilder to add the '_total' suffix to counter names, compatible with [Prometheus naming best practices](https://prometheus.io/docs/practices/naming/).

This is useful for migrating from the [prometheus-client] crate, (where the counter suffix is enforced) without breaking existing dashboards.

[prometheus-client](https://docs.rs/prometheus-client/latest/prometheus_client/)