### PR TITLE
feat(metrics-tracing-context): add configurable per-field merge policy

### DIFF
--- a/metrics-tracing-context/CHANGELOG.md
+++ b/metrics-tracing-context/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Added `FieldMergePolicy` and `MetricsLayer::with_field_merge_policy`, allowing the merge
+  behavior for duplicate span field names to be configured per field, such as composing
+  hierarchical values (e.g. `component = "analyzer.worker"`) across nested spans.
+
 ## [0.18.1] - 2025-06-20
 
 ### Changed

--- a/metrics-tracing-context/README.md
+++ b/metrics-tracing-context/README.md
@@ -1,3 +1,20 @@
 # metrics-tracing-context
 
 A crate to use tracing context as metrics labels.
+
+## Configuring field merge policies
+
+By default, when a child span defines a field that its parent also defines, the child's
+value wins. This behavior can be customized per field name using a `FieldMergePolicy`,
+for example to compose hierarchical values across nested spans:
+
+```rust
+use metrics_tracing_context::{FieldMergePolicy, MetricsLayer};
+
+let metrics_layer = MetricsLayer::new()
+    .with_field_merge_policy("component", FieldMergePolicy::Append("."));
+```
+
+With this configuration, given a root span with `component = "analyzer"` and a nested
+span with `component = "worker"`, metrics emitted within the nested span will carry
+`component = "analyzer.worker"`.

--- a/metrics-tracing-context/src/field_merge.rs
+++ b/metrics-tracing-context/src/field_merge.rs
@@ -1,0 +1,32 @@
+//! Field merge policies.
+//!
+//! A [`FieldMergePolicy`] determines what happens when the same span field name shows up
+//! more than once: either a child span defines a field that its parent also defines, or
+//! [`Span::record`][tracing::Span::record] is used to set a value for a field that the span
+//! already holds. Policies are configured per field name via
+//! [`MetricsLayer::with_field_merge_policy`][crate::MetricsLayer::with_field_merge_policy].
+
+/// The merge policy applied when a value is merged over an existing value for the same
+/// span field name.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum FieldMergePolicy {
+    /// The most recently defined value wins: a child span's field overrides the value
+    /// inherited from its parent, and a recorded value overrides the previously held one.
+    ///
+    /// This is the historical behavior of the crate, and it applies to any field name
+    /// without an explicitly configured policy.
+    Override,
+    /// Compose both values hierarchically as `<outer><sep><inner>`.
+    ///
+    /// When a child span inherits a field from its parent, the parent's value is treated
+    /// as the outer value and the child's own value as the inner one. When a value is set
+    /// via [`Span::record`][tracing::Span::record], the previously held value is treated
+    /// as the outer value and the newly recorded value as the inner one. If only one of
+    /// the two values exists, it is used as-is.
+    ///
+    /// As spans nest, values accumulate into a path: given `component = "analyzer"` on the
+    /// root span, `component = "worker"` on a child span, and `component = "task"` on a
+    /// grandchild span, metrics emitted within the grandchild span see
+    /// `component = "analyzer.worker.task"`.
+    Append(&'static str),
+}

--- a/metrics-tracing-context/src/lib.rs
+++ b/metrics-tracing-context/src/lib.rs
@@ -75,6 +75,39 @@
 //! multiple times only keeps the most recently recorded value, including if a field was already present
 //! from a parent span and is then recorded dynamically in the current span.
 //!
+//! ## Configuring field merge policies
+//!
+//! The merge behavior can be customized per field name by configuring a
+//! [`FieldMergePolicy`] on [`MetricsLayer`]. This is particularly useful for hierarchical
+//! values, such as component paths, where nested spans should compose their values into a
+//! single label instead of overriding each other:
+//!
+//! ```rust
+//! # use metrics_util::{debugging::DebuggingRecorder, layers::Layer};
+//! # use tracing_subscriber::{layer::SubscriberExt, Registry};
+//! use metrics_tracing_context::{FieldMergePolicy, MetricsLayer, TracingContextLayer};
+//!
+//! # let my_recorder = DebuggingRecorder::new();
+//! let metrics_layer = MetricsLayer::new()
+//!     .with_field_merge_policy("component", FieldMergePolicy::Append("."));
+//! let subscriber = Registry::default().with(metrics_layer);
+//! let recorder = TracingContextLayer::all().layer(my_recorder);
+//! # metrics::with_local_recorder(&recorder, || {
+//! # use tracing::{span, Level};
+//! # let root = span!(Level::TRACE, "root", component = "analyzer");
+//! # let _root_guard = root.enter();
+//! # let leaf = span!(Level::TRACE, "leaf", component = "worker");
+//! # let _leaf_guard = leaf.enter();
+//! # use metrics::counter;
+//! counter!("jobs_processed").increment(1);
+//! # });
+//! ```
+//!
+//! With this configuration, a metric emitted within both spans would carry
+//! `component = "analyzer.worker"`, as the values are composed from the span ancestry.
+//! Fields without an explicitly configured policy continue to use
+//! [`FieldMergePolicy::Override`], which preserves this crate's historical behavior.
+//!
 //! ## Span fields and ancestry
 //!
 //! Likewise, we capture the sum of all fields for a span and its parent span(s), meaning that if you have the
