### PR TITLE
feat(metrics-exporter-prometheus): expose clear() method from registry

### DIFF
--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -465,4 +465,11 @@ impl PrometheusHandle {
     pub fn run_upkeep(&self) {
         self.inner.run_upkeep();
     }
+
+    /// Clears the underlying registry via [`Registry::clear()`](metrics_util::registry::Registry::clear).
+    ///
+    /// Note that this is eventually consistent. See also the docs on [`Registry::clear()`].
+    pub fn clear(&self) {
+        self.inner.registry.clear();
+    }
 }


### PR DESCRIPTION
Similarly to #653, I need to remove data from the registry, and in my case, just clearing the whole registry suffices.
I hope this also helps some other people. :)