### PR TITLE
enhancement(metrics): allow specifying description and unit in registration macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crossbeam-channel = { version = "0.5", default-features = false }
 crossbeam-epoch = { version = "0.9", default-features = false }
 crossbeam-queue = { version = "0.3", default-features = false, features = ["std"] }
 crossbeam-utils = { version = "0.8", default-features = false }
-evmap = { version = "11", defualt-features = false }
+evmap = { version = "11", default-features = false }
 getopts = { version = "0.2", default-features = false }
 hashbrown = { version = "0.16", default-features = false, features = ["default-hasher", "raw-entry"] }
 hdrhistogram = { version = "7.2", default-features = false }

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -297,79 +297,6 @@ macro_rules! __register_metric {
     }};
 }
 
-/// Registers a counter with provided description
-///
-///## Usage
-///
-/// ```rust
-/// # #![no_implicit_prelude]
-/// # use ::std::convert::From;
-/// # use ::std::format;
-/// # use ::std::string::String;
-/// # use metrics::create_counter as create_counter;
-/// # fn main() {
-/// // A basic counter:
-/// let counter = create_counter!("some_metric_name");
-/// counter.increment(1);
-///
-/// // A basic counter with labels
-/// let counter = create_counter!("some_metric_name", "label1" => "value2" );
-/// counter.increment(1);
-///
-/// // A counter with description!
-/// let counter = create_counter!(describe: "my super counter", "some_metric_name");
-/// counter.increment(1);
-///
-/// // A counter with description and unit!
-/// let counter = create_counter!(describe: "my super counter", unit: metrics::Unit::Bytes, "some_metric_name");
-/// counter.increment(1);
-///
-/// // A custom level counter with description and unit!
-/// let counter = create_counter!(
-///     describe: "my super counter",
-///     unit: metrics::Unit::Bytes,
-///     level: metrics::Level::INFO,
-///     "some_metric_name",
-/// );
-/// counter.increment(1);
-///
-/// // A custom target counter with description and unit!
-/// let counter = create_counter!(
-///     describe: "my super counter",
-///     unit: metrics::Unit::Bytes,
-///     target: "custom_target",
-///     "some_metric_name",
-/// );
-/// counter.increment(1);
-///
-/// // A counter with description and fancy label, even target module!
-/// let counter = create_counter!(
-///     describe: "my super counter",
-///     unit: metrics::Unit::Bytes,
-///     target: ::core::module_path!(),
-///     level: metrics::Level::INFO,
-///     "some_metric_name",
-///     "label1" => "value1",
-///     "label2" => "value2"
-/// );
-/// counter.increment(1);
-/// # }
-/// ```
-#[macro_export]
-macro_rules! create_counter {
-    ($($input:tt)*) => {
-        $crate::__register_metric!(
-            describe_counter,
-            register_counter,
-            describe = __internal_metric_description_none__,
-            unit = __internal_metric_unit_none__,
-            target = ::core::module_path!(),
-            level = $crate::Level::INFO;
-            $($input)*
-        )
-    };
-}
-
 /// Registers a gauge.
 ///
 /// Gauges represent a single value that can go up or down over time, and always starts out with an
