### PR TITLE
fix(metrics-exporter-tcp): remove double client_count decrement on WAKER-path disconnect

### DIFF
--- a/metrics-exporter-tcp/src/lib.rs
+++ b/metrics-exporter-tcp/src/lib.rs
@@ -436,7 +436,6 @@ fn run_transport(
                         let done = drive_connection(conn, wbuf, msgs);
                         if done {
                             clients_to_remove.push(*token);
-                            state.decrement_clients();
                             continue;
                         }
 
@@ -458,7 +457,6 @@ fn run_transport(
                         let done = drive_connection(conn, wbuf, msgs);
                         if done {
                             clients_to_remove.push(*token);
-                            state.decrement_clients();
                         }
                     }
 
@@ -639,4 +637,89 @@ fn would_block(err: &io::Error) -> bool {
 
 fn interrupted(err: &io::Error) -> bool {
     err.kind() == io::ErrorKind::Interrupted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{TcpListener as StdTcpListener, TcpStream as StdTcpStream};
+    use std::time::Duration;
+
+    // Poll `client_count` until `pred` holds or the bounded retry budget is
+    // exhausted. Termination is decided by the predicate, not by elapsed time;
+    // the short sleep only yields to the exporter thread between checks.
+    fn poll_until<F>(recorder: &TcpRecorder, pred: F) -> bool
+    where
+        F: Fn(usize) -> bool,
+    {
+        for _ in 0..1000 {
+            if pred(recorder.state.client_count.load(Ordering::Acquire)) {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+        false
+    }
+
+    // Regression test for https://github.com/metrics-rs/metrics/issues/676
+    //
+    // When the metric fan-out (WAKER) path detects a disconnected client it must
+    // only count it down once. Previously the WAKER branch decremented
+    // `client_count` itself *and* the shared removal loop decremented it again,
+    // so a single disconnect subtracted twice and wrapped the `AtomicUsize`
+    // around. That corrupted the `count == 1` transition in `decrement_clients`,
+    // leaving `should_send` stuck `false` and silently dropping every metric
+    // after one connect/disconnect cycle.
+    #[test]
+    fn waker_removal_decrements_client_count_once() {
+        // Discover a free ephemeral port on localhost, then hand it to the
+        // exporter. Binding-then-dropping avoids depending on a fixed port.
+        let probe = StdTcpListener::bind("127.0.0.1:0").expect("failed to bind probe listener");
+        let addr = probe.local_addr().expect("failed to read probe addr");
+        drop(probe);
+
+        let recorder =
+            TcpBuilder::new().listen_address(addr).build().expect("failed to build TCP recorder");
+
+        // Connect a real client and wait until the exporter has accepted it and
+        // bumped the client count to exactly one.
+        let client = StdTcpStream::connect(addr).expect("failed to connect to exporter");
+        assert!(
+            poll_until(&recorder, |count| count == 1),
+            "exporter never registered the connected client",
+        );
+
+        // Register a counter and record once while the client is alive so the
+        // fan-out (WAKER) path first runs against a live connection.
+        let metadata = metrics::Metadata::new("test", metrics::Level::INFO, None);
+        let counter = recorder.register_counter(&Key::from_name("issue_676"), &metadata);
+        counter.increment(1);
+
+        // Disconnect the client, then keep recording to drive the WAKER fan-out
+        // path until it observes the broken connection and removes the client.
+        // On the buggy code this double-decrements and wraps `client_count` to a
+        // huge value; on the fix it settles back to zero.
+        drop(client);
+
+        let mut removed = false;
+        for _ in 0..1000 {
+            counter.increment(1);
+            if recorder.state.client_count.load(Ordering::Acquire) == 0 {
+                removed = true;
+                break;
+            }
+            // Give the exporter thread a chance to process the wake and let the
+            // peer reset arrive so the next write fails deterministically. The
+            // loop exits on the count check above, not on elapsed time.
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        let final_count = recorder.state.client_count.load(Ordering::Acquire);
+        assert!(
+            removed,
+            "client_count never returned to 0 after a WAKER-path disconnect \
+             (double-decrement wrapped it to {final_count}); should_send is now {}",
+            recorder.state.should_send(),
+        );
+    }
 }


### PR DESCRIPTION
Fixes #676.

## Root cause
In `run_transport`, the metric fan-out (`WAKER`) branch removes a disconnected client by both pushing its token to `clients_to_remove` *and* calling `state.decrement_clients()` inline (at the two `if done { ... }` sites). The shared removal loop then calls `state.decrement_clients()` again when it does `clients.remove(&token)`. So a single WAKER-path disconnect decrements the `client_count` `AtomicUsize` **twice**: `fetch_sub` takes it 1 -> 0 (which sets `should_send = false`), then 0 -> `usize::MAX` (wrap). Because `should_send()` gates `push_metric`, the recorder then silently drops every counter/gauge/histogram after just one connect/disconnect cycle.

The per-client token branch already shows the intended pattern: it decrements exactly once at the point of removal.

## Fix
Remove the two redundant `state.decrement_clients()` calls in the WAKER branch, leaving the removal loop as the single decrement -- matching the token branch. Two lines deleted, no behavior change on the happy path.

## Test
Adds an in-crate regression test (`waker_removal_decrements_client_count_once`) that binds the exporter to a localhost ephemeral port, connects a real `TcpStream`, records a metric to run the WAKER fan-out with a live client, disconnects, then keeps recording to drive the WAKER removal path while polling `client_count` (bounded retries, no timing-dependent sleeps for correctness).

- Before the fix: `client_count` wraps to `usize::MAX` and never returns to 0 (assertion reports `18446744073709551615`, `should_send` stuck `false`).
- After the fix: it settles back to 0 and the test passes.

## Verification
- `cargo test -p metrics-exporter-tcp` -- red before the fix, green after.
- `cargo fmt -p metrics-exporter-tcp --check` -- clean.
- `cargo clippy` -- no new warnings from this change.

---
This contribution was prepared with AI assistance and reviewed by me before submission.