@@ -106,9 +139,11 @@ use metrics::{
 };
 use metrics_util::layers::Layer;
 
+pub mod field_merge;
 pub mod label_filter;
 mod tracing_integration;
 
+pub use field_merge::FieldMergePolicy;
 pub use label_filter::LabelFilter;
 use tracing_integration::Map;
 pub use tracing_integration::{Labels, MetricsLayer};

--- a/metrics-tracing-context/src/tracing_integration.rs
+++ b/metrics-tracing-context/src/tracing_integration.rs
@@ -1,10 +1,13 @@
 //! The code that integrates with the `tracing` crate.
 
+use crate::field_merge::FieldMergePolicy;
+use indexmap::map::Entry;
 use indexmap::IndexMap;
 use lockfree_object_pool::{LinearObjectPool, LinearOwnedReusable};
 use metrics::{Key, SharedString};
 use once_cell::sync::OnceCell;
 use std::cmp;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tracing_core::span::{Attributes, Id, Record};
 use tracing_core::{field::Visit, Dispatch, Field, Subscriber};
@@ -95,17 +98,35 @@ impl AsRef<Map> for Labels {
 
 /// [`MetricsLayer`] is a [`tracing_subscriber::Layer`] that captures the span
 /// fields and allows them to be later on used as metrics labels.
+///
+/// Merge behavior for individual field names can be customized via
+/// [`MetricsLayer::with_field_merge_policy`].
 #[derive(Default)]
 pub struct MetricsLayer {
     #[allow(clippy::type_complexity)]
     with_labels:
         Option<fn(&Dispatch, &Id, f: &mut dyn FnMut(&Labels) -> Option<Key>) -> Option<Key>>,
+    field_merges: HashMap<String, FieldMergePolicy>,
 }
 
 impl MetricsLayer {
     /// Create a new [`MetricsLayer`].
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Configures the [`FieldMergePolicy`] applied when merging values for the given
+    /// span field name.
+    ///
+    /// Field names without an explicitly configured policy are merged using
+    /// [`FieldMergePolicy::Override`], which preserves this crate's historical behavior.
+    pub fn with_field_merge_policy(
+        mut self,
+        field: impl AsRef<str>,
+        policy: FieldMergePolicy,
+    ) -> Self {
+        self.field_merges.insert(field.as_ref().to_owned(), policy);
+        self
     }
 
     pub(crate) fn with_labels(
@@ -139,7 +160,31 @@ where
 
         if let Some(parent) = span.parent() {
             if let Some(parent_labels) = parent.extensions().get::<Labels>() {
-                labels.extend_from_labels(parent_labels);
+                if self.field_merges.is_empty() {
+                    labels.extend_from_labels(parent_labels);
+                } else {
+                    // Merging the parent's values over the child's own values: for
+                    // `Append`, the parent's value is the outer value and the value
+                    // already held by the child is the inner one.
+                    let field_merges = &self.field_merges;
+                    labels.extend(parent_labels, |map, k, v| {
+                        match field_merges.get(k.as_ref()) {
+                            Some(FieldMergePolicy::Append(sep)) => match map.entry(k.clone()) {
+                                Entry::Occupied(mut entry) => {
+                                    let composed = format!("{v}{sep}{}", entry.get());
+                                    entry.insert(composed.into());
+                                }
+                                Entry::Vacant(entry) => {
+                                    entry.insert(v.clone());
+                                }
+                            },
+                            // `FieldMergePolicy::Override`: the child's own value wins.
+                            _ => {
+                                map.entry(k.clone()).or_insert_with(|| v.clone());
+                            }
+                        }
+                    });
+                }
             }
         }
 
@@ -152,7 +197,29 @@ where
 
         let ext = &mut span.extensions_mut();
         if let Some(existing) = ext.get_mut::<Labels>() {
-            existing.extend_from_labels_overwrite(&labels);
+            if self.field_merges.is_empty() {
+                existing.extend_from_labels_overwrite(&labels);
+            } else {
+                // Merging the newly recorded values over the values held so far: for
+                // `Append`, the previously held value is the outer value and the newly
+                // recorded value is the inner one.
+                let field_merges = &self.field_merges;
+                existing.extend(&labels, |map, k, v| match field_merges.get(k.as_ref()) {
+                    Some(FieldMergePolicy::Append(sep)) => match map.entry(k.clone()) {
+                        Entry::Occupied(mut entry) => {
+                            let composed = format!("{}{sep}{v}", entry.get());
+                            entry.insert(composed.into());
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert(v.clone());
+                        }
+                    },
+                    // `FieldMergePolicy::Override`: the newly recorded value wins.
+                    _ => {
+                        map.insert(k.clone(), v.clone());
+                    }
+                });
+            }
         } else {
             ext.insert(labels);
         }

--- a/metrics-tracing-context/tests/integration.rs
+++ b/metrics-tracing-context/tests/integration.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use metrics::{counter, Key, KeyName, Label};
-use metrics_tracing_context::{LabelFilter, MetricsLayer, TracingContextLayer};
+use metrics_tracing_context::{FieldMergePolicy, LabelFilter, MetricsLayer, TracingContextLayer};
 use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshot};
 use metrics_util::{layers::Layer, CompositeKey, MetricKind};
 use tracing::dispatcher::{set_default, Dispatch};
@@ -70,12 +70,31 @@ static SAME_CALLSITE_PATH_2: &[Label] = &[
     Label::from_static_parts("path2_specific", "bar"),
     Label::from_static_parts("path2_specific_dynamic", "bar_dynamic"),
 ];
+static COMPONENT_WORKER_PATH: &[Label] =
+    &[Label::from_static_parts("component", "analyzer.worker")];
+static COMPONENT_TASK_PATH: &[Label] =
+    &[Label::from_static_parts("component", "analyzer.worker.task")];
+static COMPONENT_SKIPPED_PATH: &[Label] = &[Label::from_static_parts("component", "analyzer.task")];
+static COMPONENT_INHERITED: &[Label] = &[Label::from_static_parts("component", "analyzer")];
+static COMPONENT_RECORDED_PATH: &[Label] =
+    &[Label::from_static_parts("component", "analyzer.worker")];
+static COMPONENT_RECORDED_LEAF_PATH: &[Label] =
+    &[Label::from_static_parts("component", "analyzer.worker.leaf")];
+static COMPONENT_METRIC_LABEL_WINS: &[Label] = &[Label::from_static_parts("component", "manual")];
+static PER_FIELD_ISOLATION: &[Label] = &[
+    Label::from_static_parts("component", "outer_c.inner_c"),
+    Label::from_static_parts("shared", "inner_s"),
+];
 
-fn with_tracing_layer<F>(layer: TracingContextLayer<F>, f: impl FnOnce()) -> Snapshot
+fn with_metrics_tracing_layer<F>(
+    metrics_layer: MetricsLayer,
+    layer: TracingContextLayer<F>,
+    f: impl FnOnce(),
+) -> Snapshot
 where
     F: LabelFilter + Clone + 'static,
 {
-    let subscriber = Registry::default().with(MetricsLayer::new());
+    let subscriber = Registry::default().with(metrics_layer);
     let _tracing_guard = set_default(&Dispatch::new(subscriber));
 
     let recorder = DebuggingRecorder::new();
@@ -85,6 +104,13 @@ where
     metrics::with_local_recorder(&recorder, f);
 
     snapshotter.snapshot()
+}
+
+fn with_tracing_layer<F>(layer: TracingContextLayer<F>, f: impl FnOnce()) -> Snapshot
+where
+    F: LabelFilter + Clone + 'static,
+{
+    with_metrics_tracing_layer(MetricsLayer::new(), layer, f)
 }
 
 #[test]
@@ -773,4 +799,269 @@ fn test(
     ));
 
     assert_eq!(snapshot, expected);
+}
+
+#[test]
+fn test_field_merge_policy_append_nested_spans() {
+    let snapshot = with_metrics_tracing_layer(
+        MetricsLayer::new().with_field_merge_policy("component", FieldMergePolicy::Append(".")),
+        TracingContextLayer::all(),
+        || {
+            let worker = || {
+                let span = span!(Level::TRACE, "worker", component = "worker");
+                let _guard = span.enter();
+
+                counter!("my_counter").increment(1);
+            };
+
+            let analyzer = || {
+                let span = span!(Level::TRACE, "analyzer", component = "analyzer");
+                let _guard = span.enter();
+                worker();
+            };
+
+            analyzer();
+        },
+    );
+
+    let snapshot = snapshot.into_vec();
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            CompositeKey::new(
+                MetricKind::Counter,
+                Key::from_static_parts(MY_COUNTER, COMPONENT_WORKER_PATH)
+            ),
+            None,
+            None,
+            DebugValue::Counter(1),
+        )]
+    );
+}
+
+#[test]
+fn test_field_merge_policy_append_three_levels() {
+    let snapshot = with_metrics_tracing_layer(
+        MetricsLayer::new().with_field_merge_policy("component", FieldMergePolicy::Append(".")),
+        TracingContextLayer::all(),
+        || {
+            let task = || {
+                let span = span!(Level::TRACE, "task", component = "task");
+                let _guard = span.enter();
+
+                counter!("my_counter").increment(1);
+            };
+
+            let worker = || {
+                let span = span!(Level::TRACE, "worker", component = "worker");
+                let _guard = span.enter();
+                task();
+            };
+
+            let analyzer = || {
+                let span = span!(Level::TRACE, "analyzer", component = "analyzer");
+                let _guard = span.enter();
+                worker();
+            };
+
+            analyzer();
+        },
+    );
+
+    let snapshot = snapshot.into_vec();
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            CompositeKey::new(
+                MetricKind::Counter,
+                Key::from_static_parts(MY_COUNTER, COMPONENT_TASK_PATH)
+            ),
+            None,
+            None,
+            DebugValue::Counter(1),
+        )]
+    );
+}
+
+#[test]
+fn test_field_merge_policy_append_with_unannotated_span() {
+    let snapshot = with_metrics_tracing_layer(
+        MetricsLayer::new().with_field_merge_policy("component", FieldMergePolicy::Append(".")),
+        TracingContextLayer::all(),
+        || {
+            let task = || {
+                let span = span!(Level::TRACE, "task", component = "task");
+                let _guard = span.enter();
+
+                counter!("my_counter").increment(1);
+            };
+
+            let middle = || {
+                let span = span!(Level::TRACE, "middle");
+                let _guard = span.enter();
+                task();
+            };
+
+            let analyzer = || {
+                let span = span!(Level::TRACE, "analyzer", component = "analyzer");
+                let _guard = span.enter();
+                middle();
+            };
+
+            analyzer();
+        },
+    );
+
+    let snapshot = snapshot.into_vec();
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            CompositeKey::new(
+                MetricKind::Counter,
+                Key::from_static_parts(MY_COUNTER, COMPONENT_SKIPPED_PATH)
+            ),
+            None,
+            None,
+            DebugValue::Counter(1),
+        )]
+    );
+}
+
+#[test]
+fn test_field_merge_policy_record_composes() {
+    let snapshot = with_metrics_tracing_layer(
+        MetricsLayer::new().with_field_merge_policy("component", FieldMergePolicy::Append(".")),
+        TracingContextLayer::all(),
+        || {
+            let parent = span!(Level::TRACE, "parent", component = "analyzer");
+            let _parent_guard = parent.enter();
+
+            let span = span!(Level::TRACE, "child", component = tracing_core::field::Empty);
+            let _span_guard = span.enter();
+
+            counter!("my_counter").increment(1);
+
+            span.record("component", "worker");
+            counter!("my_counter").increment(1);
+
+            span.record("component", "leaf");
+            counter!("my_counter").increment(1);
+        },
+    );
+
+    let snapshot = snapshot.into_vec();
+
+    assert_eq!(
+        snapshot,
+        vec![
+            (
+                CompositeKey::new(
+                    MetricKind::Counter,
+                    Key::from_static_parts(MY_COUNTER, COMPONENT_INHERITED)
+                ),
+                None,
+                None,
+                DebugValue::Counter(1),
+            ),
+            (
+                CompositeKey::new(
+                    MetricKind::Counter,
+                    Key::from_static_parts(MY_COUNTER, COMPONENT_RECORDED_PATH)
+                ),
+                None,
+                None,
+                DebugValue::Counter(1),
+            ),
+            (
+                CompositeKey::new(
+                    MetricKind::Counter,
+                    Key::from_static_parts(MY_COUNTER, COMPONENT_RECORDED_LEAF_PATH)
+                ),
+                None,
+                None,
+                DebugValue::Counter(1),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_field_merge_policy_metric_labels_take_precedence() {
+    let snapshot = with_metrics_tracing_layer(
+        MetricsLayer::new().with_field_merge_policy("component", FieldMergePolicy::Append(".")),
+        TracingContextLayer::all(),
+        || {
+            let worker = || {
+                let span = span!(Level::TRACE, "worker", component = "worker");
+                let _guard = span.enter();
+
+                counter!("my_counter", "component" => "manual").increment(1);
+            };
+
+            let analyzer = || {
+                let span = span!(Level::TRACE, "analyzer", component = "analyzer");
+                let _guard = span.enter();
+                worker();
+            };
+
+            analyzer();
+        },
+    );
+
+    let snapshot = snapshot.into_vec();
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            CompositeKey::new(
+                MetricKind::Counter,
+                Key::from_static_parts(MY_COUNTER, COMPONENT_METRIC_LABEL_WINS)
+            ),
+            None,
+            None,
+            DebugValue::Counter(1),
+        )]
+    );
+}
+
+#[test]
+fn test_field_merge_policy_per_field_isolation() {
+    let snapshot = with_metrics_tracing_layer(
+        MetricsLayer::new().with_field_merge_policy("component", FieldMergePolicy::Append(".")),
+        TracingContextLayer::all(),
+        || {
+            let inner = || {
+                let span = span!(Level::TRACE, "inner", component = "inner_c", shared = "inner_s");
+                let _guard = span.enter();
+
+                counter!("my_counter").increment(1);
+            };
+
+            let outer = || {
+                let span = span!(Level::TRACE, "outer", component = "outer_c", shared = "outer_s");
+                let _guard = span.enter();
+                inner();
+            };
+
+            outer();
+        },
+    );
+
+    let snapshot = snapshot.into_vec();
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            CompositeKey::new(
+                MetricKind::Counter,
+                Key::from_static_parts(MY_COUNTER, PER_FIELD_ISOLATION)
+            ),
+            None,
+            None,
+            DebugValue::Counter(1),
+        )]
+    );
 }