@@ -446,9 +373,8 @@ macro_rules! create_counter {
 /// let gauge = gauge!(name);
 ///
 /// let gauge = gauge!(format!("{}_via_format", "name"));
-///
 /// //Full gauge customization example
-/// let counter = gauge!(
+/// let gauge = gauge!(
 ///     describe: "super gauge",
 ///     unit: metrics::Unit::Bytes,
 ///     target: ::core::module_path!(),
@@ -548,7 +474,7 @@ macro_rules! gauge {
 ///
 /// let histogram = histogram!(format!("{}_via_format", "name"));
 /// //Full histogram customization example
-/// let counter = histogram!(
+/// let histogram = histogram!(
 ///     describe: "super counter",
 ///     unit: metrics::Unit::Bytes,
 ///     target: ::core::module_path!(),

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -68,14 +68,37 @@ macro_rules! key_var {
 /// which includes using macros such as `format!` directly at the callsite. String literals are
 /// preferred for performance where possible.
 ///
+/// # Usage
+///
+/// ```
+/// [opt: value] <$name> [$labels]
+/// ```
+///
+/// Only `$name` is required to initialize metrics.
+///
+/// All `opt`s MUST be specified before `$name` while `$labels` parameter block always go after `$name`
+///
+/// Following is brief explanation of parameters
+///
+/// ## Required parameters
+///
+/// - `$name` - Name of the metric. Can be expression that results in `String` or `&'static str`
+///
 /// ## Optional Parameters
 ///
 /// Following parameters can be provided in any order
 ///
-/// `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
-/// `level:` - Specifies counter level. Defaults to `INFO`.
-/// `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
-/// `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+/// - `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
+/// - `level:` - Specifies counter level. Defaults to `INFO`.
+/// - `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
+/// - `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+///
+/// ## Labels
+///
+/// Labels can be passed as _one_ of following:
+/// - Arbitrary number of `<key> => <value>` where `key` and `value` can be expression that results in `&'static str` or `String`
+/// - Static reference to collection of **Label**
+/// - Collection/iterator that implements [IntoLabels](trait.IntoLabels.html)
 ///
 /// # Example
 /// ```
@@ -361,14 +384,37 @@ macro_rules! create_counter {
 /// which includes using macros such as `format!` directly at the callsite. String literals are
 /// preferred for performance where possible.
 ///
+/// # Usage
+///
+/// ```
+/// [opt: value] <$name> [$labels]
+/// ```
+///
+/// Only `$name` is required to initialize metrics.
+///
+/// All `opt`s MUST be specified before `$name` while `$labels` parameter block always go after `$name`
+///
+/// Following is brief explanation of parameters
+///
+/// ## Required parameters
+///
+/// - `$name` - Name of the metric. Can be expression that results in `String` or `&'static str`
+///
 /// ## Optional Parameters
 ///
 /// Following parameters can be provided in any order
 ///
-/// `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
-/// `level:` - Specifies counter level. Defaults to `INFO`.
-/// `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
-/// `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+/// - `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
+/// - `level:` - Specifies counter level. Defaults to `INFO`.
+/// - `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
+/// - `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+///
+/// ## Labels
+///
+/// Labels can be passed as _one_ of following:
+/// - Arbitrary number of `<key> => <value>` where `key` and `value` can be expression that results in `&'static str` or `String`
+/// - Static reference to collection of **Label**
+/// - Collection/iterator that implements [IntoLabels](trait.IntoLabels.html)
 ///
 /// # Example
 /// ```
@@ -444,14 +490,37 @@ macro_rules! gauge {
 /// which includes using macros such as `format!` directly at the callsite. String literals are
 /// preferred for performance where possible.
 ///
+/// # Usage
+///
+/// ```
+/// [opt: value] <$name> [$labels]
+/// ```
+///
+/// Only `$name` is required to initialize metrics.
+///
+/// All `opt`s MUST be specified before `$name` while `$labels` parameter block always go after `$name`
+///
+/// Following is brief explanation of parameters
+///
+/// ## Required parameters
+///
+/// - `$name` - Name of the metric. Can be expression that results in `String` or `&'static str`
+///
 /// ## Optional Parameters
 ///
 /// Following parameters can be provided in any order
 ///
-/// `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
-/// `level:` - Specifies counter level. Defaults to `INFO`.
-/// `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
-/// `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+/// - `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
+/// - `level:` - Specifies counter level. Defaults to `INFO`.
+/// - `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
+/// - `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+///
+/// ## Labels
+///
+/// Labels can be passed as _one_ of following:
+/// - Arbitrary number of `<key> => <value>` where `key` and `value` can be expression that results in `&'static str` or `String`
+/// - Static reference to collection of **Label**
+/// - Collection/iterator that implements [IntoLabels](trait.IntoLabels.html)
 ///
 /// # Example
 /// ```

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -70,9 +70,7 @@ macro_rules! key_var {
 ///
 /// # Usage
 ///
-/// ```
-/// [opt: value] <$name> [$labels]
-/// ```
+/// `[opt: value,] <$name,> [$labels,]`
 ///
 /// Only `$name` is required to initialize metrics.
 ///
@@ -386,9 +384,7 @@ macro_rules! create_counter {
 ///
 /// # Usage
 ///
-/// ```
-/// [opt: value] <$name> [$labels]
-/// ```
+/// `[opt: value,] <$name,> [$labels,]`
 ///
 /// Only `$name` is required to initialize metrics.
 ///
@@ -492,9 +488,7 @@ macro_rules! gauge {
 ///
 /// # Usage
 ///
-/// ```
-/// [opt: value] <$name> [$labels]
-/// ```
+/// `[opt: value,] <$name,> [$labels,]`
 ///
 /// Only `$name` is required to initialize metrics.
 ///

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -5,7 +5,7 @@ macro_rules! metadata_var {
         static METADATA: $crate::Metadata<'static> = $crate::Metadata::new(
             $target,
             $level,
-            ::core::option::Option::Some(::std::module_path!()),
+            ::core::option::Option::Some(::core::module_path!()),
         );
         &METADATA
     }};
@@ -19,6 +19,28 @@ macro_rules! count {
     };
     ($head:tt $($tail:tt)*) => {
         1usize + $crate::count!($($tail)*)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! internal_target_fallback {
+    ($target:expr) => {{
+        $target
+    }};
+    () => {
+        ::core::module_path!()
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! internal_level_fallback {
+    ($level:expr) => {{
+        $level
+    }};
+    () => {
+        $crate::Level::INFO
     };
 }
 
@@ -115,11 +137,146 @@ macro_rules! counter {
         $crate::counter!(target: $target, level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
     };
     (level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::counter!(target: ::std::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
+        $crate::counter!(target: ::core::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
     };
     ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::counter!(target: ::std::module_path!(), level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+        $crate::counter!(target: ::core::module_path!(), level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
     };
+}
+
+/// Registers a counter with provided description
+///
+/// This is macro useful if you only need to register macro once
+///
+/// ## Example
+///
+/// ```rust
+/// # #![no_implicit_prelude]
+/// # use ::std::convert::From;
+/// # use ::std::format;
+/// # use ::std::string::String;
+/// # use metrics::create_counter;
+/// # fn main() {
+/// // A basic counter:
+/// let counter = create_counter!("some_metric_name");
+/// counter.increment(1);
+///
+/// // A basic counter with labels
+/// let counter = create_counter!("some_metric_name", "label1" => "value2" );
+/// counter.increment(1);
+///
+/// // A counter with description!
+/// let counter = create_counter!(describe: "my super counter", "some_metric_name");
+/// counter.increment(1);
+///
+/// // A counter with description and unit!
+/// let counter = create_counter!(describe: "my super counter", unit: metrics::Unit::Bytes, "some_metric_name");
+/// counter.increment(1);
+///
+/// // A custom level counter with description and unit!
+/// let counter = create_counter!(
+///     describe: "my super counter",
+///     unit: metrics::Unit::Bytes,
+///     level: metrics::Level::INFO,
+///     "some_metric_name",
+/// );
+/// counter.increment(1);
+///
+/// // A custom target counter with description and unit!
+/// let counter = create_counter!(
+///     describe: "my super counter",
+///     unit: metrics::Unit::Bytes,
+///     target: "custom_target",
+///     "some_metric_name",
+/// );
+/// counter.increment(1);
+///
+/// // A counter with description and fancy label, even target module!
+/// let counter = create_counter!(
+///     describe: "my super counter",
+///     unit: metrics::Unit::Bytes,
+///     target: ::core::module_path!(),
+///     level: metrics::Level::INFO,
+///     "some_metric_name",
+///     "label1" => "value1",
+///     "label2" => "value2"
+/// );
+/// counter.increment(1);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! create_counter {
+    (
+        $(describe: $description:expr$(,unit: $unit:expr)?,)?
+        $(target: $target:expr,)?
+        level: $level:expr,
+        $name:expr
+        $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?
+     ) => {{
+        $(
+            $crate::describe!(
+                describe_counter,
+                $name,
+                $( $unit, )?
+                $description
+            );
+        )?
+
+        let metric_key = $crate::key_var!($name $(, $label_key $(=> $label_value)?)*);
+        let metadata = $crate::metadata_var!($crate::internal_target_fallback!($($target)?), $level);
+
+        $crate::with_recorder(|recorder| recorder.register_counter(&metric_key, metadata))
+    }};
+    (
+        $(describe: $description:expr$(,unit: $unit:expr)?,)?
+        $(level: $level:expr,)?
+        target: $target:expr,
+        $($rest:tt)+
+    ) => {{
+        $crate::create_counter!(
+            $(describe: $description$(,unit: $unit)?,)?
+            target: $target,
+            level: $crate::internal_level_fallback!($($level)?),
+            $($rest)+
+        )
+    }};
+    (
+        describe: $description:expr, unit: $unit:expr,
+        $($rest:tt)+
+    ) => {{
+        $crate::create_counter!(
+            describe: $description,
+            unit:$unit,
+            target: ::core::module_path!(),
+            level: $crate::Level::INFO,
+            $($rest)+
+        )
+    }};
+    (
+        $(unit: $unit:expr,)?
+        describe: $description:expr,
+        $($rest:tt)+
+    ) => {{
+        $crate::create_counter!(
+            describe: $description,
+            $(unit: $unit,)?
+            target: ::core::module_path!(),
+            level: $crate::Level::INFO,
+            $($rest)+
+        )
+    }};
+    //Do not use rest:tt here as it can infinitely stuck on some usages
+    (
+        $name:expr
+        $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?
+    ) => {{
+        $crate::create_counter!(
+            target: ::core::module_path!(),
+            level: $crate::Level::INFO,
+            $name
+            $(, $label_key $(=> $label_value)?)*
+        )
+    }}
 }
 
 /// Registers a gauge.
@@ -182,10 +339,10 @@ macro_rules! gauge {
         $crate::gauge!(target: $target, level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
     };
     (level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::gauge!(target: ::std::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
+        $crate::gauge!(target: ::core::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
     };
     ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::gauge!(target: ::std::module_path!(), level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+        $crate::gauge!(target: ::core::module_path!(), level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
     };
 }
 
@@ -246,10 +403,10 @@ macro_rules! histogram {
         $crate::histogram!(target: $target, level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
     };
     (level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::histogram!(target: ::std::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
+        $crate::histogram!(target: ::core::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
     };
     ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::histogram!(target: ::std::module_path!(), level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+        $crate::histogram!(target: ::core::module_path!(), level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
     };
 }
 

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -74,7 +74,7 @@ macro_rules! key_var {
 ///
 /// `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
 /// `level:` - Specifies counter level. Defaults to `INFO`.
-/// `describe:` - Specifies counter description to register for counter. If specified `$name` has to be Copy-able.
+/// `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
 /// `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
 ///
 /// # Example
@@ -367,7 +367,7 @@ macro_rules! create_counter {
 ///
 /// `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
 /// `level:` - Specifies counter level. Defaults to `INFO`.
-/// `describe:` - Specifies counter description to register for counter. If specified `$name` has to be Copy-able.
+/// `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
 /// `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
 ///
 /// # Example
@@ -450,7 +450,7 @@ macro_rules! gauge {
 ///
 /// `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
 /// `level:` - Specifies counter level. Defaults to `INFO`.
-/// `describe:` - Specifies counter description to register for counter. If specified `$name` has to be Copy-able.
+/// `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
 /// `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
 ///
 /// # Example

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -279,6 +279,213 @@ macro_rules! create_counter {
     }}
 }
 
+#[doc(hidden)]
+#[macro_export]
+///Internal macro to register metric description when provided by metric creation macro
+macro_rules! __describe_metric {
+    // Do nothing if metric description is not set
+    ($method:ident, __internal_metric_description_none__, $($rest:tt)*) => {{}};
+    // Found description only
+    ($method:ident, $description:expr, __internal_metric_unit_none__, $name:expr) => {{
+        $crate::with_recorder(|recorder| {
+            recorder.$method(
+                ::core::convert::Into::into($name),
+                ::core::option::Option::None,
+                ::core::convert::Into::into($description),
+            );
+        });
+    }};
+    // Found description + unit
+    ($method:ident, $description:expr, $unit:expr, $name:expr) => {{
+        $crate::with_recorder(|recorder| {
+            recorder.$method(
+                ::core::convert::Into::into($name),
+                ::core::option::Option::Some($unit),
+                ::core::convert::Into::into($description),
+            );
+        });
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_metric {
+    // `target:` — replace the accumulator's `target` slot.
+    (
+        $describe:ident,
+        $register:ident,
+        describe = $description:tt,
+        unit = $unit:tt,
+        target = $_old:expr,
+        level = $level:expr;
+        target: $target:expr,
+        $($rest:tt)*
+    ) => {
+        $crate::__register_metric!(
+            $describe,
+            $register,
+            describe = $description,
+            unit = $unit,
+            target = $target,
+            level = $level;
+            $($rest)*
+        )
+    };
+    // `level:` — replace the accumulator's `level` slot.
+    (
+        $describe:ident,
+        $register:ident,
+        describe = $description:tt,
+        unit = $unit:tt,
+        target = $target:expr,
+        level = $_old:expr;
+        level: $level:expr,
+        $($rest:tt)*
+    ) => {
+        $crate::__register_metric!(
+            $describe,
+            $register,
+            describe = $description,
+            unit = $unit,
+            target = $target,
+            level = $level;
+            $($rest)*
+        )
+    };
+    // `describe:` — replace the accumulator's `describe` slot.
+    (
+        $describe:ident,
+        $register:ident,
+        describe = $old:tt,
+        unit = $unit:tt,
+        target = $target:expr,
+        level = $level:expr;
+        describe: $description:expr,
+        $($rest:tt)*
+    ) => {
+        $crate::__register_metric!(
+            $describe,
+            $register,
+            describe = $description,
+            unit = $unit,
+            target = $target,
+            level = $level;
+            $($rest)*
+        )
+    };
+    // `unit:` — replace the accumulator's `unit` slot.
+    (
+        $describe:ident,
+        $register:ident,
+        describe = $description:tt,
+        unit = $old:tt,
+        target = $target:expr,
+        level = $level:expr;
+        unit: $unit:expr,
+        $($rest:tt)*
+    ) => {
+        $crate::__register_metric!(
+            $describe,
+            $register,
+            describe = $description,
+            unit = $unit,
+            target = $target,
+            level = $level;
+            $($rest)*
+        )
+    };
+    // Terminator — emit the registration call.
+    (
+        $describe:ident,
+        $register:ident,
+        describe = $description:tt,
+        unit = $unit:tt,
+        target = $target:expr,
+        level = $level:expr;
+        $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?
+    ) => {{
+        $crate::__describe_metric!(describe_counter, $description, $unit, $name);
+
+        let metric_key = $crate::key_var!($name $(, $label_key $(=> $label_value)?)*);
+        let metadata = $crate::metadata_var!($target, $level);
+
+        $crate::with_recorder(|recorder| recorder.$register(&metric_key, metadata))
+    }};
+}
+
+/// Registers a counter with provided description
+///
+///## Usage
+///
+/// ```rust
+/// # #![no_implicit_prelude]
+/// # use ::std::convert::From;
+/// # use ::std::format;
+/// # use ::std::string::String;
+/// # use metrics::create_counter2 as create_counter;
+/// # fn main() {
+/// // A basic counter:
+/// let counter = create_counter!("some_metric_name");
+/// counter.increment(1);
+///
+/// // A basic counter with labels
+/// let counter = create_counter!("some_metric_name", "label1" => "value2" );
+/// counter.increment(1);
+///
+/// // A counter with description!
+/// let counter = create_counter!(describe: "my super counter", "some_metric_name");
+/// counter.increment(1);
+///
+/// // A counter with description and unit!
+/// let counter = create_counter!(describe: "my super counter", unit: metrics::Unit::Bytes, "some_metric_name");
+/// counter.increment(1);
+///
+/// // A custom level counter with description and unit!
+/// let counter = create_counter!(
+///     describe: "my super counter",
+///     unit: metrics::Unit::Bytes,
+///     level: metrics::Level::INFO,
+///     "some_metric_name",
+/// );
+/// counter.increment(1);
+///
+/// // A custom target counter with description and unit!
+/// let counter = create_counter!(
+///     describe: "my super counter",
+///     unit: metrics::Unit::Bytes,
+///     target: "custom_target",
+///     "some_metric_name",
+/// );
+/// counter.increment(1);
+///
+/// // A counter with description and fancy label, even target module!
+/// let counter = create_counter!(
+///     describe: "my super counter",
+///     unit: metrics::Unit::Bytes,
+///     target: ::core::module_path!(),
+///     level: metrics::Level::INFO,
+///     "some_metric_name",
+///     "label1" => "value1",
+///     "label2" => "value2"
+/// );
+/// counter.increment(1);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! create_counter2 {
+    ($($input:tt)*) => {
+        $crate::__register_metric!(
+            describe_counter,
+            register_counter,
+            describe = __internal_metric_description_none__,
+            unit = __internal_metric_unit_none__,
+            target = ::core::module_path!(),
+            level = $crate::Level::INFO;
+            $($input)*
+        )
+    };
+}
+
 /// Registers a gauge.
 ///
 /// Gauges represent a single value that can go up or down over time, and always starts out with an

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -24,28 +24,6 @@ macro_rules! count {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! internal_target_fallback {
-    ($target:expr) => {{
-        $target
-    }};
-    () => {
-        ::core::module_path!()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! internal_level_fallback {
-    ($level:expr) => {{
-        $level
-    }};
-    () => {
-        $crate::Level::INFO
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
 macro_rules! key_var {
     ($name: literal) => {{
         static METRIC_KEY: $crate::Key = $crate::Key::from_static_name($name);
@@ -90,6 +68,15 @@ macro_rules! key_var {
 /// which includes using macros such as `format!` directly at the callsite. String literals are
 /// preferred for performance where possible.
 ///
+/// ## Optional Parameters
+///
+/// Following parameters can be provided in any order
+///
+/// `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
+/// `level:` - Specifies counter level. Defaults to `INFO`.
+/// `describe:` - Specifies counter description to register for counter. If specified `$name` has to be Copy-able.
+/// `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+///
 /// # Example
 /// ```
 /// # #![no_implicit_prelude]
@@ -122,161 +109,33 @@ macro_rules! key_var {
 /// let name = String::from("some_owned_metric_name");
 /// let counter = counter!(name);
 ///
-/// let counter = counter!(format!("{}_via_format", "name"));
+/// let gauge = counter!(format!("{}_via_format", "name"));
+///
+/// //Full counter customization example
+/// let counter = counter!(
+///     describe: "super counter",
+///     unit: metrics::Unit::Bytes,
+///     target: ::core::module_path!(),
+///     level: metrics::Level::INFO,
+///     "super_counter",
+///     "label1" => "value1",
+///     "label2" => "value2"
+/// );
 /// # }
 /// ```
 #[macro_export]
 macro_rules! counter {
-    (target: $target:expr, level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {{
-        let metric_key = $crate::key_var!($name $(, $label_key $(=> $label_value)?)*);
-        let metadata = $crate::metadata_var!($target, $level);
-
-        $crate::with_recorder(|recorder| recorder.register_counter(&metric_key, metadata))
-    }};
-    (target: $target:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::counter!(target: $target, level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+    ($($input:tt)*) => {
+        $crate::__register_metric!(
+            describe_counter,
+            register_counter,
+            describe = __internal_metric_description_none__,
+            unit = __internal_metric_unit_none__,
+            target = ::core::module_path!(),
+            level = $crate::Level::INFO;
+            $($input)*
+        )
     };
-    (level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::counter!(target: ::core::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
-    };
-    ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::counter!(target: ::core::module_path!(), level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
-    };
-}
-
-/// Registers a counter with provided description
-///
-/// This is macro useful if you only need to register macro once
-///
-/// ## Example
-///
-/// ```rust
-/// # #![no_implicit_prelude]
-/// # use ::std::convert::From;
-/// # use ::std::format;
-/// # use ::std::string::String;
-/// # use metrics::create_counter;
-/// # fn main() {
-/// // A basic counter:
-/// let counter = create_counter!("some_metric_name");
-/// counter.increment(1);
-///
-/// // A basic counter with labels
-/// let counter = create_counter!("some_metric_name", "label1" => "value2" );
-/// counter.increment(1);
-///
-/// // A counter with description!
-/// let counter = create_counter!(describe: "my super counter", "some_metric_name");
-/// counter.increment(1);
-///
-/// // A counter with description and unit!
-/// let counter = create_counter!(describe: "my super counter", unit: metrics::Unit::Bytes, "some_metric_name");
-/// counter.increment(1);
-///
-/// // A custom level counter with description and unit!
-/// let counter = create_counter!(
-///     describe: "my super counter",
-///     unit: metrics::Unit::Bytes,
-///     level: metrics::Level::INFO,
-///     "some_metric_name",
-/// );
-/// counter.increment(1);
-///
-/// // A custom target counter with description and unit!
-/// let counter = create_counter!(
-///     describe: "my super counter",
-///     unit: metrics::Unit::Bytes,
-///     target: "custom_target",
-///     "some_metric_name",
-/// );
-/// counter.increment(1);
-///
-/// // A counter with description and fancy label, even target module!
-/// let counter = create_counter!(
-///     describe: "my super counter",
-///     unit: metrics::Unit::Bytes,
-///     target: ::core::module_path!(),
-///     level: metrics::Level::INFO,
-///     "some_metric_name",
-///     "label1" => "value1",
-///     "label2" => "value2"
-/// );
-/// counter.increment(1);
-/// # }
-/// ```
-#[macro_export]
-macro_rules! create_counter {
-    (
-        $(describe: $description:expr$(,unit: $unit:expr)?,)?
-        $(target: $target:expr,)?
-        level: $level:expr,
-        $name:expr
-        $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?
-     ) => {{
-        $(
-            $crate::describe!(
-                describe_counter,
-                $name,
-                $( $unit, )?
-                $description
-            );
-        )?
-
-        let metric_key = $crate::key_var!($name $(, $label_key $(=> $label_value)?)*);
-        let metadata = $crate::metadata_var!($crate::internal_target_fallback!($($target)?), $level);
-
-        $crate::with_recorder(|recorder| recorder.register_counter(&metric_key, metadata))
-    }};
-    (
-        $(describe: $description:expr$(,unit: $unit:expr)?,)?
-        $(level: $level:expr,)?
-        target: $target:expr,
-        $($rest:tt)+
-    ) => {{
-        $crate::create_counter!(
-            $(describe: $description$(,unit: $unit)?,)?
-            target: $target,
-            level: $crate::internal_level_fallback!($($level)?),
-            $($rest)+
-        )
-    }};
-    (
-        describe: $description:expr, unit: $unit:expr,
-        $($rest:tt)+
-    ) => {{
-        $crate::create_counter!(
-            describe: $description,
-            unit:$unit,
-            target: ::core::module_path!(),
-            level: $crate::Level::INFO,
-            $($rest)+
-        )
-    }};
-    (
-        $(unit: $unit:expr,)?
-        describe: $description:expr,
-        $($rest:tt)+
-    ) => {{
-        $crate::create_counter!(
-            describe: $description,
-            $(unit: $unit,)?
-            target: ::core::module_path!(),
-            level: $crate::Level::INFO,
-            $($rest)+
-        )
-    }};
-    //Do not use rest:tt here as it can infinitely stuck on some usages
-    (
-        $name:expr
-        $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?
-    ) => {{
-        $crate::create_counter!(
-            target: ::core::module_path!(),
-            level: $crate::Level::INFO,
-            $name
-            $(, $label_key $(=> $label_value)?)*
-        )
-    }}
 }
 
 #[doc(hidden)]
@@ -284,7 +143,11 @@ macro_rules! create_counter {
 ///Internal macro to register metric description when provided by metric creation macro
 macro_rules! __describe_metric {
     // Do nothing if metric description is not set
-    ($method:ident, __internal_metric_description_none__, $($rest:tt)*) => {{}};
+    ($method:ident, __internal_metric_description_none__, __internal_metric_unit_none__, $($rest:tt)*) => {{}};
+    // Show compilation error if `unit` only specified
+    ($method:ident, __internal_metric_description_none__, $unit:expr, $($rest:tt)*) => {{
+        compile_error!("'unit:' requires to specify parameter 'describe:'");
+    }};
     // Found description only
     ($method:ident, $description:expr, __internal_metric_unit_none__, $name:expr) => {{
         $crate::with_recorder(|recorder| {
@@ -422,7 +285,7 @@ macro_rules! __register_metric {
 /// # use ::std::convert::From;
 /// # use ::std::format;
 /// # use ::std::string::String;
-/// # use metrics::create_counter2 as create_counter;
+/// # use metrics::create_counter as create_counter;
 /// # fn main() {
 /// // A basic counter:
 /// let counter = create_counter!("some_metric_name");
@@ -472,7 +335,7 @@ macro_rules! __register_metric {
 /// # }
 /// ```
 #[macro_export]
-macro_rules! create_counter2 {
+macro_rules! create_counter {
     ($($input:tt)*) => {
         $crate::__register_metric!(
             describe_counter,
@@ -497,6 +360,15 @@ macro_rules! create_counter2 {
 /// Metric names are shown below using string literals, but they can also be owned `String` values,
 /// which includes using macros such as `format!` directly at the callsite. String literals are
 /// preferred for performance where possible.
+///
+/// ## Optional Parameters
+///
+/// Following parameters can be provided in any order
+///
+/// `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
+/// `level:` - Specifies counter level. Defaults to `INFO`.
+/// `describe:` - Specifies counter description to register for counter. If specified `$name` has to be Copy-able.
+/// `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
 ///
 /// # Example
 /// ```
@@ -532,24 +404,31 @@ macro_rules! create_counter2 {
 /// let gauge = gauge!(name);
 ///
 /// let gauge = gauge!(format!("{}_via_format", "name"));
+///
+/// //Full gauge customization example
+/// let counter = gauge!(
+///     describe: "super gauge",
+///     unit: metrics::Unit::Bytes,
+///     target: ::core::module_path!(),
+///     level: metrics::Level::INFO,
+///     "super_gauge",
+///     "label1" => "value1",
+///     "label2" => "value2"
+/// );
 /// # }
 /// ```
 #[macro_export]
 macro_rules! gauge {
-    (target: $target:expr, level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {{
-        let metric_key = $crate::key_var!($name $(, $label_key $(=> $label_value)?)*);
-        let metadata = $crate::metadata_var!($target, $level);
-
-        $crate::with_recorder(|recorder| recorder.register_gauge(&metric_key, metadata))
-    }};
-    (target: $target:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::gauge!(target: $target, level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
-    };
-    (level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::gauge!(target: ::core::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
-    };
-    ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::gauge!(target: ::core::module_path!(), level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+    ($($input:tt)*) => {
+        $crate::__register_metric!(
+            describe_gauge,
+            register_gauge,
+            describe = __internal_metric_description_none__,
+            unit = __internal_metric_unit_none__,
+            target = ::core::module_path!(),
+            level = $crate::Level::INFO;
+            $($input)*
+        )
     };
 }
 
@@ -564,6 +443,15 @@ macro_rules! gauge {
 /// Metric names are shown below using string literals, but they can also be owned `String` values,
 /// which includes using macros such as `format!` directly at the callsite. String literals are
 /// preferred for performance where possible.
+///
+/// ## Optional Parameters
+///
+/// Following parameters can be provided in any order
+///
+/// `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
+/// `level:` - Specifies counter level. Defaults to `INFO`.
+/// `describe:` - Specifies counter description to register for counter. If specified `$name` has to be Copy-able.
+/// `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
 ///
 /// # Example
 /// ```
@@ -596,24 +484,30 @@ macro_rules! gauge {
 /// let histogram = histogram!(name);
 ///
 /// let histogram = histogram!(format!("{}_via_format", "name"));
+/// //Full histogram customization example
+/// let counter = histogram!(
+///     describe: "super counter",
+///     unit: metrics::Unit::Bytes,
+///     target: ::core::module_path!(),
+///     level: metrics::Level::INFO,
+///     "super_counter",
+///     "label1" => "value1",
+///     "label2" => "value2"
+/// );
 /// # }
 /// ```
 #[macro_export]
 macro_rules! histogram {
-    (target: $target:expr, level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {{
-        let metric_key = $crate::key_var!($name $(, $label_key $(=> $label_value)?)*);
-        let metadata = $crate::metadata_var!($target, $level);
-
-        $crate::with_recorder(|recorder| recorder.register_histogram(&metric_key, metadata))
-    }};
-    (target: $target:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::histogram!(target: $target, level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
-    };
-    (level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::histogram!(target: ::core::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
-    };
-    ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
-        $crate::histogram!(target: ::core::module_path!(), level: $crate::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+    ($($input:tt)*) => {
+        $crate::__register_metric!(
+            describe_histogram,
+            register_histogram,
+            describe = __internal_metric_description_none__,
+            unit = __internal_metric_unit_none__,
+            target = ::core::module_path!(),
+            level = $crate::Level::INFO;
+            $($input)*
+        )
     };
 }
 

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -88,7 +88,7 @@ macro_rules! key_var {
 ///
 /// - `target:` - Module path of the counter. Defaults to `::core::module_path!()`.
 /// - `level:` - Verbosity level of the counter. Defaults to `INFO`.
-/// - `describe:` - Description of the counter. If specified, `$name` will be used twice.
+/// - `description:` - Description of the counter. If specified, `$name` will be used twice.
 /// - `unit:` - Unit of measurement of the counter. Description must be provided in order to specify units.
 ///
 /// ## Labels
@@ -134,7 +134,7 @@ macro_rules! key_var {
 ///
 /// // Full counter customization example
 /// let counter = counter!(
-///     describe: "super counter",
+///     description: "super counter",
 ///     unit: metrics::Unit::Bytes,
 ///     target: ::core::module_path!(),
 ///     level: metrics::Level::INFO,
@@ -150,7 +150,7 @@ macro_rules! counter {
         $crate::__register_metric!(
             describe_counter,
             register_counter,
-            describe = __internal_metric_description_none__,
+            description = __internal_metric_description_none__,
             unit = __internal_metric_unit_none__,
             target = ::core::module_path!(),
             level = $crate::Level::INFO;
@@ -167,7 +167,7 @@ macro_rules! __describe_metric {
     ($method:ident, __internal_metric_description_none__, __internal_metric_unit_none__, $($rest:tt)*) => {{}};
     // Show compilation error if `unit` only specified
     ($method:ident, __internal_metric_description_none__, $unit:expr, $($rest:tt)*) => {{
-        compile_error!("'unit:' requires to specify parameter 'describe:'");
+        compile_error!("'unit:' requires to specify parameter 'description:'");
     }};
     // Found description only
     ($method:ident, $description:expr, __internal_metric_unit_none__, $name:expr) => {{
@@ -198,7 +198,7 @@ macro_rules! __register_metric {
     (
         $describe:ident,
         $register:ident,
-        describe = $description:tt,
+        description = $description:tt,
         unit = $unit:tt,
         target = $_old:expr,
         level = $level:expr;
@@ -208,7 +208,7 @@ macro_rules! __register_metric {
         $crate::__register_metric!(
             $describe,
             $register,
-            describe = $description,
+            description = $description,
             unit = $unit,
             target = $target,
             level = $level;
@@ -219,7 +219,7 @@ macro_rules! __register_metric {
     (
         $describe:ident,
         $register:ident,
-        describe = $description:tt,
+        description = $description:tt,
         unit = $unit:tt,
         target = $target:expr,
         level = $_old:expr;
@@ -229,28 +229,28 @@ macro_rules! __register_metric {
         $crate::__register_metric!(
             $describe,
             $register,
-            describe = $description,
+            description = $description,
             unit = $unit,
             target = $target,
             level = $level;
             $($rest)*
         )
     };
-    // `describe:` — replace the accumulator's `describe` slot.
+    // `description:` — replace the accumulator's `describe` slot.
     (
         $describe:ident,
         $register:ident,
-        describe = $old:tt,
+        description = $old:tt,
         unit = $unit:tt,
         target = $target:expr,
         level = $level:expr;
-        describe: $description:expr,
+        description: $description:expr,
         $($rest:tt)*
     ) => {
         $crate::__register_metric!(
             $describe,
             $register,
-            describe = $description,
+            description = $description,
             unit = $unit,
             target = $target,
             level = $level;
@@ -261,7 +261,7 @@ macro_rules! __register_metric {
     (
         $describe:ident,
         $register:ident,
-        describe = $description:tt,
+        description = $description:tt,
         unit = $old:tt,
         target = $target:expr,
         level = $level:expr;
@@ -271,7 +271,7 @@ macro_rules! __register_metric {
         $crate::__register_metric!(
             $describe,
             $register,
-            describe = $description,
+            description = $description,
             unit = $unit,
             target = $target,
             level = $level;
@@ -282,13 +282,13 @@ macro_rules! __register_metric {
     (
         $describe:ident,
         $register:ident,
-        describe = $description:tt,
+        description = $description:tt,
         unit = $unit:tt,
         target = $target:expr,
         level = $level:expr;
         $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?
     ) => {{
-        $crate::__describe_metric!(describe_counter, $description, $unit, $name);
+        $crate::__describe_metric!($describe, $description, $unit, $name);
 
         let metric_key = $crate::key_var!($name $(, $label_key $(=> $label_value)?)*);
         let metadata = $crate::metadata_var!($target, $level);
@@ -329,7 +329,7 @@ macro_rules! __register_metric {
 ///
 /// - `target:` - Module path of the counter. Defaults to `::core::module_path!()`.
 /// - `level:` - Verbosity level of the counter. Defaults to `INFO`.
-/// - `describe:` - Description of the counter. If specified, `$name` will be used twice.
+/// - `description:` - Description of the counter. If specified, `$name` will be used twice.
 /// - `unit:` - Unit of measurement of the counter. Description must be provided in order to specify units.
 ///
 /// ## Labels
@@ -375,7 +375,7 @@ macro_rules! __register_metric {
 /// let gauge = gauge!(format!("{}_via_format", "name"));
 /// // Full gauge customization example
 /// let gauge = gauge!(
-///     describe: "super gauge",
+///     description: "super gauge",
 ///     unit: metrics::Unit::Bytes,
 ///     target: ::core::module_path!(),
 ///     level: metrics::Level::INFO,
@@ -391,7 +391,7 @@ macro_rules! gauge {
         $crate::__register_metric!(
             describe_gauge,
             register_gauge,
-            describe = __internal_metric_description_none__,
+            description = __internal_metric_description_none__,
             unit = __internal_metric_unit_none__,
             target = ::core::module_path!(),
             level = $crate::Level::INFO;
@@ -432,7 +432,7 @@ macro_rules! gauge {
 ///
 /// - `target:` - Module path of the counter. Defaults to `::core::module_path!()`.
 /// - `level:` - Verbosity level of the counter. Defaults to `INFO`.
-/// - `describe:` - Description of the counter. If specified, `$name` will be used twice.
+/// - `description:` - Description of the counter. If specified, `$name` will be used twice.
 /// - `unit:` - Unit of measurement of the counter. Description must be provided in order to specify units.
 ///
 /// ## Labels
@@ -475,7 +475,7 @@ macro_rules! gauge {
 /// let histogram = histogram!(format!("{}_via_format", "name"));
 /// // Full histogram customization example
 /// let histogram = histogram!(
-///     describe: "super counter",
+///     description: "super counter",
 ///     unit: metrics::Unit::Bytes,
 ///     target: ::core::module_path!(),
 ///     level: metrics::Level::INFO,
@@ -491,7 +491,7 @@ macro_rules! histogram {
         $crate::__register_metric!(
             describe_histogram,
             register_histogram,
-            describe = __internal_metric_description_none__,
+            description = __internal_metric_description_none__,
             unit = __internal_metric_unit_none__,
             target = ::core::module_path!(),
             level = $crate::Level::INFO;

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -236,7 +236,7 @@ macro_rules! __register_metric {
             $($rest)*
         )
     };
-    // `description:` — replace the accumulator's `describe` slot.
+    // `description:` — replace the accumulator's `description` slot.
     (
         $describe:ident,
         $register:ident,

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -80,21 +80,21 @@ macro_rules! key_var {
 ///
 /// ## Required parameters
 ///
-/// - `$name` - Name of the metric. Can be expression that results in `String` or `&'static str`
+/// - `$name` - Name of the metric. Must be a string literal or an expression that results in `String` or `&'static str`.
 ///
 /// ## Optional Parameters
 ///
-/// Following parameters can be provided in any order
+/// The following parameters can be provided in any order:
 ///
-/// - `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
-/// - `level:` - Specifies counter level. Defaults to `INFO`.
-/// - `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
-/// - `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+/// - `target:` - Module path of the counter. Defaults to `::core::module_path!()`.
+/// - `level:` - Verbosity level of the counter. Defaults to `INFO`.
+/// - `describe:` - Description of the counter. If specified, `$name` will be used twice.
+/// - `unit:` - Unit of measurement of the counter. Description must be provided in order to specify units.
 ///
 /// ## Labels
 ///
 /// Labels can be passed as _one_ of following:
-/// - Arbitrary number of `<key> => <value>` where `key` and `value` can be expression that results in `&'static str` or `String`
+/// - Arbitrary number of `<key> => <value>` where `key` and `value` can be a string literal or an expression that results in `String` or `&'static str`.
 /// - Static reference to collection of **Label**
 /// - Collection/iterator that implements [IntoLabels](trait.IntoLabels.html)
 ///
@@ -130,9 +130,9 @@ macro_rules! key_var {
 /// let name = String::from("some_owned_metric_name");
 /// let counter = counter!(name);
 ///
-/// let gauge = counter!(format!("{}_via_format", "name"));
+/// let counter = counter!(format!("{}_via_format", "name"));
 ///
-/// //Full counter customization example
+/// // Full counter customization example
 /// let counter = counter!(
 ///     describe: "super counter",
 ///     unit: metrics::Unit::Bytes,
@@ -321,21 +321,21 @@ macro_rules! __register_metric {
 ///
 /// ## Required parameters
 ///
-/// - `$name` - Name of the metric. Can be expression that results in `String` or `&'static str`
+/// - `$name` - Name of the metric. Must be a string literal or an expression that results in `String` or `&'static str`.
 ///
 /// ## Optional Parameters
 ///
-/// Following parameters can be provided in any order
+/// The following parameters can be provided in any order:
 ///
-/// - `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
-/// - `level:` - Specifies counter level. Defaults to `INFO`.
-/// - `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
-/// - `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+/// - `target:` - Module path of the counter. Defaults to `::core::module_path!()`.
+/// - `level:` - Verbosity level of the counter. Defaults to `INFO`.
+/// - `describe:` - Description of the counter. If specified, `$name` will be used twice.
+/// - `unit:` - Unit of measurement of the counter. Description must be provided in order to specify units.
 ///
 /// ## Labels
 ///
 /// Labels can be passed as _one_ of following:
-/// - Arbitrary number of `<key> => <value>` where `key` and `value` can be expression that results in `&'static str` or `String`
+/// - Arbitrary number of `<key> => <value>` where `key` and `value` can be a string literal or an expression that results in `String` or `&'static str`.
 /// - Static reference to collection of **Label**
 /// - Collection/iterator that implements [IntoLabels](trait.IntoLabels.html)
 ///
@@ -373,7 +373,7 @@ macro_rules! __register_metric {
 /// let gauge = gauge!(name);
 ///
 /// let gauge = gauge!(format!("{}_via_format", "name"));
-/// //Full gauge customization example
+/// // Full gauge customization example
 /// let gauge = gauge!(
 ///     describe: "super gauge",
 ///     unit: metrics::Unit::Bytes,
@@ -424,21 +424,21 @@ macro_rules! gauge {
 ///
 /// ## Required parameters
 ///
-/// - `$name` - Name of the metric. Can be expression that results in `String` or `&'static str`
+/// - `$name` - Name of the metric. Must be a string literal or an expression that results in `String` or `&'static str`.
 ///
 /// ## Optional Parameters
 ///
-/// Following parameters can be provided in any order
+/// The following parameters can be provided in any order:
 ///
-/// - `target:` - Specifies counter target. Defaults to `::core::module_path!()`.
-/// - `level:` - Specifies counter level. Defaults to `INFO`.
-/// - `describe:` - Specifies counter description to register for counter. If specified `$name` will be used twice.
-/// - `unit:` - Specifies counter unit to register for counter if `describe:` is specified.
+/// - `target:` - Module path of the counter. Defaults to `::core::module_path!()`.
+/// - `level:` - Verbosity level of the counter. Defaults to `INFO`.
+/// - `describe:` - Description of the counter. If specified, `$name` will be used twice.
+/// - `unit:` - Unit of measurement of the counter. Description must be provided in order to specify units.
 ///
 /// ## Labels
 ///
 /// Labels can be passed as _one_ of following:
-/// - Arbitrary number of `<key> => <value>` where `key` and `value` can be expression that results in `&'static str` or `String`
+/// - Arbitrary number of `<key> => <value>` where `key` and `value` can be a string literal or an expression that results in `String` or `&'static str`.
 /// - Static reference to collection of **Label**
 /// - Collection/iterator that implements [IntoLabels](trait.IntoLabels.html)
 ///
@@ -473,7 +473,7 @@ macro_rules! gauge {
 /// let histogram = histogram!(name);
 ///
 /// let histogram = histogram!(format!("{}_via_format", "name"));
-/// //Full histogram customization example
+/// // Full histogram customization example
 /// let histogram = histogram!(
 ///     describe: "super counter",
 ///     unit: metrics::Unit::Bytes,

--- a/metrics/tests/macros.rs
+++ b/metrics/tests/macros.rs
@@ -4,4 +4,5 @@ pub fn macros() {
     t.pass("tests/macros/01_basic.rs");
     t.pass("tests/macros/02_trailing_comma.rs");
     t.pass("tests/macros/03_mod_aliasing.rs");
+    t.pass("tests/macros/04_customization.rs");
 }

--- a/metrics/tests/macros/04_customization.rs
+++ b/metrics/tests/macros/04_customization.rs
@@ -1,0 +1,111 @@
+use metrics::{counter, gauge, histogram, Level, Unit};
+
+#[allow(dead_code)]
+fn target_only() {
+    counter!(target: "rendering", "qwe").increment(1);
+    gauge!(target: "rendering", "qwe").set(1.0);
+    histogram!(target: "rendering", "qwe").record(1.0);
+}
+
+#[allow(dead_code)]
+fn level_only() {
+    counter!(level: Level::DEBUG, "qwe").increment(1);
+    gauge!(level: Level::DEBUG, "qwe").set(1.0);
+    histogram!(level: Level::DEBUG, "qwe").record(1.0);
+}
+
+#[allow(dead_code)]
+fn describe_only() {
+    counter!(describe: "rendering counter", "qwe").increment(1);
+    gauge!(describe: "rendering gauge", "qwe").set(1.0);
+    histogram!(describe: "rendering histogram", "qwe").record(1.0);
+}
+
+#[allow(dead_code)]
+fn describe_with_unit() {
+    counter!(describe: "rendering counter", unit: Unit::Count, "qwe").increment(1);
+    gauge!(describe: "rendering gauge", unit: Unit::Count, "qwe").set(1.0);
+    histogram!(describe: "rendering histogram", unit: Unit::Count, "qwe").record(1.0);
+}
+
+#[allow(dead_code)]
+fn unit_with_describe() {
+    counter!(unit: Unit::Count, describe: "rendering counter", "qwe").increment(1);
+    gauge!(unit: Unit::Count, describe: "rendering gauge", "qwe").set(1.0);
+    histogram!(unit: Unit::Count, describe: "rendering histogram",  "qwe").record(1.0);
+}
+
+#[allow(dead_code)]
+fn target_then_level() {
+    counter!(target: "rendering", level: Level::DEBUG, "qwe").increment(1);
+    gauge!(target: "rendering", level: Level::DEBUG, "qwe").set(1.0);
+    histogram!(target: "rendering", level: Level::DEBUG, "qwe").record(1.0);
+}
+
+#[allow(dead_code)]
+fn level_then_target() {
+    counter!(level: Level::DEBUG, target: "rendering", "qwe").increment(1);
+    gauge!(level: Level::DEBUG, target: "rendering", "qwe").set(1.0);
+    histogram!(level: Level::DEBUG, target: "rendering", "qwe").record(1.0);
+}
+
+#[allow(dead_code)]
+fn named_args_with_literal_labels() {
+    counter!(level: Level::DEBUG, target: "rendering", "qwe", "foo" => "bar").increment(1);
+    counter!(target: "rendering", level: Level::DEBUG, "qwe", "foo" => "bar", "baz" => "qux")
+        .increment(1);
+    counter!(level: Level::DEBUG, "qwe", "foo" => "bar").increment(1);
+    gauge!(target: "rendering", "qwe", "foo" => "bar").set(1.0);
+    histogram!(level: Level::DEBUG, "qwe", "foo" => "bar").record(1.0);
+}
+
+#[allow(dead_code)]
+fn named_args_with_expr_labels() {
+    let key = "foo";
+    let value = String::from("bar");
+    counter!(target: "rendering", "qwe", key => value.clone()).increment(1);
+    counter!(level: Level::DEBUG, "qwe", key => format!("{}_suffix", value)).increment(1);
+    counter!(
+        target: "rendering",
+        level: Level::DEBUG,
+        "qwe",
+        key => value.clone(),
+        "literal_key" => value.clone()
+    )
+    .increment(1);
+    gauge!(level: Level::DEBUG, target: "rendering", "qwe", key => value.clone()).set(1.0);
+    histogram!(target: "rendering", "qwe", key => value).record(1.0);
+}
+
+#[allow(dead_code)]
+fn named_args_with_inline_slice_labels() {
+    counter!(target: "rendering", "qwe", &[("foo", "bar")]).increment(1);
+    gauge!(level: Level::DEBUG, target: "rendering", "qwe", &[("foo", "bar")]).set(1.0);
+    histogram!(target: "rendering", level: Level::DEBUG, "qwe", &[("foo", "bar")]).record(1.0);
+}
+
+#[allow(dead_code)]
+fn named_args_with_bound_slice_labels() {
+    let labels = [("foo", "bar")];
+    counter!(target: "rendering", "qwe", &labels).increment(1);
+    counter!(level: Level::DEBUG, target: "rendering", "qwe", &labels).increment(1);
+
+    let owned_labels = vec![(String::from("foo"), String::from("bar"))];
+    gauge!(target: "rendering", "qwe", &owned_labels).set(1.0);
+    histogram!(level: Level::DEBUG, "qwe", &owned_labels).record(1.0);
+}
+
+#[allow(dead_code)]
+fn named_args_with_trailing_comma() {
+    counter!(target: "rendering", level: Level::DEBUG, "qwe",).increment(1);
+    counter!(level: Level::DEBUG, target: "rendering", "qwe", "foo" => "bar",).increment(1);
+
+    let key = "foo";
+    let value = "bar";
+    counter!(target: "rendering", "qwe", key => value,).increment(1);
+
+    let labels = [("foo", "bar")];
+    counter!(level: Level::DEBUG, "qwe", &labels,).increment(1);
+}
+
+fn main() {}

--- a/metrics/tests/macros/04_customization.rs
+++ b/metrics/tests/macros/04_customization.rs
@@ -16,23 +16,23 @@ fn level_only() {
 
 #[allow(dead_code)]
 fn describe_only() {
-    counter!(describe: "rendering counter", "qwe").increment(1);
-    gauge!(describe: "rendering gauge", "qwe").set(1.0);
-    histogram!(describe: "rendering histogram", "qwe").record(1.0);
+    counter!(description: "rendering counter", "qwe").increment(1);
+    gauge!(description: "rendering gauge", "qwe").set(1.0);
+    histogram!(description: "rendering histogram", "qwe").record(1.0);
 }
 
 #[allow(dead_code)]
 fn describe_with_unit() {
-    counter!(describe: "rendering counter", unit: Unit::Count, "qwe").increment(1);
-    gauge!(describe: "rendering gauge", unit: Unit::Count, "qwe").set(1.0);
-    histogram!(describe: "rendering histogram", unit: Unit::Count, "qwe").record(1.0);
+    counter!(description: "rendering counter", unit: Unit::Count, "qwe").increment(1);
+    gauge!(description: "rendering gauge", unit: Unit::Count, "qwe").set(1.0);
+    histogram!(description: "rendering histogram", unit: Unit::Count, "qwe").record(1.0);
 }
 
 #[allow(dead_code)]
 fn unit_with_describe() {
-    counter!(unit: Unit::Count, describe: "rendering counter", "qwe").increment(1);
-    gauge!(unit: Unit::Count, describe: "rendering gauge", "qwe").set(1.0);
-    histogram!(unit: Unit::Count, describe: "rendering histogram",  "qwe").record(1.0);
+    counter!(unit: Unit::Count, description: "rendering counter", "qwe").increment(1);
+    gauge!(unit: Unit::Count, description: "rendering gauge", "qwe").set(1.0);
+    histogram!(unit: Unit::Count, description: "rendering histogram",  "qwe").record(1.0);
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
When I initially integrated metrics crate into my code I had one inconvenience that I needed to describe and create counter separately, even though I technically only create it once...

Putting aside the fact that you need to always describe metric before creating it, I always end up creating macro that would wrap description and creation into one beautiful macro
So I want to propose such interface here

The basic idea is to use optional labels to `describe` which in turn allows to add optional tag `unit`
Then in order not to confuse macro parser (due to presence of `describe`), I wrapped labels into optional brackets `{ label1 => value2 }`

This will allow user to describe macro in one go with creation
But this is admittedly very complex, so let me know if you're interested in this approach and I'll add macros for other metrics