### PR TITLE
fix clippy warnings

### DIFF
--- a/metrics-exporter-dogstatsd/src/builder.rs
+++ b/metrics-exporter-dogstatsd/src/builder.rs
@@ -435,7 +435,7 @@ mod tests {
             DogStatsDBuilder::default().with_aggregation_mode(AggregationMode::Aggressive);
         assert_eq!(builder.get_flush_interval(), DEFAULT_FLUSH_INTERVAL_AGGRESSIVE);
 
-        let custom_flush_interval = Duration::from_millis(123456789);
+        let custom_flush_interval = Duration::from_millis(123_456_789);
         let builder = DogStatsDBuilder::default().with_flush_interval(custom_flush_interval);
         assert_eq!(builder.get_flush_interval(), custom_flush_interval);
     }
@@ -461,9 +461,7 @@ mod tests {
         assert_eq!(
             builder.unwrap_err(),
             BuildError::InvalidConfiguration {
-                reason: format!(
-                    "maximum payload length (65528 bytes) exceeds UDP datagram maximum length (65527 bytes)"
-                )
+                reason: "maximum payload length (65528 bytes) exceeds UDP datagram maximum length (65527 bytes)".to_string()
             }
         );
     }
@@ -522,9 +520,7 @@ mod tests {
             assert_eq!(
                 builder.unwrap_err(),
                 BuildError::InvalidConfiguration {
-                    reason: format!(
-                        "maximum payload length (4294967296 bytes) exceeds theoretical upper bound (4294967295 bytes)"
-                    )
+                    reason: "maximum payload length (4294967296 bytes) exceeds theoretical upper bound (4294967295 bytes)".to_string()
                 }
             );
         }

--- a/metrics-exporter-dogstatsd/src/writer.rs
+++ b/metrics-exporter-dogstatsd/src/writer.rs
@@ -644,7 +644,7 @@ mod tests {
             (
                 Key::from("test_counter"),
                 666,
-                Some(345678),
+                Some(345_678),
                 None,
                 &[],
                 "test_counter:666|c|T345678\n",
@@ -660,7 +660,7 @@ mod tests {
             (
                 Key::from_parts("test_counter", &[("foo", "bar"), ("baz", "quux")]),
                 777,
-                Some(234567),
+                Some(234_567),
                 None,
                 &[],
                 "test_counter:777|c|#foo:bar,baz:quux|T234567\n",
@@ -668,7 +668,7 @@ mod tests {
             (
                 Key::from_parts("test_counter", &[("foo", "bar"), ("baz", "quux")]),
                 777,
-                Some(234567),
+                Some(234_567),
                 Some("server1"),
                 &[],
                 "server1.test_counter:777|c|#foo:bar,baz:quux|T234567\n",
@@ -676,7 +676,7 @@ mod tests {
             (
                 Key::from_parts("test_counter", &[("foo", "bar"), ("baz", "quux")]),
                 777,
-                Some(234567),
+                Some(234_567),
                 None,
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
                 "test_counter:777|c|#foo:bar,baz:quux,gfoo:bar,gbaz:quux|T234567\n",
@@ -684,7 +684,7 @@ mod tests {
             (
                 Key::from_parts("test_counter", &[("foo", "bar"), ("baz", "quux")]),
                 777,
-                Some(234567),
+                Some(234_567),
                 Some("server1"),
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
                 "server1.test_counter:777|c|#foo:bar,baz:quux,gfoo:bar,gbaz:quux|T234567\n",
@@ -709,7 +709,7 @@ mod tests {
             (
                 Key::from("test_gauge"),
                 1967.0,
-                Some(345678),
+                Some(345_678),
                 None,
                 &[],
                 "test_gauge:1967.0|g|T345678\n",
@@ -725,7 +725,7 @@ mod tests {
             (
                 Key::from_parts("test_gauge", &[("foo", "bar"), ("baz", "quux")]),
                 3.13232,
-                Some(234567),
+                Some(234_567),
                 None,
                 &[],
                 "test_gauge:3.13232|g|#foo:bar,baz:quux|T234567\n",
@@ -733,7 +733,7 @@ mod tests {
             (
                 Key::from_parts("test_gauge", &[("foo", "bar"), ("baz", "quux")]),
                 3.13232,
-                Some(234567),
+                Some(234_567),
                 Some("server1"),
                 &[],
                 "server1.test_gauge:3.13232|g|#foo:bar,baz:quux|T234567\n",
@@ -741,7 +741,7 @@ mod tests {
             (
                 Key::from_parts("test_gauge", &[("foo", "bar"), ("baz", "quux")]),
                 3.13232,
-                Some(234567),
+                Some(234_567),
                 None,
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
                 "test_gauge:3.13232|g|#foo:bar,baz:quux,gfoo:bar,gbaz:quux|T234567\n",
@@ -749,7 +749,7 @@ mod tests {
             (
                 Key::from_parts("test_gauge", &[("foo", "bar"), ("baz", "quux")]),
                 3.13232,
-                Some(234567),
+                Some(234_567),
                 Some("server1"),
                 &[Label::new("gfoo", "bar"), Label::new("gbaz", "quux")][..],
                 "server1.test_gauge:3.13232|g|#foo:bar,baz:quux,gfoo:bar,gbaz:quux|T234567\n",

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -272,7 +272,7 @@ mod tests {
                             ),
                             None,
                             None,
-                            DebugValue::Gauge(OrderedFloat(456.0 as f64))
+                            DebugValue::Gauge(OrderedFloat(456.0))
                         ),
                         (
                             CompositeKey::new(
@@ -284,7 +284,7 @@ mod tests {
                             ),
                             None,
                             None,
-                            DebugValue::Gauge(OrderedFloat(654.0 as f64))
+                            DebugValue::Gauge(OrderedFloat(654.0))
                         ),
                         (
                             CompositeKey::new(


### PR DESCRIPTION
If you have the latest version of Rust installed locally, clippy raises some warnings which are fixed in this PR.