### PR TITLE
perf: use write! macro in write_metric_line

### DIFF
--- a/metrics-exporter-prometheus/src/formatting.rs
+++ b/metrics-exporter-prometheus/src/formatting.rs
@@ -88,7 +88,7 @@ pub fn write_metric_line<T, T2>(
         buffer.push('}');
     }
 
-    let _ = write!(buffer, " {value}\n");
+    let _ = writeln!(buffer, " {value}");
 }
 
 fn add_metric_name(

--- a/metrics-exporter-prometheus/src/formatting.rs
+++ b/metrics-exporter-prometheus/src/formatting.rs
@@ -1,5 +1,7 @@
 //! Helpers for rendering metrics in the Prometheus exposition format.
 
+use std::fmt::Write;
+
 use metrics::Unit;
 
 use crate::common::LabelSet;
@@ -59,6 +61,8 @@ pub fn write_metric_line<T, T2>(
     T: std::fmt::Display,
     T2: std::fmt::Display,
 {
+    buffer.reserve(name.len() + 128);
+
     add_metric_name(buffer, name, unit, suffix);
 
     if !labels.is_empty() || additional_label.is_some() {
@@ -78,18 +82,13 @@ pub fn write_metric_line<T, T2>(
             if !first {
                 buffer.push(',');
             }
-            buffer.push_str(name);
-            buffer.push_str("=\"");
-            buffer.push_str(value.to_string().as_str());
-            buffer.push('"');
+            let _ = write!(buffer, "{name}=\"{value}\"");
         }
 
         buffer.push('}');
     }
 
-    buffer.push(' ');
-    buffer.push_str(value.to_string().as_str());
-    buffer.push('\n');
+    let _ = write!(buffer, " {value}\n");
 }
 
 fn add_metric_name(


### PR DESCRIPTION
Avoids intermediate String allocations from to_string() calls by writing directly to the buffer with the write! macro.