### PR TITLE
fix(metrics-exporter-prometheus): use portable atomics

### DIFF
--- a/metrics-exporter-prometheus/src/native_histogram.rs
+++ b/metrics-exporter-prometheus/src/native_histogram.rs
@@ -3,8 +3,9 @@
 //! This module implements Prometheus native histograms, which use exponential buckets
 //! to efficiently represent histogram data without requiring predefined bucket boundaries.
 
+use metrics::atomics::AtomicU64;
 use std::collections::btree_map::Entry;
-use std::sync::atomic::{AtomicI32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI32, Ordering};
 
 /// IEEE 754 frexp implementation matching Go's math.Frexp behavior.
 /// Returns (mantissa, exponent) such that f = mantissa × 2^exponent,

--- a/metrics/src/key.rs
+++ b/metrics/src/key.rs
@@ -628,9 +628,9 @@ mod tests {
 
     #[test]
     fn test_buildhasherdefault_keyhasher_agrees_with_get_hash() {
-        use std::hash::{BuildHasher, BuildHasherDefault};
         #[allow(deprecated)]
         use crate::KeyHasher;
+        use std::hash::{BuildHasher, BuildHasherDefault};
 
         // The Registry in `metrics-util` versions 0.19.0..=0.20.1 uses
         // `BuildHasherDefault<metrics::KeyHasher>` as the HashMap's BuildHasher, while looking
@@ -646,9 +646,9 @@ mod tests {
 
     #[test]
     fn test_keyhasher_byte_mode_distinguishes_inputs() {
-        use std::hash::{BuildHasher, BuildHasherDefault};
         #[allow(deprecated)]
         use crate::KeyHasher;
+        use std::hash::{BuildHasher, BuildHasherDefault};
 
         // Validates the byte-mode fallback path used by `metrics_util::DefaultHashable<H>` in
         // `metrics-util 0.19.x`: when `Hash::hash` writes bytes (not just `write_u64`), the


### PR DESCRIPTION
Use `metrics::atomics::AtomicU64` instead of `std::sync::atomic::AtomicU64` so the crate builds for platforms lacking 64-bit atomics support.