### PR TITLE
fix: ensure counter metrics include _total suffix in HELP and TYPE lines

### DIFF
--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -120,11 +120,11 @@ impl Inner {
         for (name, mut by_labels) in counters.drain() {
             let unit = descriptions.get(name.as_str()).and_then(|(desc, unit)| {
                 let unit = unit.filter(|_| self.enable_unit_suffix);
-                write_help_line(&mut output, name.as_str(), unit, desc);
+                write_help_line(&mut output, name.as_str(), unit, self.counter_suffix, desc);
                 unit
             });
 
-            write_type_line(&mut output, name.as_str(), unit, "counter");
+            write_type_line(&mut output, name.as_str(), unit, self.counter_suffix, "counter");
             for (labels, value) in by_labels.drain() {
                 write_metric_line::<&str, u64>(
                     &mut output,
@@ -142,11 +142,11 @@ impl Inner {
         for (name, mut by_labels) in gauges.drain() {
             let unit = descriptions.get(name.as_str()).and_then(|(desc, unit)| {
                 let unit = unit.filter(|_| self.enable_unit_suffix);
-                write_help_line(&mut output, name.as_str(), unit, desc);
+                write_help_line(&mut output, name.as_str(), unit, None, desc);
                 unit
             });
 
-            write_type_line(&mut output, name.as_str(), unit, "gauge");
+            write_type_line(&mut output, name.as_str(), unit, None, "gauge");
             for (labels, value) in by_labels.drain() {
                 write_metric_line::<&str, f64>(
                     &mut output,
@@ -164,12 +164,12 @@ impl Inner {
         for (name, mut by_labels) in distributions.drain() {
             let unit = descriptions.get(name.as_str()).and_then(|(desc, unit)| {
                 let unit = unit.filter(|_| self.enable_unit_suffix);
-                write_help_line(&mut output, name.as_str(), unit, desc);
+                write_help_line(&mut output, name.as_str(), unit, None, desc);
                 unit
             });
 
             let distribution_type = self.distribution_builder.get_distribution_type(name.as_str());
-            write_type_line(&mut output, name.as_str(), unit, distribution_type);
+            write_type_line(&mut output, name.as_str(), unit, None, distribution_type);
             for (labels, distribution) in by_labels.drain(..) {
                 let (sum, count) = match distribution {
                     Distribution::Summary(summary, quantiles, sum) => {


### PR DESCRIPTION
Following #596 

The Prometheus exporter now properly appends the _total suffix to counter metric names in both help text and type declarations, ensuring consistency with Prometheus naming conventions.

This also makes the python `prometheus_client.parser.text_string_to_metric_families` parse the metrics better.

Even though not mandatory by the exposition format, I've seen the prometheus go client append these suffixes to both HELP and TYPE lines. For example see:

```bash
docker run -d --rm -p 9090:9090 prom/prometheus
curl http://localhost:9090/metrics
```