### PR TITLE
fix(metrics-exporter-prometheus): don't evict metrics with live handles

### DIFF
--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- `idle_timeout` no longer removes metrics whose handle is still held by the application. Removing
+  them freed nothing, since the handle owns the metric's storage, and it stranded the holder: its
+  later updates landed in storage no longer reachable from the registry, so the metric stayed
+  missing from the scrape output for good. Such a metric is now removed on the first render after
+  its last handle is dropped.
+
 ## [0.18.3] - 2026-04-30
 
 ### Fixed

--- a/metrics-exporter-prometheus/src/exporter/builder.rs
+++ b/metrics-exporter-prometheus/src/exporter/builder.rs
@@ -393,6 +393,13 @@ impl PrometheusBuilder {
     /// generate rendered output, and so metrics will not be removed unless a request has been made recently enough to
     /// prune the idle metrics.
     ///
+    /// Metrics whose handles the application still holds are the exception: they are never removed, however long they
+    /// stay idle.  A handle -- the [`Counter`](metrics::Counter), [`Gauge`](metrics::Gauge) or
+    /// [`Histogram`](metrics::Histogram) returned when the metric is registered -- owns the metric's storage, so
+    /// removing the registry's entry would free nothing, and would strand its holder: later updates through that handle
+    /// would land in storage that no longer backs anything in the scrape output, silencing the metric for good.  Once
+    /// the last handle to such a metric is dropped, it is pruned like any other idle metric, on the next render.
+    ///
     /// Further, the metric kind "mask" configures which metrics will be considered by the idle timeout.  If the kind of
     /// a metric being considered for idle timeout is not of a kind represented by the mask, it will not be affected,
     /// even if it would have otherwise been removed for exceeding the idle timeout.
@@ -926,9 +933,64 @@ mod tests {
         let rendered = handle.render();
         assert_eq!(rendered, expected);
 
+        // Only unheld metrics are removed, so let go of them first.
+        drop(counter1);
+        drop(gauge1);
+        drop(histo1);
+
         mock.increment(Duration::from_secs(2));
         let rendered = handle.render();
         assert_eq!(rendered, "");
+    }
+
+    #[test]
+    fn test_idle_timeout_keeps_held_handles() {
+        let (clock, mock) = Clock::mock();
+
+        let recorder = PrometheusBuilder::new()
+            .idle_timeout(MetricKindMask::ALL, Some(Duration::from_secs(10)))
+            .set_quantiles(&[0.0, 1.0])
+            .unwrap()
+            .build_with_clock(clock);
+
+        let key = Key::from_name("basic_counter");
+        let counter1 = recorder.register_counter(&key, &METADATA);
+        counter1.increment(42);
+
+        let key = Key::from_name("basic_gauge");
+        let gauge1 = recorder.register_gauge(&key, &METADATA);
+        gauge1.set(-3.14);
+
+        let key = Key::from_name("basic_histogram");
+        let histo1 = recorder.register_histogram(&key, &METADATA);
+        histo1.record(1.0);
+
+        let handle = recorder.handle();
+        let expected = concat!(
+            "# TYPE basic_counter counter\n",
+            "basic_counter 42\n\n",
+            "# TYPE basic_gauge gauge\n",
+            "basic_gauge -3.14\n\n",
+            "# TYPE basic_histogram summary\n",
+            "basic_histogram{quantile=\"0\"} 1\n",
+            "basic_histogram{quantile=\"1\"} 1\n",
+            "basic_histogram_sum 1\n",
+            "basic_histogram_count 1\n\n",
+        );
+
+        assert_eq!(handle.render(), expected);
+
+        // Far past the idle timeout and never updated again, but all three handles are still held:
+        // removing them would silence metrics that their holder can still write to.
+        mock.increment(Duration::from_secs(30));
+        assert_eq!(handle.render(), expected);
+
+        // Dropping the handles makes them removable, and they go on the very next render: being
+        // held does not grant a metric a fresh idle period.
+        drop(counter1);
+        drop(gauge1);
+        drop(histo1);
+        assert_eq!(handle.render(), "");
     }
 
     #[test]
@@ -975,6 +1037,10 @@ mod tests {
         mock.increment(Duration::from_secs(9));
         let rendered = handle.render();
         assert_eq!(rendered, expected);
+
+        drop(counter1);
+        drop(gauge1);
+        drop(histo1);
 
         mock.increment(Duration::from_secs(2));
         let rendered = handle.render();
@@ -1055,6 +1121,10 @@ mod tests {
             "basic_histogram_count{type=\"special\"} 1\n\n",
         );
 
+        drop(counter1);
+        drop(gauge1);
+        drop(histo1);
+
         mock.increment(Duration::from_secs(2));
         let rendered = handle.render();
         assert_eq!(rendered, expected_after);
@@ -1102,6 +1172,11 @@ mod tests {
 
         counter1.increment(1);
 
+        // Dropped so that the counter surviving below is down to its recent update rather than to
+        // us holding it.
+        drop(counter1);
+        drop(gauge1);
+
         let expected_after = concat!("# TYPE basic_counter counter\n", "basic_counter 43\n\n",);
 
         mock.increment(Duration::from_secs(2));
@@ -1134,8 +1209,10 @@ mod tests {
         assert_eq!(rendered, expected);
 
         // Now increment the counter and advance time by two seconds: this pushes it over the idle
-        // timeout threshold, but it should not be removed since it has been updated.
+        // timeout threshold, but it should not be removed since it has been updated.  Dropped
+        // right after, since a held metric is never removed for being idle.
         counter1.increment(1);
+        drop(counter1);
 
         let expected_after = concat!("# TYPE basic_counter counter\n", "basic_counter 43\n\n",);
 

--- a/metrics-exporter-prometheus/src/recorder.rs
+++ b/metrics-exporter-prometheus/src/recorder.rs
@@ -55,14 +55,15 @@ pub(crate) struct Inner {
 
 impl Inner {
     fn get_recent_metrics(&self) -> Snapshot {
+        // Sweep idle metrics before snapshotting, so that a metric being removed is not rendered
+        // one last time on its way out.  Metrics the application still holds a handle to are never
+        // removed, however idle: see `Recency`.
+        self.recency.evict_idle_counters(&self.registry);
+        self.recency.evict_idle_gauges(&self.registry);
+
         let mut counters = HashMap::new();
         let counter_handles = self.registry.get_counter_handles();
         for (key, counter) in counter_handles {
-            let gen = counter.get_generation();
-            if !self.recency.should_store_counter(&key, gen, &self.registry) {
-                continue;
-            }
-
             let name = sanitize_metric_name(key.name());
             let labels = LabelSet::from_key_and_global(&key, &self.global_labels);
             let value = counter.get_inner().load(Ordering::Acquire);
@@ -74,11 +75,6 @@ impl Inner {
         let mut gauges = HashMap::new();
         let gauge_handles = self.registry.get_gauge_handles();
         for (key, gauge) in gauge_handles {
-            let gen = gauge.get_generation();
-            if !self.recency.should_store_gauge(&key, gen, &self.registry) {
-                continue;
-            }
-
             let name = sanitize_metric_name(key.name());
             let labels = LabelSet::from_key_and_global(&key, &self.global_labels);
             let value = f64::from_bits(gauge.get_inner().load(Ordering::Acquire));
@@ -90,28 +86,23 @@ impl Inner {
         // Update distributions
         self.drain_histograms_to_distributions();
         // Remove expired histograms
-        let histogram_handles = self.registry.get_histogram_handles();
-        for (key, histogram) in histogram_handles {
-            let gen = histogram.get_generation();
-            if !self.recency.should_store_histogram(&key, gen, &self.registry) {
-                // Since we store aggregated distributions directly, when we're told that a metric
-                // is not recent enough and should be/was deleted from the registry, we also need to
-                // delete it on our side as well.
-                let name = sanitize_metric_name(key.name());
-                let labels = LabelSet::from_key_and_global(&key, &self.global_labels);
-                let mut wg = self.distributions.write().unwrap_or_else(PoisonError::into_inner);
-                let delete_by_name = if let Some(by_name) = wg.get_mut(&name) {
-                    by_name.swap_remove(&labels);
-                    by_name.is_empty()
-                } else {
-                    false
-                };
+        for key in self.recency.evict_idle_histograms(&self.registry) {
+            // Since we store aggregated distributions directly, when a histogram is removed from
+            // the registry, we also need to delete it on our side as well.
+            let name = sanitize_metric_name(key.name());
+            let labels = LabelSet::from_key_and_global(&key, &self.global_labels);
+            let mut wg = self.distributions.write().unwrap_or_else(PoisonError::into_inner);
+            let delete_by_name = if let Some(by_name) = wg.get_mut(&name) {
+                by_name.swap_remove(&labels);
+                by_name.is_empty()
+            } else {
+                false
+            };
 
-                // If there's no more variants in the per-metric-name distribution map, then delete
-                // it entirely, otherwise we end up with weird empty output during render.
-                if delete_by_name {
-                    wg.remove(&name);
-                }
+            // If there's no more variants in the per-metric-name distribution map, then delete it
+            // entirely, otherwise we end up with weird empty output during render.
+            if delete_by_name {
+                wg.remove(&name);
             }
         }
 

--- a/metrics-util/CHANGELOG.md
+++ b/metrics-util/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **Breaking change**: `Recency::should_store_counter`, `should_store_gauge` and
+  `should_store_histogram` have been replaced by `Recency::evict_idle_counters`,
+  `evict_idle_gauges` and `evict_idle_histograms`, which sweep the registry themselves and return
+  the keys they removed. Exporters that keep per-metric state on the side, such as aggregated
+  distributions, should key their cleanup off the returned keys.
+- Metrics whose handles are still held outside of the registry are no longer removed for being
+  idle. Removing them freed nothing, since the handle owns the metric's storage, and it silenced
+  the holder: its later updates landed in storage the registry could no longer reach. Such a
+  metric is removed by the first sweep after its last handle is dropped.
+
 ## [0.20.4] - 2026-05-13
 
 ### Fixed

--- a/metrics-util/src/registry/recency.rs
+++ b/metrics-util/src/registry/recency.rs
@@ -22,6 +22,13 @@
 //! `Recency` uses the generation of a metric, along with a measurement of time when a metric is
 //! observed, to build a complete picture that allows deciding if a given metric has gone "idle" or
 //! not, and thus whether it should actually be deleted.
+//!
+//! Idleness alone is not sufficient to delete a metric, however, as the caller may still be holding
+//! the handle it was given when the metric was registered.  Deleting the registry's entry for such
+//! a metric frees nothing, since the handle owns the storage, and it orphans the holder: its
+//! subsequent updates land in storage the registry can no longer reach, and the metric is silent
+//! for good.  `Recency` therefore only deletes metrics that the registry holds the last reference
+//! to.
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
@@ -74,6 +81,17 @@ impl<T> Generational<T> {
     /// Gets the current generation.
     pub fn get_generation(&self) -> Generation {
         Generation(self.gen.load(Ordering::Acquire))
+    }
+
+    /// Whether anything other than the registry is holding this metric.
+    ///
+    /// Every clone of a `Generational` clones `gen`, and a handle handed out at registration owns
+    /// one such clone, so a strong count above one means the metric has a live holder.  This is
+    /// only meaningful from inside [`Registry::retain_counters`] and friends, where the map's own
+    /// copy is the sole reference the registry owns, and where holding the shard lock means no
+    /// further clone can be handed out while we decide.
+    fn is_held(&self) -> bool {
+        Arc::strong_count(&self.gen) > 1
     }
 
     /// Acquires a reference to the inner value, and increments the generation.
@@ -214,6 +232,11 @@ impl GenerationalAtomicStorage {
 /// metric has occurred for the purposes of removing idle metrics from the registry.  In addition,
 /// it will remove the value from the registry itself to reduce the aforementioned bloat.
 ///
+/// Metrics whose handles are still held outside of the registry are never removed, however idle
+/// they are: the holder can still write to such a metric, and removing it would silence those
+/// writes while freeing nothing.  Such a metric is removed by the first sweep after its last
+/// handle is dropped, without being granted a fresh idle period.
+///
 /// [`Recency`] is separate from [`Registry`] specifically to avoid imposing any slowdowns when
 /// tracking recency does not matter, despite their otherwise tight coupling.
 #[derive(Debug)]
@@ -244,105 +267,185 @@ where
         Recency { mask, inner: Mutex::new((clock, HashMap::new())), idle_timeout }
     }
 
-    /// Checks if the given counter should be stored, based on its known recency.
+    /// Removes idle counters from the given registry, returning the keys that were removed.
     ///
-    /// If the given key has been updated recently enough, and should continue to be stored, this
-    /// method will return `true` and will update the last update time internally.  If the given key
-    /// has not been updated recently enough, the key will be removed from the given registry if the
-    /// given generation also matches.
-    pub fn should_store_counter<S>(
-        &self,
-        key: &K,
-        gen: Generation,
-        registry: &Registry<K, S>,
-    ) -> bool
+    /// A counter is removed if it has not been updated within the idle timeout and the registry
+    /// holds the last reference to it.  A counter the application is still holding a handle to is
+    /// kept, however idle, and is removed by the first call made after that handle is dropped.
+    pub fn evict_idle_counters<S>(&self, registry: &Registry<K, GenerationalStorage<S>>) -> Vec<K>
     where
         S: Storage<K>,
     {
-        self.should_store(key, gen, registry, MetricKind::Counter, |registry, key| {
-            registry.delete_counter(key)
-        })
+        self.evict(MetricKind::Counter, |f| registry.retain_counters(f))
     }
 
-    /// Checks if the given gauge should be stored, based on its known recency.
+    /// Removes idle gauges from the given registry, returning the keys that were removed.
     ///
-    /// If the given key has been updated recently enough, and should continue to be stored, this
-    /// method will return `true` and will update the last update time internally.  If the given key
-    /// has not been updated recently enough, the key will be removed from the given registry if the
-    /// given generation also matches.
-    pub fn should_store_gauge<S>(&self, key: &K, gen: Generation, registry: &Registry<K, S>) -> bool
+    /// A gauge is removed if it has not been updated within the idle timeout and the registry holds
+    /// the last reference to it.  A gauge the application is still holding a handle to is kept,
+    /// however idle, and is removed by the first call made after that handle is dropped.
+    pub fn evict_idle_gauges<S>(&self, registry: &Registry<K, GenerationalStorage<S>>) -> Vec<K>
     where
         S: Storage<K>,
     {
-        self.should_store(key, gen, registry, MetricKind::Gauge, |registry, key| {
-            registry.delete_gauge(key)
-        })
+        self.evict(MetricKind::Gauge, |f| registry.retain_gauges(f))
     }
 
-    /// Checks if the given histogram should be stored, based on its known recency.
+    /// Removes idle histograms from the given registry, returning the keys that were removed.
     ///
-    /// If the given key has been updated recently enough, and should continue to be stored, this
-    /// method will return `true` and will update the last update time internally.  If the given key
-    /// has not been updated recently enough, the key will be removed from the given registry if the
-    /// given generation also matches.
-    pub fn should_store_histogram<S>(
-        &self,
-        key: &K,
-        gen: Generation,
-        registry: &Registry<K, S>,
-    ) -> bool
+    /// A histogram is removed if it has not been updated within the idle timeout and the registry
+    /// holds the last reference to it.  A histogram the application is still holding a handle to is
+    /// kept, however idle, and is removed by the first call made after that handle is dropped.
+    ///
+    /// Exporters that keep their own state per metric, such as aggregated distributions, should use
+    /// the returned keys to drop the state belonging to the removed histograms.
+    pub fn evict_idle_histograms<S>(&self, registry: &Registry<K, GenerationalStorage<S>>) -> Vec<K>
     where
         S: Storage<K>,
     {
-        self.should_store(key, gen, registry, MetricKind::Histogram, |registry, key| {
-            registry.delete_histogram(key)
-        })
+        self.evict(MetricKind::Histogram, |f| registry.retain_histograms(f))
     }
 
-    fn should_store<F, S>(
-        &self,
-        key: &K,
-        gen: Generation,
-        registry: &Registry<K, S>,
-        kind: MetricKind,
-        delete_op: F,
-    ) -> bool
+    fn evict<T, R>(&self, kind: MetricKind, retain: R) -> Vec<K>
     where
-        F: Fn(&Registry<K, S>, &K) -> bool,
-        S: Storage<K>,
+        R: FnOnce(&mut dyn FnMut(&K, &Generational<T>) -> bool),
     {
-        if let Some(idle_timeout) = self.idle_timeout {
-            if self.mask.matches(kind) {
-                let mut guard = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
-                let (clock, entries) = guard.deref_mut();
+        let mut evicted = Vec::new();
 
-                let now = clock.now();
-                let deleted = if let Some((last_gen, last_update)) = entries.get_mut(key) {
-                    // If the value is the same as the latest value we have internally, and
-                    // we're over the idle timeout period, then remove it and continue.
-                    if *last_gen == gen {
-                        // If the delete returns false, that means that our generation counter is
-                        // out-of-date, and that the metric has been updated since, so we don't
-                        // actually want to delete it yet.
-                        (now - *last_update) > idle_timeout && delete_op(registry, key)
-                    } else {
-                        // Value has changed, so mark it such.
-                        *last_update = now;
-                        *last_gen = gen;
-                        false
-                    }
+        let idle_timeout = match self.idle_timeout {
+            Some(idle_timeout) if self.mask.matches(kind) => idle_timeout,
+            _ => return evicted,
+        };
+
+        let mut guard = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let (clock, entries) = guard.deref_mut();
+        let now = clock.now();
+
+        // Deciding from inside `retain` is what makes `is_held` sound: the shard write lock is held
+        // for the whole visit, and handles are only ever cloned out of the registry under that same
+        // lock, so no holder can appear between the check and the removal.
+        retain(&mut |key, handle| {
+            let gen = handle.get_generation();
+            let evict = if let Some((last_gen, last_update)) = entries.get_mut(key) {
+                // If the value is the same as the latest value we have internally, and we're over
+                // the idle timeout period, then remove it, unless somebody still holds it.
+                if *last_gen == gen {
+                    (now - *last_update) > idle_timeout && !handle.is_held()
                 } else {
-                    entries.insert(key.clone(), (gen, now));
+                    // Value has changed, so mark it such.
+                    *last_update = now;
+                    *last_gen = gen;
                     false
-                };
-
-                if deleted {
-                    entries.remove(key);
-                    return false;
                 }
+            } else {
+                entries.insert(key.clone(), (gen, now));
+                false
+            };
+
+            if evict {
+                entries.remove(key);
+                evicted.push(key.clone());
             }
+
+            !evict
+        });
+
+        evicted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use metrics::{Counter, CounterFn, Gauge, Histogram, Key};
+    use quanta::Clock;
+
+    use super::{GenerationalStorage, Recency};
+    use crate::{registry::Registry, MetricKindMask};
+
+    fn recency(clock: Clock, mask: MetricKindMask) -> Recency<Key> {
+        Recency::new(clock, mask, Some(Duration::from_secs(10)))
+    }
+
+    #[test]
+    fn evicts_idle_counters_but_not_held_ones() {
+        let (clock, mock) = Clock::mock();
+        let registry = Registry::new(GenerationalStorage::atomic());
+        let recency = recency(clock, MetricKindMask::ALL);
+
+        let held = Key::from_name("held");
+        let transient = Key::from_name("transient");
+        let handle: Counter = registry.get_or_create_counter(&held, |c| c.clone().into());
+        handle.increment(1);
+        let _: Counter = registry.get_or_create_counter(&transient, |c| c.clone().into());
+
+        // The first sweep only records when each metric was last seen.
+        assert!(recency.evict_idle_counters(&registry).is_empty());
+
+        mock.increment(Duration::from_secs(11));
+        assert_eq!(recency.evict_idle_counters(&registry), vec![transient.clone()]);
+        assert!(registry.get_counter(&transient).is_none());
+        assert!(registry.get_counter(&held).is_some(), "still held by the caller");
+
+        // Dropping the last handle makes it evictable right away: being held does not grant a
+        // metric a fresh idle period.
+        drop(handle);
+        assert_eq!(recency.evict_idle_counters(&registry), vec![held.clone()]);
+        assert!(registry.get_counter(&held).is_none());
+    }
+
+    #[test]
+    fn evicts_idle_histograms_and_returns_their_keys() {
+        let (clock, mock) = Clock::mock();
+        let registry = Registry::new(GenerationalStorage::atomic());
+        let recency = recency(clock, MetricKindMask::ALL);
+
+        let key = Key::from_name("histogram");
+        let handle: Histogram = registry.get_or_create_histogram(&key, |h| h.clone().into());
+        handle.record(1.0);
+
+        assert!(recency.evict_idle_histograms(&registry).is_empty());
+
+        mock.increment(Duration::from_secs(11));
+        assert!(recency.evict_idle_histograms(&registry).is_empty(), "still held by the caller");
+
+        drop(handle);
+        assert_eq!(recency.evict_idle_histograms(&registry), vec![key.clone()]);
+        assert!(registry.get_histogram(&key).is_none());
+    }
+
+    #[test]
+    fn keeps_metrics_that_are_still_being_updated() {
+        let (clock, mock) = Clock::mock();
+        let registry = Registry::new(GenerationalStorage::atomic());
+        let recency = recency(clock, MetricKindMask::ALL);
+
+        let key = Key::from_name("busy");
+        registry.get_or_create_counter(&key, |c| c.increment(1));
+
+        for _ in 0..3 {
+            mock.increment(Duration::from_secs(11));
+            registry.get_or_create_counter(&key, |c| c.increment(1));
+            assert!(recency.evict_idle_counters(&registry).is_empty());
         }
 
-        true
+        mock.increment(Duration::from_secs(11));
+        assert_eq!(recency.evict_idle_counters(&registry), vec![key]);
+    }
+
+    #[test]
+    fn ignores_metrics_outside_the_mask() {
+        let (clock, mock) = Clock::mock();
+        let registry = Registry::new(GenerationalStorage::atomic());
+        let recency = recency(clock, MetricKindMask::COUNTER);
+
+        let key = Key::from_name("gauge");
+        let _: Gauge = registry.get_or_create_gauge(&key, |g| g.clone().into());
+
+        assert!(recency.evict_idle_gauges(&registry).is_empty());
+        mock.increment(Duration::from_secs(11));
+        assert!(recency.evict_idle_gauges(&registry).is_empty());
+        assert!(registry.get_gauge(&key).is_some());
     }
 }


### PR DESCRIPTION
<NOTE: This is marked as draft as I need to self-review more thoroughly>

Callers may hold a Counter/Gauge/Histogram handle for the lifetime of the process to keep registration off the hot path. With idle_timeout set, the exporter deleted the registry entry for such a metric once it went idle, which fails at both things eviction is for: the storage isn't reclaimed, since the caller's Arc keeps it alive, and if that handle is the metric's only producer, nothing ever re-registers it, so its later updates land in storage the registry can no longer reach. The metric goes silent for the rest of the process's life.

Recency now sweeps the registry through retain_*, which lends it the map's own copy of each handle: a reference count above one means the application is still holding that metric, and the entry stays. Deciding under the shard lock also means a handle handed out by a concurrent registration cannot be orphaned. A metric that was held is evicted by the first sweep after its last handle is dropped, without a fresh idle period.

This replaces Recency::should_store_* with Recency::evict_idle_*, which is a breaking change for metrics-util.