### PR TITLE
feat: make key retention more efficient

### DIFF
--- a/metrics-benchmark/src/main.rs
+++ b/metrics-benchmark/src/main.rs
@@ -69,15 +69,18 @@ impl Recorder for BenchmarkingRecorder {
     fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
 
     fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
-        self.registry.get_or_create_counter(key, |c| Counter::from_arc(c.clone()))
+        let key = key.to_retained();
+        self.registry.get_or_create_counter(&key, |c| Counter::from_arc(c.clone()))
     }
 
     fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
-        self.registry.get_or_create_gauge(key, |g| Gauge::from_arc(g.clone()))
+        let key = key.to_retained();
+        self.registry.get_or_create_gauge(&key, |g| Gauge::from_arc(g.clone()))
     }
 
     fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
-        self.registry.get_or_create_histogram(key, |h| Histogram::from_arc(h.clone()))
+        let key = key.to_retained();
+        self.registry.get_or_create_histogram(&key, |h| Histogram::from_arc(h.clone()))
     }
 }
 

--- a/metrics-exporter-dogstatsd/src/recorder.rs
+++ b/metrics-exporter-dogstatsd/src/recorder.rs
@@ -21,20 +21,23 @@ impl Recorder for DogStatsDRecorder {
     fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
 
     fn register_counter(&self, key: &Key, _: &Metadata<'_>) -> Counter {
+        let key = key.to_retained();
         self.state
             .registry()
-            .get_or_create_counter(key, |existing| Counter::from_arc(Arc::clone(existing)))
+            .get_or_create_counter(&key, |existing| Counter::from_arc(Arc::clone(existing)))
     }
 
     fn register_gauge(&self, key: &Key, _: &Metadata<'_>) -> Gauge {
+        let key = key.to_retained();
         self.state
             .registry()
-            .get_or_create_gauge(key, |existing| Gauge::from_arc(Arc::clone(existing)))
+            .get_or_create_gauge(&key, |existing| Gauge::from_arc(Arc::clone(existing)))
     }
 
     fn register_histogram(&self, key: &Key, _: &Metadata<'_>) -> Histogram {
+        let key = key.to_retained();
         self.state
             .registry()
-            .get_or_create_histogram(key, |existing| Histogram::from_arc(Arc::clone(existing)))
+            .get_or_create_histogram(&key, |existing| Histogram::from_arc(Arc::clone(existing)))
     }
 }

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -380,15 +380,18 @@ impl Recorder for PrometheusRecorder {
     }
 
     fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
-        self.inner.registry.get_or_create_counter(key, |c| c.clone().into())
+        let key = key.to_retained();
+        self.inner.registry.get_or_create_counter(&key, |c| c.clone().into())
     }
 
     fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
-        self.inner.registry.get_or_create_gauge(key, |c| c.clone().into())
+        let key = key.to_retained();
+        self.inner.registry.get_or_create_gauge(&key, |c| c.clone().into())
     }
 
     fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
-        self.inner.registry.get_or_create_histogram(key, |c| c.clone().into())
+        let key = key.to_retained();
+        self.inner.registry.get_or_create_histogram(&key, |c| c.clone().into())
     }
 }
 

--- a/metrics-util/src/debugging.rs
+++ b/metrics-util/src/debugging.rs
@@ -193,24 +193,27 @@ impl Recorder for DebuggingRecorder {
     }
 
     fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
+        let key = key.to_retained();
         let ckey = CompositeKey::new(MetricKind::Counter, key.clone());
         self.track_metric(ckey);
 
-        self.inner.registry.get_or_create_counter(key, |c| Counter::from_arc(c.clone()))
+        self.inner.registry.get_or_create_counter(&key, |c| Counter::from_arc(c.clone()))
     }
 
     fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+        let key = key.to_retained();
         let ckey = CompositeKey::new(MetricKind::Gauge, key.clone());
         self.track_metric(ckey);
 
-        self.inner.registry.get_or_create_gauge(key, |g| Gauge::from_arc(g.clone()))
+        self.inner.registry.get_or_create_gauge(&key, |g| Gauge::from_arc(g.clone()))
     }
 
     fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+        let key = key.to_retained();
         let ckey = CompositeKey::new(MetricKind::Histogram, key.clone());
         self.track_metric(ckey);
 
-        self.inner.registry.get_or_create_histogram(key, |h| Histogram::from_arc(h.clone()))
+        self.inner.registry.get_or_create_histogram(&key, |h| Histogram::from_arc(h.clone()))
     }
 }
 

--- a/metrics/src/cow.rs
+++ b/metrics/src/cow.rs
@@ -205,6 +205,18 @@ where
     }
 }
 
