### PR TITLE
feat(metrics-exporter-datadog): sanitize metric name and labels by default

### DIFF
--- a/metrics-exporter-dogstatsd/src/builder.rs
+++ b/metrics-exporter-dogstatsd/src/builder.rs
@@ -98,6 +98,7 @@ pub struct DogStatsDBuilder {
     histogram_sampling: bool,
     histogram_reservoir_size: usize,
     histograms_as_distributions: bool,
+    sanitize_labels: bool,
     global_labels: Vec<Label>,
     global_prefix: Option<String>,
 }
@@ -241,6 +242,15 @@ impl DogStatsDBuilder {
         self
     }
 
+    /// Sets whether labels are sanitized according to Datadog's tag rules.
+    ///
+    /// Defaults to `true`.
+    #[must_use]
+    pub fn with_label_sanitization(mut self, enabled: bool) -> Self {
+        self.sanitize_labels = enabled;
+        self
+    }
+
     /// Adds a global prefix for every metric name.
     ///
     /// Global prefix is applied to all metrics. Its intended use is to introduce a configurable
@@ -367,6 +377,7 @@ impl DogStatsDBuilder {
             flush_interval,
             write_timeout: self.write_timeout,
             global_labels: self.global_labels,
+            sanitize_labels: self.sanitize_labels,
         };
 
         if self.synchronous {
@@ -415,6 +426,7 @@ impl Default for DogStatsDBuilder {
             histogram_sampling: false,
             histogram_reservoir_size: DEFAULT_HISTOGRAM_RESERVOIR_SIZE,
             histograms_as_distributions: true,
+            sanitize_labels: true,
             global_labels: Vec::default(),
             global_prefix: Option::default(),
         }
@@ -424,6 +436,15 @@ impl Default for DogStatsDBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn label_sanitization_configuration() {
+        let builder = DogStatsDBuilder::default();
+        assert!(builder.sanitize_labels);
+
+        let builder = builder.with_label_sanitization(false);
+        assert!(!builder.sanitize_labels);
+    }
 
     #[test]
     fn default_flush_interval_agg_mode() {

--- a/metrics-exporter-dogstatsd/src/forwarder/mod.rs
+++ b/metrics-exporter-dogstatsd/src/forwarder/mod.rs
@@ -121,6 +121,8 @@ pub(crate) struct ForwarderConfiguration {
 
     /// Global labels to attach to all metrics.
     pub global_labels: Vec<Label>,
+
+    pub sanitize_labels: bool,
 }
 
 impl ForwarderConfiguration {

--- a/metrics-exporter-dogstatsd/src/forwarder/sync.rs
+++ b/metrics-exporter-dogstatsd/src/forwarder/sync.rs
@@ -147,7 +147,8 @@ impl Forwarder {
         let mut flush_state = FlushState::default();
         let mut writer =
             PayloadWriter::new(self.config.max_payload_len, self.config.is_length_prefixed())
-                .with_global_labels(&self.config.global_labels);
+                .with_global_labels(&self.config.global_labels)
+                .with_label_sanitization(self.config.sanitize_labels);
         let mut telemetry_update = TelemetryUpdate::default();
 
         let mut next_flush = Instant::now() + self.config.flush_interval;

--- a/metrics-exporter-dogstatsd/src/writer.rs
+++ b/metrics-exporter-dogstatsd/src/writer.rs
@@ -3,6 +3,7 @@ use std::vec::Drain;
 use metrics::{Key, Label};
 
 const SMALLEST_VALID_PAYLOAD: &[u8] = b"a:0|c\n";
+const MAX_TAG_LENGTH: usize = 200;
 
 #[derive(Clone, Copy)]
 enum MetricType {
@@ -108,6 +109,7 @@ pub(super) struct PayloadWriter {
     trailer_buf: Vec<u8>,
     with_length_prefix: bool,
     global_tags: Vec<Label>,
+    sanitize_labels: bool,
 }
 
 impl PayloadWriter {
@@ -137,6 +139,7 @@ impl PayloadWriter {
             trailer_buf: Vec::new(),
             with_length_prefix,
             global_tags: Vec::new(),
+            sanitize_labels: true,
         };
 
         writer.prepare_for_write();
@@ -146,6 +149,11 @@ impl PayloadWriter {
     /// Sets the global labels to apply to all metrics.
     pub fn with_global_labels(mut self, global_labels: &[Label]) -> Self {
         self.global_tags = global_labels.to_vec();
+        self
+    }
+
+    pub fn with_label_sanitization(mut self, enabled: bool) -> Self {
+        self.sanitize_labels = enabled;
         self
     }
 
@@ -286,6 +294,7 @@ impl PayloadWriter {
         let tags = key.labels();
         let mut wrote_tag = false;
         for tag in tags.chain(self.global_tags.iter()) {
+            let trailer_len = self.trailer_buf.len();
             // If we haven't written a tag yet, write out the tags prefix first.
             //
             // Otherwise, write a tag separator.
@@ -293,10 +302,13 @@ impl PayloadWriter {
                 self.trailer_buf.push(b',');
             } else {
                 self.trailer_buf.extend_from_slice(b"|#");
-                wrote_tag = true;
             }
 
-            write_tag(&mut self.trailer_buf, tag);
+            if write_tag(&mut self.trailer_buf, tag, self.sanitize_labels) {
+                wrote_tag = true;
+            } else {
+                self.trailer_buf.truncate(trailer_len);
+            }
         }
 
         if let Some(timestamp) = maybe_timestamp {
@@ -564,16 +576,55 @@ impl<'a> Payloads<'a> {
     }
 }
 
-fn write_tag(buf: &mut Vec<u8>, label: &Label) {
-    // If the label value is empty, we treat it as a bare label. This means all we write is something like
-    // `label_name`, instead of a more naive form, like `label_name:`.
-    buf.extend_from_slice(label.key().as_bytes());
-    if label.value().is_empty() {
-        return;
+fn write_tag(buf: &mut Vec<u8>, label: &Label, sanitize_labels: bool) -> bool {
+    if !sanitize_labels {
+        buf.extend_from_slice(label.key().as_bytes());
+        if !label.value().is_empty() {
+            buf.push(b':');
+            buf.extend_from_slice(label.value().as_bytes());
+        }
+        return true;
     }
 
-    buf.push(b':');
-    buf.extend_from_slice(label.value().as_bytes());
+    let start = buf.len();
+    let mut chars_written = 0;
+    let mut last_was_underscore = false;
+    let separator = (!label.value().is_empty()).then_some(':');
+    let chars = label.key().chars().chain(separator).chain(label.value().chars());
+
+    'tag: for character in chars {
+        for character in character.to_lowercase() {
+            if chars_written == MAX_TAG_LENGTH {
+                break 'tag;
+            }
+            if chars_written == 0 && !character.is_alphabetic() {
+                continue;
+            }
+
+            let character = if character.is_alphanumeric()
+                || matches!(character, '_' | '-' | ':' | '.' | '/')
+            {
+                character
+            } else {
+                '_'
+            };
+
+            if character == '_' && last_was_underscore {
+                continue;
+            }
+
+            let mut encoded = [0; 4];
+            buf.extend_from_slice(character.encode_utf8(&mut encoded).as_bytes());
+            chars_written += 1;
+            last_was_underscore = character == '_';
+        }
+    }
+
+    if last_was_underscore {
+        buf.pop();
+    }
+
+    buf.len() != start
 }
 
 #[cfg(test)]
@@ -584,7 +635,7 @@ mod tests {
     use crate::writer::SMALLEST_VALID_PAYLOAD;
     const SMALLEST_VALID_PAYLOAD_LEN: usize = SMALLEST_VALID_PAYLOAD.len();
 
-    use super::PayloadWriter;
+    use super::{write_tag, PayloadWriter};
 
     #[derive(Debug)]
     enum InputMetric {
@@ -700,6 +751,67 @@ mod tests {
             let actual = string_from_writer(&mut writer);
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn sanitizes_labels_by_default() {
+        let key = Key::from_parts("test_counter", &[("tag", "Foo|Bar")]);
+        let mut writer = PayloadWriter::new(8192, false);
+
+        let result = writer.write_counter(&key, 1, None, None);
+        assert_eq!(result.payloads_written(), 1);
+
+        let actual = string_from_writer(&mut writer);
+        assert_eq!(actual, "test_counter:1|c|#tag:foo_bar\n");
+    }
+
+    #[test]
+    fn sanitizes_labels_using_datadog_rules() {
+        let key =
+            Key::from_parts("test_counter", &[("_Env NAME", "Staging|East___"), ("RÉGION", "気")]);
+        let mut writer = PayloadWriter::new(8192, false);
+
+        let result = writer.write_counter(&key, 1, None, None);
+        assert_eq!(result.payloads_written(), 1);
+
+        let actual = string_from_writer(&mut writer);
+        assert_eq!(actual, "test_counter:1|c|#env_name:staging_east,région:気\n");
+    }
+
+    #[test]
+    fn limits_sanitized_labels_to_two_hundred_characters() {
+        let label = Label::new("tag", "x".repeat(250));
+        let mut buf = Vec::new();
+
+        assert!(write_tag(&mut buf, &label, true));
+
+        let tag = String::from_utf8(buf).unwrap();
+        assert_eq!(tag.chars().count(), 200);
+        assert!(tag.starts_with("tag:"));
+    }
+
+    #[test]
+    fn omits_labels_that_are_empty_after_sanitizing() {
+        let key = Key::from_parts("test_counter", &[("123", "___")]);
+        let mut writer = PayloadWriter::new(8192, false);
+
+        let result = writer.write_counter(&key, 1, None, None);
+        assert_eq!(result.payloads_written(), 1);
+
+        let actual = string_from_writer(&mut writer);
+        assert_eq!(actual, "test_counter:1|c\n");
+    }
+
+    #[test]
+    fn allows_label_sanitization_to_be_disabled() {
+        let key = Key::from_parts("test_counter", &[("tag", "Foo|Bar")]);
+        let mut writer = PayloadWriter::new(8192, false).with_label_sanitization(false);
+
+        let result = writer.write_counter(&key, 1, None, None);
+        assert_eq!(result.payloads_written(), 1);
+
+        let actual = string_from_writer(&mut writer);
+        assert_eq!(actual, "test_counter:1|c|#tag:Foo|Bar\n");
     }
 
     #[test]

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -628,9 +628,9 @@ mod tests {
 
     #[test]
     fn test_buildhasherdefault_keyhasher_agrees_with_get_hash() {
-        use std::hash::{BuildHasher, BuildHasherDefault};
         #[allow(deprecated)]
         use crate::KeyHasher;
+        use std::hash::{BuildHasher, BuildHasherDefault};
 
         // The Registry in `metrics-util` versions 0.19.0..=0.20.1 uses
         // `BuildHasherDefault<metrics::KeyHasher>` as the HashMap's BuildHasher, while looking
@@ -646,9 +646,9 @@ mod tests {
 
     #[test]
     fn test_keyhasher_byte_mode_distinguishes_inputs() {
-        use std::hash::{BuildHasher, BuildHasherDefault};
         #[allow(deprecated)]
         use crate::KeyHasher;
+        use std::hash::{BuildHasher, BuildHasherDefault};
 
         // Validates the byte-mode fallback path used by `metrics_util::DefaultHashable<H>` in
         // `metrics-util 0.19.x`: when `Hash::hash` writes bytes (not just `write_u64`), the


### PR DESCRIPTION
Sanitize DogStatsD labels by default before writing payloads.

The sanitizer lowercases tags, replaces invalid runs, trims underscores, and enforces the 200-character limit. `with_label_sanitization(false)` keeps raw labels for non-Datadog targets.

Fixes #603

Tests:
- `cargo test -p metrics-exporter-dogstatsd --all-features`
- `cargo clippy -p metrics-exporter-dogstatsd --all-features --all-targets`
- `cargo fmt --all -- --check`