### PR TITLE
fix(metrics-exporter-dogstatsd): support IPv6 remote addresses

### DIFF
--- a/metrics-exporter-dogstatsd/src/forwarder/sync.rs
+++ b/metrics-exporter-dogstatsd/src/forwarder/sync.rs
@@ -2,7 +2,7 @@
 use std::os::unix::net::{UnixDatagram, UnixStream};
 use std::{
     io::{self, Write as _},
-    net::{Ipv4Addr, UdpSocket},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     sync::Arc,
     thread::sleep,
     time::Instant,
@@ -15,6 +15,16 @@ use crate::{
     telemetry::{Telemetry, TelemetryUpdate},
     writer::PayloadWriter,
 };
+
+/// Returns the local address to bind to when connecting to the given remote addresses.
+///
+/// A socket can only connect within its own address family, so this follows the first address that will be tried.
+fn udp_bind_addr(addrs: &[SocketAddr]) -> SocketAddr {
+    match addrs.first() {
+        Some(SocketAddr::V6(_)) => (Ipv6Addr::UNSPECIFIED, 0).into(),
+        _ => (Ipv4Addr::UNSPECIFIED, 0).into(),
+    }
+}
 
 enum Client {
     Udp(UdpSocket),
@@ -29,13 +39,11 @@ enum Client {
 impl Client {
     fn from_forwarder_config(config: &ForwarderConfiguration) -> io::Result<Self> {
         match &config.remote_addr {
-            RemoteAddr::Udp(addrs) => {
-                UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).and_then(|socket| {
-                    socket.connect(&addrs[..])?;
-                    socket.set_write_timeout(Some(config.write_timeout))?;
-                    Ok(Client::Udp(socket))
-                })
-            }
+            RemoteAddr::Udp(addrs) => UdpSocket::bind(udp_bind_addr(addrs)).and_then(|socket| {
+                socket.connect(&addrs[..])?;
+                socket.set_write_timeout(Some(config.write_timeout))?;
+                Ok(Client::Udp(socket))
+            }),
 
             #[cfg(unix)]
             RemoteAddr::Unixgram(path) => UnixDatagram::unbound().and_then(|socket| {
@@ -210,5 +218,23 @@ impl Forwarder {
 
             self.update_telemetry(&telemetry_update);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn udp_bind_addr_matches_remote_address_family() {
+        let v4 = SocketAddr::from((Ipv4Addr::LOCALHOST, 8125));
+        let v6 = SocketAddr::from((Ipv6Addr::LOCALHOST, 8125));
+        let v4_bind = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0));
+        let v6_bind = SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0));
+
+        assert_eq!(udp_bind_addr(&[v4]), v4_bind);
+        assert_eq!(udp_bind_addr(&[v6]), v6_bind);
+        assert_eq!(udp_bind_addr(&[v6, v4]), v6_bind);
+        assert_eq!(udp_bind_addr(&[v4, v6]), v4_bind);
     }
 }


### PR DESCRIPTION
`metrics-exporter-dogstatsd` can't send to an IPv6 remote address. In `forwarder/sync.rs` the UDP socket is always bound to `Ipv4Addr::UNSPECIFIED` regardless of the remote's address family, so connecting the resulting `AF_INET` socket to an IPv6 remote is rejected by the kernel (`EAFNOSUPPORT` on Linux, `EINVAL` on macOS).

The failure is silent. `RemoteAddr::try_from` uses `to_socket_addrs()`, so `[::1]:8125` and `udp://[fd00::1]:8125` parse fine and neither `with_remote_address()` nor `build()` returns an error. Socket creation is deferred to the forwarder thread's first flush, and on failure the state machine falls back to `Disconnected` and retries on the next one. So the application starts up normally and drops every metric, logging only `Failed to send payload.` once per flush interval.

This patch selects the bind address family from the first remote address, with a unit test covering that selection. I also verified locally that a datagram now reaches a real `[::1]` listener, but left that round trip out as a test since it would be flaky on runners without IPv6 loopback.

Known limitation: `connect(&addrs[..])` walks the whole address list, but the socket family is fixed by the first entry, so a mixed-family list can still fail on the rest. Doing that properly needs a socket per attempt inside the connect loop, which felt like more surgery than this bug warrants — happy to fold it in if you'd rather. It does mean a hostname resolving AAAA-first now connects over IPv6 instead of falling through to IPv4; the default `127.0.0.1:8125` is unaffected.
