### PR TITLE
Upgrade hashbrown to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,7 +700,16 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -885,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1063,7 +1078,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1213,7 +1228,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "getopts",
- "hashbrown",
+ "hashbrown 0.16.0",
  "hdrhistogram",
  "indexmap",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ crossbeam-epoch = { version = "0.9", default-features = false }
 crossbeam-queue = { version = "0.3", default-features = false, features = ["std"] }
 crossbeam-utils = { version = "0.8", default-features = false }
 getopts = { version = "0.2", default-features = false }
-hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "raw-entry"] }
+hashbrown = { version = "0.16", default-features = false, features = ["default-hasher", "raw-entry"] }
 hdrhistogram = { version = "7.2", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper = { version = "1.1", default-features = false, features = ["server", "client"] }


### PR DESCRIPTION
I can see that there's a Dependabot config, but the last actual Dependabot PR seems to be #544, from a year ago.

See here:

https://github.com/metrics-rs/metrics/pulls?q=is%3Apr+label%3Adependencies+sort%3Aupdated-desc

In any case, would be nice to keep dependencies up to date. I can probably take care of some of the other ones if this is merged:

- [ ] itertools
- [ ] mockall
- [ ] ordered-float
- [ ] prost
- [ ] radix_trie
- [ ] ratatui
- [ ] critertion (currently at `=0.3.3` -- not sure why?)