### PR TITLE
Make Histogram::record_many O(1) end to end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rand_xoshiro = { version = "0.7", default-features = false }
 rapidhash = { version = "4.4.1", default-features = false }
 ratatui = { version = "0.29", default-features = false }
 rustls = { version = "0.23", default-features = false }
-sketches-ddsketch = { version = "0.3", default-features = false }
+sketches-ddsketch = { version = "0.4", default-features = false }
 thiserror = { version = "2", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt", "net", "time", "rt-multi-thread"] }
 tracing = { version = "0.1", default-features = false }

--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **Breaking:** `Distribution::record_samples` now takes `(f64, usize, Instant)` entries — the
+  middle element is the number of times the value was observed.
+- `Histogram::record_many` is now `O(1)` in time and buffered memory instead of `O(count)`: the
+  registry buffers one `(value, count, timestamp)` entry per call, and all three distribution types
+  (bucketed histogram, summary, native histogram) apply counts in constant time when draining.
+
 ## [0.18.3] - 2026-04-30
 
 ### Fixed

--- a/metrics-exporter-prometheus/src/distribution.rs
+++ b/metrics-exporter-prometheus/src/distribution.rs
@@ -67,21 +67,27 @@ impl Distribution {
     }
 
     /// Records the given `samples` in the current distribution.
-    pub fn record_samples(&mut self, samples: &[(f64, Instant)]) {
-        match self {
-            Distribution::Histogram(hist) => {
-                hist.record_many(samples.iter().map(|(sample, _ts)| sample));
+    ///
+    /// Each entry is `(value, count, timestamp)`, recording `value` as if it
+    /// had been observed `count` times at `timestamp`. Recording is O(1) in
+    /// `count` for every distribution type.
+    pub fn record_samples(&mut self, samples: &[(f64, usize, Instant)]) {
+        for &(value, count, ts) in samples {
+            // A zero count records nothing; skipping it here also keeps an
+            // infinite value from poisoning the summary sum (inf * 0.0 == NaN).
+            if count == 0 {
+                continue;
             }
-            Distribution::Summary(hist, _, sum) => {
-                for (sample, ts) in samples {
-                    hist.add(*sample, *ts);
-                    *sum += *sample;
+            match self {
+                Distribution::Histogram(hist) => hist.record_n(value, count),
+                Distribution::Summary(hist, _, sum) => {
+                    hist.add_n(value, count, ts);
+                    #[allow(clippy::cast_precision_loss)]
+                    {
+                        *sum += value * (count as f64);
+                    }
                 }
-            }
-            Distribution::NativeHistogram(hist) => {
-                for (sample, _ts) in samples {
-                    hist.observe(*sample);
-                }
+                Distribution::NativeHistogram(hist) => hist.observe_n(value, count),
             }
         }
     }
@@ -206,8 +212,9 @@ pub struct RollingSummary {
     // This is the maximum duration a bucket will be kept.
     max_bucket_duration: Duration,
     // Total samples since creation of this summary.  This is separate from the Summary since it is
-    // never reset.
-    count: usize,
+    // never reset. u64 rather than usize: weighted counts make 2^32 reachable
+    // on 32-bit targets, and a wrapped total renders as a counter reset.
+    count: u64,
 }
 
 impl Default for RollingSummary {
@@ -238,8 +245,20 @@ impl RollingSummary {
     ///
     /// Any values that expire at the `value_ts` are removed from the `RollingSummary`.
     pub fn add(&mut self, value: f64, now: Instant) {
+        self.add_n(value, 1, now);
+    }
+
+    /// Add a sample `value` to the `RollingSummary` `n` times, as if `add` had been called `n`
+    /// times with the same `now`, in constant time.
+    ///
+    /// Any values that expire at the `value_ts` are removed from the `RollingSummary`.
+    pub fn add_n(&mut self, value: f64, n: usize, now: Instant) {
+        if n == 0 {
+            return;
+        }
+
         // The count is incremented even if this value is too old to be saved in any bucket.
-        self.count += 1;
+        self.count += n as u64;
 
         // If we can find a bucket that this value belongs in, then we can just add it in and be
         // done.
@@ -252,7 +271,7 @@ impl RollingSummary {
             }
 
             if now >= bucket.begin && now < end {
-                bucket.summary.add(value);
+                bucket.summary.add_n(value, n);
                 return;
             }
         }
@@ -264,7 +283,7 @@ impl RollingSummary {
 
         if self.buckets.is_empty() {
             let mut summary = Summary::with_defaults();
-            summary.add(value);
+            summary.add_n(value, n);
             self.buckets.push(Bucket { begin: now, summary });
             return;
         }
@@ -275,7 +294,7 @@ impl RollingSummary {
         let reftime = self.buckets[0].begin;
 
         let mut summary = Summary::with_defaults();
-        summary.add(value);
+        summary.add_n(value, n);
 
         // If the value is newer than the first bucket then count upwards to the new bucket time.
         let mut begin;
@@ -319,7 +338,7 @@ impl RollingSummary {
     }
 
     /// Gets the totoal number of samples this summary has seen so far.
-    pub fn count(&self) -> usize {
+    pub fn count(&self) -> u64 {
         self.count
     }
 
@@ -334,6 +353,59 @@ mod tests {
     use super::*;
 
     use quanta::Clock;
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn record_samples_ignores_zero_count_entries() {
+        // Zero-count entries can only arrive via direct callers of this pub
+        // API (the registry filters them); an infinite value with count zero
+        // must not poison the summary sum — the one piece of state updated
+        // here rather than in a callee with its own zero guard. The weighted
+        // happy path is covered end to end in tests/record_many.rs.
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(3600));
+        let now = clock.now();
+
+        let mut dist = Distribution::new_summary(
+            Arc::new(vec![]),
+            DEFAULT_SUMMARY_BUCKET_DURATION,
+            DEFAULT_SUMMARY_BUCKET_COUNT,
+        );
+        dist.record_samples(&[(2.0, 3, now), (f64::INFINITY, 0, now)]);
+        let Distribution::Summary(summary, _, sum) = &dist else {
+            panic!("expected summary");
+        };
+        assert_eq!(summary.count(), 3);
+        assert_eq!(*sum, 6.0);
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn rolling_summary_add_n_equals_repeated_add() {
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(3600));
+
+        let mut repeated = RollingSummary::default();
+        let mut counted = RollingSummary::default();
+
+        for (v, n) in [(42.0, 500usize), (7.0, 250)] {
+            for _ in 0..n {
+                repeated.add(v, clock.now());
+            }
+            counted.add_n(v, n, clock.now());
+            mock.increment(Duration::from_secs(20));
+        }
+        counted.add_n(9.0, 0, clock.now()); // no-op
+
+        assert_eq!(repeated.count(), counted.count());
+        assert_eq!(repeated.buckets().len(), counted.buckets().len());
+        let now = clock.now();
+        let (r, c) = (repeated.snapshot(now), counted.snapshot(now));
+        assert_eq!(r.count(), c.count());
+        for q in [0.25, 0.5, 0.75, 0.99] {
+            assert_eq!(r.quantile(q), c.quantile(q), "quantile {q} diverged");
+        }
+    }
 
     #[test]
     fn new_rolling_summary() {

--- a/metrics-exporter-prometheus/src/native_histogram.rs
+++ b/metrics-exporter-prometheus/src/native_histogram.rs
@@ -711,8 +711,22 @@ impl NativeHistogram {
     }
 
     /// Records a single observation.
+    #[cfg(test)]
     pub(crate) fn observe(&self, value: f64) {
-        self.count.fetch_add(1, Ordering::Relaxed);
+        self.observe_n(value, 1);
+    }
+
+    /// Records an observation `n` times, as if `observe` had been called `n`
+    /// times, in constant time.
+    ///
+    /// Observing with an `n` of zero is a no-op.
+    pub(crate) fn observe_n(&self, value: f64, n: usize) {
+        if n == 0 {
+            return;
+        }
+        let n = n as u64;
+
+        self.count.fetch_add(n, Ordering::Relaxed);
 
         // Skip sparse bucket logic and sum updates for NaN values
         if value.is_nan() {
@@ -723,7 +737,8 @@ impl NativeHistogram {
         loop {
             let current_sum_bits = self.sum.load(Ordering::Relaxed);
             let current_sum = f64::from_bits(current_sum_bits);
-            let new_sum = current_sum + value;
+            #[allow(clippy::cast_precision_loss)]
+            let new_sum = current_sum + value * (n as f64);
 
             if self
                 .sum
@@ -798,12 +813,12 @@ impl NativeHistogram {
             // Use single entry API call to avoid race condition
             match buckets.entry(key) {
                 Entry::Vacant(entry) => {
-                    entry.insert(1);
+                    entry.insert(n);
                     self.bucket_count.fetch_add(1, Ordering::Relaxed);
                     added_new_bucket = true;
                 }
                 Entry::Occupied(mut entry) => {
-                    *entry.get_mut() += 1;
+                    *entry.get_mut() += n;
                 }
             }
         } else if value < -zero_threshold {
@@ -811,17 +826,17 @@ impl NativeHistogram {
             // Use single entry API call to avoid race condition
             match buckets.entry(key) {
                 Entry::Vacant(entry) => {
-                    entry.insert(1);
+                    entry.insert(n);
                     self.bucket_count.fetch_add(1, Ordering::Relaxed);
                     added_new_bucket = true;
                 }
                 Entry::Occupied(mut entry) => {
-                    *entry.get_mut() += 1;
+                    *entry.get_mut() += n;
                 }
             }
         } else {
             // Value is within zero threshold
-            self.zero_count.fetch_add(1, Ordering::Relaxed);
+            self.zero_count.fetch_add(n, Ordering::Relaxed);
         }
 
         // Check bucket limit after releasing locks
@@ -1001,6 +1016,28 @@ mod tests {
         let (m, e) = frexp(-2.0);
         assert!((m - (-0.5)).abs() < f64::EPSILON);
         assert_eq!(e, 2);
+    }
+
+    #[test]
+    fn test_observe_n_equals_repeated_observe() {
+        let config = NativeHistogramConfig::new(2.0, 160, 0.001).unwrap();
+        let repeated = NativeHistogram::new(config.clone());
+        let counted = NativeHistogram::new(config);
+
+        // Positive, negative, zero-threshold, and NaN paths, with mixed counts.
+        for (v, n) in [(4.2, 1_000usize), (-7.0, 250), (0.0001, 33), (123.45, 1), (f64::NAN, 5)] {
+            for _ in 0..n {
+                repeated.observe(v);
+            }
+            counted.observe_n(v, n);
+        }
+        counted.observe_n(42.0, 0); // no-op
+
+        assert_eq!(repeated.count(), counted.count());
+        assert!((repeated.sum() - counted.sum()).abs() < 1e-6);
+        assert_eq!(repeated.zero_count(), counted.zero_count());
+        assert_eq!(repeated.positive_buckets(), counted.positive_buckets());
+        assert_eq!(repeated.negative_buckets(), counted.negative_buckets());
     }
 
     #[test]

--- a/metrics-exporter-prometheus/src/protobuf.rs
+++ b/metrics-exporter-prometheus/src/protobuf.rs
@@ -158,7 +158,7 @@ pub(crate) fn render_protobuf_to_write<W: Write>(
                     pb::Metric {
                         label: label_pairs,
                         summary: Some(pb::Summary {
-                            sample_count: Some(summary.count() as u64),
+                            sample_count: Some(summary.count()),
                             sample_sum: Some(sum),
                             quantile: quantile_values,
 

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -246,7 +246,7 @@ impl Inner {
                             );
                         }
 
-                        (sum, summary.count() as u64)
+                        (sum, summary.count())
                     }
                     Distribution::Histogram(histogram) => {
                         for (le, count) in histogram.buckets() {

--- a/metrics-exporter-prometheus/src/registry.rs
+++ b/metrics-exporter-prometheus/src/registry.rs
@@ -28,10 +28,15 @@ impl<K> metrics_util::registry::Storage<K> for AtomicStorage {
     }
 }
 
-/// An `AtomicBucket` newtype wrapper that tracks the time of value insertion.
+/// An `AtomicBucket` newtype wrapper that tracks the time of value insertion,
+/// and the number of times each value was observed.
+///
+/// Entries are `(value, count, insertion time)`: a plain `record` stores a
+/// count of 1, while `record_many` stores its full count in a single entry so
+/// that recording a value N times is O(1) in both time and buffered memory.
 #[derive(Debug)]
 pub struct AtomicBucketInstant<T> {
-    inner: AtomicBucket<(T, Instant)>,
+    inner: AtomicBucket<(T, usize, Instant)>,
 }
 
 impl<T> AtomicBucketInstant<T> {
@@ -41,7 +46,7 @@ impl<T> AtomicBucketInstant<T> {
 
     pub fn clear_with<F>(&self, f: F)
     where
-        F: FnMut(&[(T, Instant)]),
+        F: FnMut(&[(T, usize, Instant)]),
     {
         self.inner.clear_with(f);
     }
@@ -50,6 +55,37 @@ impl<T> AtomicBucketInstant<T> {
 impl HistogramFn for AtomicBucketInstant<f64> {
     fn record(&self, value: f64) {
         let now = Instant::now();
-        self.inner.push((value, now));
+        self.inner.push((value, 1, now));
+    }
+
+    fn record_many(&self, value: f64, count: usize) {
+        if count == 0 {
+            return;
+        }
+        let now = Instant::now();
+        self.inner.push((value, count, now));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AtomicBucketInstant;
+    use metrics::HistogramFn;
+
+    #[test]
+    fn record_many_buffers_a_single_entry() {
+        let bucket = AtomicBucketInstant::new();
+        bucket.record_many(3.0, 1_000_000);
+        bucket.record(2.0);
+        bucket.record_many(9.0, 0); // no-op: buffers nothing
+
+        let mut entries = Vec::new();
+        bucket.clear_with(|xs| entries.extend_from_slice(xs));
+
+        // The whole point of the counted entry: a million-count record is ONE
+        // buffered sample, not a million.
+        assert_eq!(entries.len(), 2);
+        assert_eq!((entries[0].0, entries[0].1), (3.0, 1_000_000));
+        assert_eq!((entries[1].0, entries[1].1), (2.0, 1));
     }
 }

--- a/metrics-exporter-prometheus/tests/record_many.rs
+++ b/metrics-exporter-prometheus/tests/record_many.rs
@@ -1,0 +1,61 @@
+//! End-to-end tests for `Histogram::record_many` through the exporter:
+//! it must render exactly like `count` calls to `record(value)`, for every
+//! distribution type.
+
+use metrics::histogram;
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
+
+#[test]
+fn record_many_renders_weighted_classic_histogram() {
+    let recorder = PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            Matcher::Full("inflight_time_us".to_string()),
+            &[1.0, 2.0, 4.0, 8.0],
+        )
+        .unwrap()
+        .build_recorder();
+    let handle = recorder.handle();
+
+    metrics::with_local_recorder(&recorder, || {
+        // e.g. an occupation-time histogram: "spent 1M µs at level 3, then
+        // 500k µs at level 5", each recorded as a single O(1) call.
+        histogram!("inflight_time_us").record_many(3.0, 1_000_000);
+        histogram!("inflight_time_us").record_many(5.0, 500_000);
+        histogram!("inflight_time_us").record(3.0);
+    });
+
+    let rendered = handle.render();
+    for expected in [
+        "inflight_time_us_bucket{le=\"4\"} 1000001",
+        "inflight_time_us_count 1500001",
+        "inflight_time_us_sum 5500003",
+    ] {
+        assert!(rendered.contains(expected), "missing {:?} in:\n{}", expected, rendered);
+    }
+}
+
+#[test]
+fn record_many_renders_weighted_summary() {
+    // Summaries are the default distribution type, so this is the path an
+    // unconfigured `record_many` user hits.
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let handle = recorder.handle();
+
+    metrics::with_local_recorder(&recorder, || {
+        histogram!("dwell").record_many(2.0, 750_000);
+        histogram!("dwell").record_many(6.0, 250_000);
+    });
+
+    let rendered = handle.render();
+    assert!(rendered.contains("dwell_count 1000000"), "{}", rendered);
+    assert!(rendered.contains("dwell_sum 3000000"), "{}", rendered);
+
+    // 75% of the weight sits at 2.0, so the median must be ~2.0 (within the
+    // sketch's relative error).
+    let p50_line = rendered
+        .lines()
+        .find(|l| l.starts_with("dwell{quantile=\"0.5\"}"))
+        .expect("missing p50 line");
+    let p50: f64 = p50_line.rsplit(' ').next().unwrap().parse().unwrap();
+    assert!((p50 - 2.0).abs() < 0.01, "p50 was {}", p50);
+}

--- a/metrics-util/CHANGELOG.md
+++ b/metrics-util/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- New `Histogram::record_n` and `Summary::add_n` methods for recording a value multiple times in
+  constant time.
+
+### Changed
+
+- `HistogramFn` for `Generational<T>` and `FanoutHistogram` now forwards `record_many` to the inner
+  implementation(s) instead of falling back to the default loop of `record` calls.
+- Updated `sketches-ddsketch` to `0.4`, which provides the constant-time weighted
+  `DDSketch::add_with_count` backing `Summary::add_n`.
+
 ## [0.20.4] - 2026-05-13
 
 ### Fixed

--- a/metrics-util/src/layers/fanout.rs
+++ b/metrics-util/src/layers/fanout.rs
@@ -90,6 +90,12 @@ impl HistogramFn for FanoutHistogram {
             histogram.record(value);
         }
     }
+
+    fn record_many(&self, value: f64, count: usize) {
+        for histogram in &self.histograms {
+            histogram.record_many(value, count);
+        }
+    }
 }
 
 impl From<FanoutHistogram> for Histogram {

--- a/metrics-util/src/registry/recency.rs
+++ b/metrics-util/src/registry/recency.rs
@@ -124,6 +124,16 @@ where
     fn record(&self, value: f64) {
         self.with_increment(|h| h.record(value))
     }
+
+    fn record_many(&self, value: f64, count: usize) {
+        // A zero count records nothing, so it must not bump the generation
+        // either — recency-based idle eviction relies on the generation only
+        // moving when the metric actually changes.
+        if count == 0 {
+            return;
+        }
+        self.with_increment(|h| h.record_many(value, count))
+    }
 }
 
 impl<T> From<Generational<T>> for Counter
@@ -344,5 +354,46 @@ where
         }
 
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Generational;
+    use metrics::HistogramFn;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Default)]
+    struct CallCounter {
+        record_calls: AtomicUsize,
+        record_many_calls: AtomicUsize,
+    }
+
+    impl HistogramFn for CallCounter {
+        fn record(&self, _value: f64) {
+            self.record_calls.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn record_many(&self, _value: f64, _count: usize) {
+            self.record_many_calls.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn histogram_record_many_forwards_to_inner() {
+        // If `Generational` fell back to the default `record_many` (a loop of
+        // `record` calls), the inner impl's own `record_many` would never run
+        // and this would be 1000 `record` calls instead.
+        let generational = Generational::new(CallCounter::default());
+        generational.record_many(42.0, 1000);
+
+        assert_eq!(generational.get_inner().record_many_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(generational.get_inner().record_calls.load(Ordering::Relaxed), 0);
+
+        // A zero count records nothing and must not bump the generation, or
+        // recency-based idle eviction would keep the metric alive forever.
+        let generation = generational.get_generation();
+        generational.record_many(1.0, 0);
+        assert_eq!(generational.get_generation(), generation);
     }
 }

--- a/metrics-util/src/storage/histogram.rs
+++ b/metrics-util/src/storage/histogram.rs
@@ -49,13 +49,27 @@ impl Histogram {
 
     /// Records a single sample.
     pub fn record(&mut self, sample: f64) {
-        self.sum += sample;
-        self.count += 1;
+        self.record_n(sample, 1);
+    }
+
+    /// Records a sample `n` times, as if `record` had been called `n` times,
+    /// in constant time (relative to `n`).
+    ///
+    /// Recording with an `n` of zero is a no-op.
+    pub fn record_n(&mut self, sample: f64, n: usize) {
+        // Guard, not just an optimization: an infinite sample with n == 0
+        // would otherwise poison the sum (inf * 0.0 == NaN).
+        if n == 0 {
+            return;
+        }
+        let n = n as u64;
+        self.sum += sample * (n as f64);
+        self.count += n;
 
         // Add the sample to every bucket where the value is less than the bound.
         for (idx, bucket) in self.bounds.iter().enumerate() {
             if sample <= *bucket {
-                self.buckets[idx] += 1;
+                self.buckets[idx] += n;
             }
         }
     }
@@ -128,5 +142,26 @@ mod tests {
 
         assert_eq!(histogram.count(), values.len() as u64 + 1);
         assert_eq!(histogram.sum(), 581.0);
+    }
+
+    #[test]
+    fn test_record_n() {
+        let buckets = &[10.0, 25.0, 100.0];
+        let mut weighted = Histogram::new(buckets).expect("histogram should have been created");
+        let mut repeated = Histogram::new(buckets).expect("histogram should have been created");
+
+        for (value, n) in [(3.0, 1_000usize), (56.0, 250), (202.0, 17), (10.0, 1)] {
+            weighted.record_n(value, n);
+            for _ in 0..n {
+                repeated.record(value);
+            }
+        }
+        weighted.record_n(42.0, 0); // no-op
+        weighted.record_n(f64::INFINITY, 0); // no-op, must not NaN the sum
+
+        assert_eq!(weighted.buckets(), repeated.buckets());
+        assert_eq!(weighted.count(), repeated.count());
+        assert_eq!(weighted.count(), 1268);
+        assert_eq!(weighted.sum(), repeated.sum());
     }
 }

--- a/metrics-util/src/storage/summary.rs
+++ b/metrics-util/src/storage/summary.rs
@@ -92,11 +92,20 @@ impl Summary {
     ///
     /// If the absolute value of `value` is smaller than given `min_value`, it will be added as a zero.
     pub fn add(&mut self, value: f64) {
+        self.add_n(value, 1);
+    }
+
+    /// Adds a sample to the summary `n` times, as if `add` had been called `n` times, in constant
+    /// time.
+    ///
+    /// If the absolute value of `value` is smaller than given `min_value`, it will be added as a
+    /// zero. Adding with an `n` of zero is a no-op.
+    pub fn add_n(&mut self, value: f64, n: usize) {
         if value.is_infinite() {
             return;
         }
 
-        self.sketch.add(value);
+        self.sketch.add_with_count(value, n as u64);
     }
 
     /// Gets the estimated value at the given quantile.

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- `HistogramFn` for `Arc<T>` now forwards `record_many` to the inner implementation instead of
+  falling back to the default loop of `record` calls, so `O(1)` `record_many` implementations are
+  reachable through handle wrappers.
+
 ## [0.24.6] - 2026-05-13
 
 ### Added

--- a/metrics/src/handles.rs
+++ b/metrics/src/handles.rs
@@ -38,6 +38,8 @@ pub trait HistogramFn {
     fn record(&self, value: f64);
 
     /// Records a value into the histogram multiple times.
+    ///
+    /// A `count` of zero must be a complete no-op, with no observable side effects.
     fn record_many(&self, value: f64, count: usize) {
         for _ in 0..count {
             self.record(value);
@@ -214,6 +216,10 @@ where
     fn record(&self, value: f64) {
         (**self).record(value);
     }
+
+    fn record_many(&self, value: f64, count: usize) {
+        (**self).record_many(value, count);
+    }
 }
 
 impl<T> From<Arc<T>> for Counter
@@ -240,5 +246,40 @@ where
 {
     fn from(inner: Arc<T>) -> Self {
         Histogram::from_arc(inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HistogramFn;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[derive(Default)]
+    struct CallCounter {
+        record_calls: AtomicUsize,
+        record_many_calls: AtomicUsize,
+    }
+
+    impl HistogramFn for CallCounter {
+        fn record(&self, _value: f64) {
+            self.record_calls.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn record_many(&self, _value: f64, _count: usize) {
+            self.record_many_calls.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn arc_forwards_record_many_to_inner() {
+        // Without the forwarding impl, `Arc<T>` would fall back to the trait's
+        // default `record_many` (a loop of `record` calls), defeating any O(1)
+        // implementation on the inner type.
+        let inner = Arc::new(CallCounter::default());
+        HistogramFn::record_many(&inner, 42.0, 1000);
+
+        assert_eq!(inner.record_many_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(inner.record_calls.load(Ordering::Relaxed), 0);
     }
 }


### PR DESCRIPTION
## Motivation

`record_many(value, count)` is documented as recording a value `count` times, but every implementation falls back to the trait's default loop of `count` `record()` calls. In `metrics-exporter-prometheus`, each call buffers a `(value, Instant)` sample until the next upkeep, so `record_many(v, 10_000_000)` buffers tens of millions of samples. This makes `record_many` unusable as a weighted observe (e.g. occupation-time histograms recording "N microseconds at level L" in one call).

## Change

`record_many` becomes O(1) in `count` on every path:

- `metrics`: `HistogramFn for Arc<T>` forwards `record_many` (wrapper chains previously fell back to the default loop).
- `metrics-util`: `Generational<T>` and `FanoutHistogram` forward `record_many`; new `Histogram::record_n` and `Summary::add_n`.
- `metrics-exporter-prometheus`: the registry buffers one `(value, count, timestamp)` entry per call; all three distribution types apply counts in constant time on drain — bucketed histograms via `record_n`, summaries via `RollingSummary::add_n` → `Summary::add_n` → `DDSketch::add_with_count`, native histograms via `observe_n`.

Summaries are the default distribution type, so an O(count) summary drain would leave the failure mode in place on exactly the unconfigured path.

Scope: O(1) applies to the prometheus exporter path. Impls whose contract is raw-sample storage (`AtomicBucket<f64>`, the sampling reservoir, dogstatsd/tcp exporters) keep the default loop — unchanged behavior.

## Breaking (exporter)

`Distribution::record_samples` now takes `&[(f64, usize, Instant)]` (`RollingSummary::count` also widens to `u64`), and `AtomicBucketInstant::clear_with` callbacks receive counted entries. Cost note: the buffered entry widens from 16 to 24 bytes, +50% inter-upkeep buffer for plain `record()` users; there is no packing that avoids it while keeping per-sample timestamps.

## Blocked on

mheffner/rust-sketches-ddsketch#22 (`DDSketch::add_with_count`) shipping in a release; the workspace dep is bumped to `0.4` in anticipation. Until then, the workspace builds and tests with a `[patch.crates-io]` path override.

## Tests

Forwarding tests at each wrapper layer (a mock distinguishes forwarding from the default loop); equivalence tests (`record_n`/`add_n`/`observe_n` ≡ repeated single records, including NaN and zero-count edges); a regression test asserting one `record_many` call buffers exactly one entry; end-to-end render tests for the classic-bucket and summary paths.
