### PR TITLE
Change from_arc to allow existing trait object

### DIFF
--- a/metrics-exporter-dogstatsd/src/recorder.rs
+++ b/metrics-exporter-dogstatsd/src/recorder.rs
@@ -24,20 +24,20 @@ impl Recorder for DogStatsDRecorder {
         let key = key.to_retained();
         self.state
             .registry()
-            .get_or_create_counter(&key, |existing| Counter::from_arc(Arc::clone(existing)))
+            .get_or_create_counter(&key, |existing| Counter::from_arc(existing.clone()))
     }
 
     fn register_gauge(&self, key: &Key, _: &Metadata<'_>) -> Gauge {
         let key = key.to_retained();
         self.state
             .registry()
-            .get_or_create_gauge(&key, |existing| Gauge::from_arc(Arc::clone(existing)))
+            .get_or_create_gauge(&key, |existing| Gauge::from_arc(existing.clone()))
     }
 
     fn register_histogram(&self, key: &Key, _: &Metadata<'_>) -> Histogram {
         let key = key.to_retained();
         self.state
             .registry()
-            .get_or_create_histogram(&key, |existing| Histogram::from_arc(Arc::clone(existing)))
+            .get_or_create_histogram(&key, |existing| Histogram::from_arc(existing.clone()))
     }
 }

--- a/metrics-util/src/recoverable.rs
+++ b/metrics-util/src/recoverable.rs
@@ -261,15 +261,15 @@ mod tests {
         }
 
         fn register_counter(&self, _: &Key, _: &Metadata<'_>) -> Counter {
-            Counter::from_arc(Arc::clone(&self.counter))
+            Counter::from_arc(self.counter.clone())
         }
 
         fn register_gauge(&self, _: &Key, _: &Metadata<'_>) -> Gauge {
-            Gauge::from_arc(Arc::clone(&self.gauge))
+            Gauge::from_arc(self.gauge.clone())
         }
 
         fn register_histogram(&self, _: &Key, _: &Metadata<'_>) -> Histogram {
-            Histogram::from_arc(Arc::clone(&self.histogram))
+            Histogram::from_arc(self.histogram.clone())
         }
     }
 

--- a/metrics/src/handles.rs
+++ b/metrics/src/handles.rs
@@ -94,7 +94,7 @@ impl Counter {
     }
 
     /// Creates a `Counter` based on a shared handler.
-    pub fn from_arc<F: CounterFn + Send + Sync + 'static>(a: Arc<F>) -> Self {
+    pub fn from_arc(a: Arc<dyn CounterFn + Send + Sync + 'static>) -> Self {
         Self { inner: Some(a) }
     }
 
@@ -123,7 +123,7 @@ impl Gauge {
     }
 
     /// Creates a `Gauge` based on a shared handler.
-    pub fn from_arc<F: GaugeFn + Send + Sync + 'static>(a: Arc<F>) -> Self {
+    pub fn from_arc(a: Arc<dyn GaugeFn + Send + Sync + 'static>) -> Self {
         Self { inner: Some(a) }
     }
 
@@ -159,7 +159,7 @@ impl Histogram {
     }
 
     /// Creates a `Histogram` based on a shared handler.
-    pub fn from_arc<F: HistogramFn + Send + Sync + 'static>(a: Arc<F>) -> Self {
+    pub fn from_arc(a: Arc<dyn HistogramFn + Send + Sync + 'static>) -> Self {
         Self { inner: Some(a) }
     }
 

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -628,9 +628,9 @@ mod tests {
 
     #[test]
     fn test_buildhasherdefault_keyhasher_agrees_with_get_hash() {
-        use std::hash::{BuildHasher, BuildHasherDefault};
         #[allow(deprecated)]
         use crate::KeyHasher;
+        use std::hash::{BuildHasher, BuildHasherDefault};
 
         // The Registry in `metrics-util` versions 0.19.0..=0.20.1 uses
         // `BuildHasherDefault<metrics::KeyHasher>` as the HashMap's BuildHasher, while looking
@@ -646,9 +646,9 @@ mod tests {
 
     #[test]
     fn test_keyhasher_byte_mode_distinguishes_inputs() {
-        use std::hash::{BuildHasher, BuildHasherDefault};
         #[allow(deprecated)]
         use crate::KeyHasher;
+        use std::hash::{BuildHasher, BuildHasherDefault};
 
         // Validates the byte-mode fallback path used by `metrics_util::DefaultHashable<H>` in
         // `metrics-util 0.19.x`: when `Hash::hash` writes bytes (not just `write_u64`), the


### PR DESCRIPTION
Current ctor for taking existing Arc objects require concrete type and will not allow existing `dyn TraitFn + Send + Sync + 'static`

This prevents user from passing their CounterFn etc as trait object already wrapped in Arc making it impossible to dynamically create counters for implementors.

For example opentelemetry has 3 ways to implement counters which I want to use, but it is impossible for me to store counters as `Arc<dyn CounterFn>` because `metrics::Counter::from_arc` will not allow to create counter from Arc containing `!Sized` (e.g. trait object)

~This change should be backward compatible because Arc with concrete type always coerces into trait object as long as there is no extra layers between pointers~

This change is not backward compatible since it will not play well with `Into` and `Arc::clone`