### PR DESCRIPTION
## What & why

`metrics-tracing-context` injects active span fields as metric labels. Today, when a child span defines a field that its parent also defines, the child's value simply **overrides** the parent's. That works for flat labels, but breaks for hierarchical values — e.g. a `component` path — where the useful label is the nested composition (`analyzer.worker.task`), not the innermost segment alone.

This PR makes the collision strategy configurable per field name, so hierarchical values can be composed from the span ancestry instead of collapsed.

## API

```rust
pub enum FieldMergePolicy {
    /// Child span overrides parent; recorded value overrides held. This is the
    /// historical behavior and the default.
    Override,
    /// Compose as `<outer><sep><inner>`: parent's value is outer, child's is inner.
    Append(&'static str),
}

MetricsLayer::new().with_field_merge_policy("component", FieldMergePolicy::Append("."));
```

With the above, given `component = "analyzer"` on the root span and `component = "worker"` on a nested span, metrics emitted within the nested span carry `component = "analyzer.worker"`. Three-level nesting yields `analyzer.worker.task`.

The policy applies at both places a field can collide:
- `on_new_span` — parent fields inherited into a child span
- `on_record` — `Span::record` setting a value for a field the span already holds (composes with the held value)

## Compatibility & performance

- **Backward compatible by default.** Any field name without an explicit policy uses `Override`, which is exactly the crate's current behavior. Existing behavior changes only where a policy is configured.
- **Zero cost on the metric hot path.** Policies are consulted only when a span is created/recorded, never during metric emission. When no policies are configured, the previous fast path is taken unchanged.

## Tests

Added to `tests/integration.rs`:
- Two- and three-level `Append` composition
- Gap in the chain (unannotated span) passes the composed value through
- `Span::record` composition, including cumulative re-records
- Metric-callsite labels still take precedence over composed span labels
- Per-field isolation (unconfigured fields keep `Override`)

## Out of scope

- No global/default policy (per-field only)
- Separator is `&'static str` (no runtime-computed separators)

## Note on CI

The Clippy job currently fails, but it is **unrelated to this change**: it is a pre-existing issue in `metrics-exporter-prometheus` (two `map_or(...)` identity expressions at `src/distribution.rs:155-156`) newly escalated to hard errors by the Rust 1.98.0 clippy `map_or_identity` lint, under that crate's `#![deny(clippy::all)]`. This PR only adds to `metrics-tracing-context`, which is clippy-clean.