### PR TITLE
fix std Cow conversion being Sized #581

### DIFF
--- a/metrics/src/cow.rs
+++ b/metrics/src/cow.rs
@@ -324,7 +324,7 @@ impl<'a> From<std::borrow::Cow<'a, str>> for Cow<'a, str> {
     }
 }
 
-impl<'a, T: Cowable> From<Cow<'a, T>> for std::borrow::Cow<'a, T> {
+impl<'a, T: Cowable + ?Sized> From<Cow<'a, T>> for std::borrow::Cow<'a, T> {
     #[inline]
     fn from(value: Cow<'a, T>) -> Self {
         match value.metadata.kind() {


### PR DESCRIPTION
fixes #581 

(would be nice to also have a way to turn KeyName into a Cow)