### PR TITLE
feat(metrics-util): Expose true count and sum on Drain for reservoir sampling

### DIFF
--- a/metrics-util/src/storage/reservoir.rs
+++ b/metrics-util/src/storage/reservoir.rs
@@ -214,3 +214,78 @@ impl AtomicSamplingReservoir {
         f(drain);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_under_capacity_no_overflow() {
+        let reservoir = AtomicSamplingReservoir::new(64);
+
+        for i in 0..10 {
+            reservoir.push(i as f64);
+        }
+
+        reservoir.consume(|drain| {
+            assert_eq!(drain.unsampled_len(), 10);
+            assert_eq!(drain.unsampled_sum(), 45.0);
+            assert_eq!(drain.sample_rate(), 1.0);
+
+            let collected: Vec<f64> = drain.collect();
+            assert_eq!(collected.len(), 10);
+        });
+    }
+
+    #[test]
+    fn test_overflow_unsampled_len_and_sum_are_true_values() {
+        let reservoir = AtomicSamplingReservoir::new(16);
+
+        for i in 0..1000 {
+            reservoir.push(i as f64);
+        }
+
+        reservoir.consume(|drain| {
+            assert_eq!(drain.unsampled_len(), 1000);
+            assert_eq!(drain.unsampled_sum(), 499500.0);
+            assert!(drain.sample_rate() < 1.0);
+
+            let collected: Vec<f64> = drain.collect();
+            assert_eq!(collected.len(), 16);
+
+            let sampled_sum: f64 = collected.iter().sum();
+            assert!(sampled_sum < 499500.0);
+        });
+    }
+
+    #[test]
+    fn test_reset_after_drain() {
+        let reservoir = AtomicSamplingReservoir::new(64);
+
+        for i in 0..100 {
+            reservoir.push(i as f64);
+        }
+
+        reservoir.consume(|_drain| {
+        });
+
+        for i in 0..50 {
+            reservoir.push(i as f64);
+        }
+
+        reservoir.consume(|drain| {
+            assert_eq!(drain.unsampled_len(), 50);
+            assert_eq!(drain.unsampled_sum(), 1225.0);
+        });
+    }
+
+    #[test]
+    fn test_empty_reservoir() {
+        let reservoir = AtomicSamplingReservoir::new(64);
+
+        reservoir.consume(|drain| {
+            assert_eq!(drain.unsampled_len(), 0);
+            assert_eq!(drain.unsampled_sum(), 0.0);
+        });
+    }
+}

--- a/metrics-util/src/storage/reservoir.rs
+++ b/metrics-util/src/storage/reservoir.rs
@@ -73,6 +73,12 @@ pub struct Drain<'a> {
 }
 
 impl<'a> Drain<'a> {
+    /// Returns the total number of samples pushed into the reservoir,
+    /// including those that were dropped by the sampling algorithm.
+    pub fn unsampled_len(&self) -> usize {
+        self.unsampled_len
+    }
+
     /// Returns the sample rate of the reservoir that produced this iterator.
     ///
     /// The sample rate is the ratio of the number of samples pushed into the reservoir to the number of samples held in

--- a/metrics-util/src/storage/reservoir.rs
+++ b/metrics-util/src/storage/reservoir.rs
@@ -33,6 +33,7 @@ fn fastrand(upper: usize) -> usize {
 struct Reservoir {
     values: Box<[AtomicU64]>,
     count: AtomicUsize,
+    unsampled_sum: AtomicU64,
 }
 
 impl Reservoir {
@@ -42,7 +43,11 @@ impl Reservoir {
             values.push(AtomicU64::new(0));
         }
 
-        Self { values: values.into_boxed_slice(), count: AtomicUsize::new(0) }
+        Self {
+            values: values.into_boxed_slice(),
+            count: AtomicUsize::new(0),
+            unsampled_sum: AtomicU64::new(0.0f64.to_bits()),
+        }
     }
 
     fn push(&self, value: f64) {
@@ -55,12 +60,22 @@ impl Reservoir {
                 self.values[maybe_idx].store(value.to_bits(), Relaxed);
             }
         }
+
+        loop {
+            let result = self.unsampled_sum.fetch_update(Relaxed, Relaxed, |curr| {
+                Some((f64::from_bits(curr) + value).to_bits())
+            });
+            if result.is_ok() {
+                break;
+            }
+        }
     }
 
     fn drain(&self) -> Drain<'_> {
         let unsampled_len = self.count.load(Relaxed);
         let len = if unsampled_len > self.values.len() { self.values.len() } else { unsampled_len };
-        Drain { reservoir: self, unsampled_len, len, idx: 0 }
+        let unsampled_sum = f64::from_bits(self.unsampled_sum.load(Relaxed));
+        Drain { reservoir: self, unsampled_len, len, idx: 0, unsampled_sum }
     }
 }
 
@@ -70,6 +85,7 @@ pub struct Drain<'a> {
     unsampled_len: usize,
     len: usize,
     idx: usize,
+    unsampled_sum: f64,
 }
 
 impl<'a> Drain<'a> {
@@ -94,6 +110,12 @@ impl<'a> Drain<'a> {
         } else {
             self.len as f64 / self.unsampled_len as f64
         }
+    }
+
+    /// Returns the sum of all samples pushed into the reservoir,
+    /// including those that were dropped by the sampling algorithm.
+    pub fn unsampled_sum(&self) -> f64 {
+        self.unsampled_sum
     }
 }
 
@@ -120,6 +142,7 @@ impl ExactSizeIterator for Drain<'_> {
 impl<'a> Drop for Drain<'a> {
     fn drop(&mut self) {
         self.reservoir.count.store(0, Release);
+        self.reservoir.unsampled_sum.store(0.0f64.to_bits(), Release);
     }
 }
 

--- a/metrics-util/src/storage/reservoir.rs
+++ b/metrics-util/src/storage/reservoir.rs
@@ -266,8 +266,7 @@ mod tests {
             reservoir.push(i as f64);
         }
 
-        reservoir.consume(|_drain| {
-        });
+        reservoir.consume(|_drain| {});
 
         for i in 0..50 {
             reservoir.push(i as f64);


### PR DESCRIPTION
## Summary

Expose two public methods on `Drain` that let downstream consumers recover accurate aggregate statistics when reservoir sampling drops values:

- **`Drain::unsampled_len()`** — returns the total number of samples pushed into the reservoir, including those dropped by sampling. The field was already tracked internally; this just adds a public getter.
- **`Drain::unsampled_sum()`** — returns the true sum of all pushed samples, including dropped ones. Atomically accumulated in `Reservoir::push()` using a `fetch_update` CAS loop on `AtomicU64` (same pattern as `GaugeFn::increment` in `metrics/src/atomics.rs`). Reset in `Drain::drop()` alongside the existing count reset.

## Motivation

When the reservoir overflows, downstream consumers draining the samples only see the sampled subset. A consumer naively counting or summing values in the drain loop would get results capped at reservoir capacity — not the true totals. For example, pushing 1000 values into a 16-slot reservoir means the drain yields only 16 samples, so a naive count gives 16 and a naive sum covers only those 16 retained values, while the true count is 1000 and the true sum is 499,500.

Previously, the only way to recover the true count was `drained_count / sample_rate`, which is a lossy float round-trip. There was no way to recover the true sum at all.

## Tests

Unit tests covering: under-capacity (no sampling), overflow (proving true values survive), reset-after-drain (A/B buffer reuse), and empty reservoir.