### PR TITLE
feat(prometheus): add render_protobuf_to_write function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",


### PR DESCRIPTION
In the same vein as #641, this patch introduces a new `render_protobuf_to_write` function, which can be used to stream metrics in chunks in protobuf format, avoiding buffering the entire set of metrics into a single byte buffer.