### PR TITLE
metrics-util: Impl Storage<K> for Arc<T>

### DIFF
--- a/metrics-util/src/registry/mod.rs
+++ b/metrics-util/src/registry/mod.rs
@@ -208,6 +208,12 @@ where
             shard_write.retain(|k, h| f(k, h));
         }
     }
+
+    #[inline(always)]
+    /// Accesses reference to the underlying storage
+    pub fn storage(&self) -> &S {
+        &self.storage
+    }
 }
 
 impl<K, S> Registry<K, S>

--- a/metrics-util/src/registry/storage.rs
+++ b/metrics-util/src/registry/storage.rs
@@ -25,6 +25,25 @@ pub trait Storage<K> {
     fn histogram(&self, key: &K) -> Self::Histogram;
 }
 
+impl<K, T: Storage<K>> Storage<K> for Arc<T> {
+    type Counter = T::Counter;
+    type Gauge = T::Gauge;
+    type Histogram = T::Histogram;
+
+    #[inline(always)]
+    fn gauge(&self, key: &K) -> Self::Gauge {
+        Storage::gauge(&**self, key)
+    }
+    #[inline(always)]
+    fn counter(&self, key: &K) -> Self::Counter {
+        Storage::counter(&**self, key)
+    }
+    #[inline(always)]
+    fn histogram(&self, key: &K) -> Self::Histogram {
+        Storage::histogram(&**self, key)
+    }
+}
+
 /// Atomic metric storage.
 ///
 /// Utilizes atomics for storing the value(s) of a given metric.  Shared access to the actual atomic


### PR DESCRIPTION
Subject
This will allow user to just wrap his storage into Arc in case he needs to access metadata shared between `Recorder` and `Storage` without need of internally wrapping `Storage` into `Arc`