### PR TITLE
chore(metrics-exporter-prometheus): update license to reflect prom protobuf schema

### DIFF
--- a/metrics-exporter-prometheus/Cargo.toml
+++ b/metrics-exporter-prometheus/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 rust-version = { workspace = true }
 
 description = "A metrics-compatible exporter for sending metrics to Prometheus."
-license = { workspace = true }
+license = "MIT AND Apache-2.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
## Context

This PR updates the license for the `metrics-exporter-prometheus` crate to reflect that the code is licensed under MIT (all the actual Rust source) _and_ Apache 2.0 (Prometheus protobuf schema).

Closes #677.