### PR TITLE
fix broken native histograms serialization

### DIFF
--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -77,7 +77,7 @@ prost-build = { workspace = true, optional = true }
 
 [[example]]
 name = "native_histograms"
-required-features = ["http-listener"]
+required-features = ["http-listener", "protobuf"]
 
 [[example]]
 name = "prometheus_push_gateway"

--- a/metrics-exporter-prometheus/src/protobuf.rs
+++ b/metrics-exporter-prometheus/src/protobuf.rs
@@ -164,6 +164,7 @@ pub(crate) fn render_protobuf(
                     }
                 }
                 Distribution::NativeHistogram(native_hist) => {
+                    metric_type = Some(pb::MetricType::Histogram);
                     // Convert our native histogram into Prometheus native histogram format
                     let positive_buckets = native_hist.positive_buckets();
                     let negative_buckets = native_hist.negative_buckets();


### PR DESCRIPTION
Running the official example for native histograms always returns empty response on the metrics protobuf endpoint:
```
> cargo run --example native_histograms --features="http-listener protobuf"
Recording metrics... Check http://127.0.0.1:9000/metrics
Native histograms will only be visible in protobuf format.
Try: curl -H 'Accept: application/vnd.google.protobuf' http://127.0.0.1:9000/metrics
Recorded 1 samples
Recorded 101 samples
Recorded 201 samples
Recorded 301 samples
Recorded 401 samples
Recorded 501 samples
Recorded 601 samples
Recorded 701 samples
Recorded 801 samples
Recorded 901 samples
Metrics server will continue running. Access http://127.0.0.1:9000/metrics
```

```
❯  curl -H 'Accept: application/vnd.google.protobuf' http://127.0.0.1:9000/metrics -v
*   Trying 127.0.0.1:9000...
* Connected to 127.0.0.1 (127.0.0.1) port 9000
> GET /metrics HTTP/1.1
> Host: 127.0.0.1:9000
> User-Agent: curl/8.7.1
> Accept: application/vnd.google.protobuf
>
* Request completely sent off
< HTTP/1.1 200 OK
< content-type: application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited
< content-length: 0
< date: Sat, 06 Dec 2025 19:26:00 GMT
<
* Connection #0 to host 127.0.0.1 left intact
```

This is caused by not setting the `metric_type` to `Histogram` so it skipped when encoding protobuf.