+impl<T> Cow<'static, [T]>
+where
+    T: Clone,
+{
+    pub(crate) fn to_retained(&self) -> Self {
+        match self.metadata.kind() {
+            Kind::Borrowed | Kind::Shared => self.clone(),
+            Kind::Owned => Cow::from_shared(Arc::<[T]>::from(self.deref())),
+        }
+    }
+}
+
 impl<'a> Cow<'a, str> {
     pub const fn const_str(val: &'a str) -> Self {
         // SAFETY: We can never create a null pointer by casting a reference to a pointer.
@@ -212,6 +224,15 @@ impl<'a> Cow<'a, str> {
         let metadata = Metadata::borrowed(val.len());
 
         Self { ptr, metadata, _lifetime: PhantomData }
+    }
+}
+
+impl Cow<'static, str> {
+    pub(crate) fn to_retained(&self) -> Self {
+        match self.metadata.kind() {
+            Kind::Borrowed | Kind::Shared => self.clone(),
+            Kind::Owned => Cow::from_shared(Arc::<str>::from(self.deref())),
+        }
     }
 }
 
@@ -805,6 +826,37 @@ pub(crate) mod const_cow {
                 assert_eq!(slice[1].key(), "key2");
                 assert_eq!(slice[1].value(), "value2");
             }
+        }
+
+        #[test]
+        fn test_to_retained_str() {
+            let borrowed = Cow::const_str("hello").to_retained();
+            assert!(matches!(borrowed.metadata.kind(), Kind::Borrowed));
+
+            let owned: Cow<'static, str> = Cow::from_owned(String::from("hello"));
+            let retained = owned.to_retained();
+            assert!(matches!(retained.metadata.kind(), Kind::Shared));
+
+            let shared = Cow::from_shared(Arc::<str>::from("hello")).to_retained();
+            assert!(matches!(shared.metadata.kind(), Kind::Shared));
+        }
+
+        #[test]
+        fn test_to_retained_slice() {
+            static LABELS: [Label; 2] = [
+                Label::from_static_parts("key1", "value1"),
+                Label::from_static_parts("key2", "value2"),
+            ];
+
+            let borrowed = Cow::const_slice(&LABELS).to_retained();
+            assert!(matches!(borrowed.metadata.kind(), Kind::Borrowed));
+
+            let owned: Cow<'static, [Label]> = Cow::from_owned(LABELS.to_vec());
+            let retained = owned.to_retained();
+            assert!(matches!(retained.metadata.kind(), Kind::Shared));
+
+            let shared = Cow::from_shared(Arc::<[Label]>::from(&LABELS[..])).to_retained();
+            assert!(matches!(shared.metadata.kind(), Kind::Shared));
         }
     }
 }

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -28,6 +28,15 @@ impl KeyName {
     pub fn into_inner(self) -> SharedString {
         self.0
     }
+
+    /// Returns a version of this name that is cheap to clone for long-lived retention.
+    ///
+    /// *NOTE:* This will allocate if this `KeyName` was created from a non-`'static`
+    /// string, however, the returned `KeyName` will not require allocation when cloned
+    /// or `to_retained` is invoked again.
+    pub fn to_retained(&self) -> Self {
+        KeyName(self.0.to_retained())
+    }
 }
 
 impl<T> From<T> for KeyName
@@ -143,6 +152,15 @@ impl Key {
     /// Consumes this [`Key`], returning the name parts and any labels.
     pub fn into_parts(self) -> (KeyName, Vec<Label>) {
         (self.name, self.labels.into_owned())
+    }
+
+    /// Returns a version of this key that is cheap to clone for long-lived retention.
+    ///
+    /// *NOTE:* This will allocate if this `Key` was created from non-`'static`
+    /// parts, however, the returned `Key` will not require allocation when cloned
+    /// or `to_retained` is invoked again.
+    pub fn to_retained(&self) -> Self {
+        Self { name: self.name.to_retained(), labels: self.labels.to_retained(), hash: self.hash }
     }
 
     /// Clones this [`Key`], and expands the existing set of labels.
@@ -590,5 +608,19 @@ mod tests {
 
         drop(shared);
         assert_eq!(shared_weak.strong_count(), 0);
+    }
+
+    #[test]
+    fn test_key_to_retained_preserves_equality_and_hash() {
+        let key = Key::from_parts(
+            String::from("retained"),
+            vec![Label::new(String::from("service"), String::from("api"))],
+        );
+
+        let retained = key.to_retained();
+
+        assert_eq!(key, retained);
+        assert_eq!(key.get_hash(), retained.get_hash());
+        assert_eq!(retained, retained.clone());
     }
 }


### PR DESCRIPTION
In the export paths for the `metrics-exporter-*` crates present in this repository, the `metrics::key::Key` type necessitates a lot of cloning, which for high-cardinality series, can be quite expensive. This patch aims to reduce that cost by introducing a `retained` mode for keys and their component parts: names and label arrays.

This change has the following key features:

1. `Cow<'static, [T]>` (used for labels) and `Cow<'static, str>` (used for names) have been given a new method `to_retained`, which either clones the contents into a `Shared` variant, or clones the existing `Cow`, preserving its `Shared` or `Borrowed` (static) state.
2. Introduced `KeyName::to_retained` and `Key::to_retained` based on the above new methods, which is intended to be used to save the object for storage in a registry or other long-lived data structure.
3. The metrics exporters that make use of a registry in this crate have been modified to convert the key into a retained key at the boundary of their instantiation.

This will significantly reduce the need for allocations when exporting a large number of metrics, as keys stored in this new retained mode will be efficient to clone.