### PR TITLE
Expose HTTP exporter's bare `serve` and `serve_uds`

### DIFF
--- a/metrics-exporter-prometheus/CHANGELOG.md
+++ b/metrics-exporter-prometheus/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- New `http_listener` module exposing standalone `serve` (and `serve_uds`) functions that run the
+  scrape endpoint HTTP server on an already-bound listener with a `PrometheusHandle`, allowing the
+  exporter to be configured and started after the recorder has been built and installed.
+  ([#708](https://github.com/metrics-rs/metrics/issues/708))
+
 ## [0.18.3] - 2026-04-30
 
 ### Fixed

--- a/metrics-exporter-prometheus/src/exporter/http_listener.rs
+++ b/metrics-exporter-prometheus/src/exporter/http_listener.rs
@@ -34,9 +34,13 @@ enum ListenerType {
 }
 
 /// Error type for HTTP listening.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum HttpListeningError {
+    /// The HTTP server encountered an error while serving.
+    #[error("http server error: {0}")]
     Hyper(hyper::Error),
+    /// An I/O error occurred while serving.
+    #[error("i/o error: {0}")]
     Io(std::io::Error),
 }
 
@@ -194,6 +198,76 @@ enum ResponseFormat {
     Protobuf,
 }
 
+/// Serves the Prometheus scrape endpoint on an already-bound TCP listener.
+///
+/// This is the same HTTP server that is spawned when configuring [`PrometheusBuilder`] with
+/// [`with_http_listener`], exposed as a standalone function so that the listener can be bound
+/// after the recorder has been built and installed — for example, once configuration has been
+/// read, or when the listener is provided externally (e.g. via socket activation).
+///
+/// The server responds to GET requests on any request path with the metrics in the Prometheus
+/// [exposition format], except for `/health`, which unconditionally responds with `OK`.
+///
+/// If `allowed_addresses` is `Some`, clients whose IP address is not covered by any of the given
+/// networks receive a 403 Forbidden response.
+///
+/// The returned future serves connections indefinitely and normally never resolves. Dropping it
+/// stops accepting new connections; requests already being served run to completion on their own
+/// spawned tasks.
+///
+/// Unlike [`PrometheusBuilder::build`][crate::PrometheusBuilder::build], calling this function
+/// does not spawn an upkeep task: the caller is responsible for calling
+/// [`PrometheusHandle::run_upkeep`] periodically. See the **Upkeep and maintenance** section in
+/// the top-level crate documentation for more information.
+///
+/// [`PrometheusBuilder`]: crate::PrometheusBuilder
+/// [`with_http_listener`]: crate::PrometheusBuilder::with_http_listener
+/// [exposition format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
+///
+/// ## Errors
+///
+/// Only unrecoverable server errors cause the future to resolve with an error; failure to accept
+/// or serve an individual connection is logged and does not terminate the server.
+pub async fn serve(
+    listener: TcpListener,
+    handle: PrometheusHandle,
+    allowed_addresses: Option<Vec<IpNet>>,
+) -> Result<(), HttpListeningError> {
+    let exporter = HttpListeningExporter {
+        handle,
+        allowed_addresses,
+        listener_type: ListenerType::Tcp(listener),
+    };
+
+    exporter.serve().await
+}
+
+/// Serves the Prometheus scrape endpoint on an already-bound Unix domain socket listener.
+///
+/// This is the Unix domain socket equivalent of [`serve`], matching the behavior of configuring
+/// [`PrometheusBuilder`][crate::PrometheusBuilder] with
+/// [`with_http_uds_listener`][crate::PrometheusBuilder::with_http_uds_listener]. Refer to
+/// [`serve`] for the full details on server behavior and the caller's upkeep responsibilities.
+/// No IP allowlisting is performed for Unix domain sockets.
+///
+/// ## Errors
+///
+/// Only unrecoverable server errors cause the future to resolve with an error; failure to accept
+/// or serve an individual connection is logged and does not terminate the server.
+#[cfg(feature = "uds-listener")]
+pub async fn serve_uds(
+    listener: UnixListener,
+    handle: PrometheusHandle,
+) -> Result<(), HttpListeningError> {
+    let exporter = HttpListeningExporter {
+        handle,
+        allowed_addresses: None,
+        listener_type: ListenerType::Uds(listener),
+    };
+
+    exporter.serve().await
+}
+
 /// Creates an `ExporterFuture` implementing a http listener that serves prometheus metrics.
 ///
 /// # Errors
@@ -211,13 +285,9 @@ pub(crate) fn new_http_listener(
         .map_err(|e| BuildError::FailedToCreateHTTPListener(e.to_string()))?;
     let listener = TcpListener::from_std(listener).unwrap();
 
-    let exporter = HttpListeningExporter {
-        handle,
-        allowed_addresses,
-        listener_type: ListenerType::Tcp(listener),
-    };
-
-    Ok(Box::pin(async move { exporter.serve().await.map_err(super::ExporterError::HttpListener) }))
+    Ok(Box::pin(async move {
+        serve(listener, handle, allowed_addresses).await.map_err(super::ExporterError::HttpListener)
+    }))
 }
 
 /// Creates an `ExporterFuture` implementing a http listener that serves prometheus metrics.
@@ -236,11 +306,8 @@ pub(crate) fn new_http_uds_listener(
     }
     let listener = UnixListener::bind(listen_path)
         .map_err(|e| BuildError::FailedToCreateHTTPListener(e.to_string()))?;
-    let exporter = HttpListeningExporter {
-        handle,
-        allowed_addresses: None,
-        listener_type: ListenerType::Uds(listener),
-    };
 
-    Ok(Box::pin(async move { exporter.serve().await.map_err(super::ExporterError::HttpListener) }))
+    Ok(Box::pin(async move {
+        serve_uds(listener, handle).await.map_err(super::ExporterError::HttpListener)
+    }))
 }

--- a/metrics-exporter-prometheus/src/exporter/mod.rs
+++ b/metrics-exporter-prometheus/src/exporter/mod.rs
@@ -90,7 +90,7 @@ impl ExporterConfig {
 }
 
 #[cfg(feature = "http-listener")]
-mod http_listener;
+pub(crate) mod http_listener;
 
 #[cfg(any(feature = "push-gateway", feature = "push-gateway-no-tls-provider"))]
 mod push_gateway;

--- a/metrics-exporter-prometheus/src/lib.rs
+++ b/metrics-exporter-prometheus/src/lib.rs
@@ -144,6 +144,59 @@ pub use self::exporter::builder::PrometheusBuilder;
 )]
 pub use self::exporter::ExporterFuture;
 
+/// Standalone HTTP listener serving the Prometheus scrape endpoint.
+///
+/// The [`serve`][http_listener::serve] and [`serve_uds`][http_listener::serve_uds] functions run
+/// the same HTTP server that [`PrometheusBuilder::build`] creates when configured with an HTTP
+/// listener, but accept an already-bound listener and a [`PrometheusHandle`]. This decouples
+/// building/installing the recorder from starting the exporter, which is useful when the recorder
+/// must be installed as early as possible but the listen address only becomes known later — for
+/// example, after configuration has been read — or when the listener is provided externally.
+///
+/// Note that unlike [`PrometheusBuilder::build`], no upkeep task is spawned automatically: the
+/// caller is responsible for calling [`PrometheusHandle::run_upkeep`] periodically. See the
+/// **Upkeep and maintenance** section in the top-level crate documentation for more information.
+///
+/// ```no_run
+/// use metrics_exporter_prometheus::PrometheusBuilder;
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     // Build and install the recorder as early as possible.
+///     let handle = PrometheusBuilder::new().install_recorder()?;
+///
+///     // ... read configuration, do other startup work ...
+///     let listen_address = "0.0.0.0:9000";
+///
+///     let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
+///     runtime.block_on(async move {
+///         // Drive the upkeep of the recorder, since no upkeep task is spawned for us.
+///         let upkeep_handle = handle.clone();
+///         tokio::spawn(async move {
+///             loop {
+///                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+///                 upkeep_handle.run_upkeep();
+///             }
+///         });
+///
+///         // Only now is the scrape endpoint socket bound.
+///         let listener = tokio::net::TcpListener::bind(listen_address).await?;
+///         metrics_exporter_prometheus::http_listener::serve(listener, handle, None).await?;
+///         Ok(())
+///     })
+/// }
+/// ```
+#[cfg(feature = "http-listener")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-listener")))]
+pub mod http_listener {
+    pub use crate::exporter::http_listener::{serve, HttpListeningError};
+
+    #[cfg(feature = "uds-listener")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "uds-listener")))]
+    pub use crate::exporter::http_listener::serve_uds;
+
+    pub use ipnet::IpNet;
+}
+
 pub mod formatting;
 #[cfg(feature = "protobuf")]
 pub mod protobuf;

--- a/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
+++ b/metrics-exporter-prometheus/tests/http_listener_integration_test.rs
@@ -121,6 +121,81 @@ mod http_listener_test {
         });
     }
 
+    #[test]
+    fn test_standalone_serve() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap_or_else(|e| panic!("Failed to create test runtime: {:?}", e));
+
+        runtime.block_on(async {
+            let recorder = PrometheusBuilder::new().build_recorder();
+            let handle = recorder.handle();
+
+            let labels = vec![Label::new("wutang", "forever")];
+            let key = Key::from_parts("basic_gauge", labels);
+            let gauge = recorder.register_gauge(&key, &METADATA);
+            gauge.set(-1.23);
+
+            // The listener is bound separately, after the recorder has been built.
+            let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .expect("failed to bind listener");
+            let socket_address =
+                listener.local_addr().expect("failed to obtain listener local address");
+
+            runtime.spawn(metrics_exporter_prometheus::http_listener::serve(
+                listener, handle, None,
+            ));
+
+            let uri = format!("http://{socket_address}")
+                .parse::<Uri>()
+                .unwrap_or_else(|e| panic!("Error parsing URI: {:?}", e));
+
+            let (status, body, _) = read_from(uri, None).await;
+
+            assert_eq!(status, StatusCode::OK);
+            assert!(String::from_utf8(body)
+                .unwrap()
+                .contains("basic_gauge{wutang=\"forever\"} -1.23"));
+        });
+    }
+
+    #[test]
+    fn test_standalone_serve_allowlist_rejection() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap_or_else(|e| panic!("Failed to create test runtime: {:?}", e));
+
+        runtime.block_on(async {
+            let recorder = PrometheusBuilder::new().build_recorder();
+            let handle = recorder.handle();
+
+            let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .expect("failed to bind listener");
+            let socket_address =
+                listener.local_addr().expect("failed to obtain listener local address");
+
+            // The allowlist does not cover 127.0.0.1, so the request must be rejected.
+            let allowed = vec!["192.168.0.0/16".parse().expect("failed to parse network")];
+            runtime.spawn(metrics_exporter_prometheus::http_listener::serve(
+                listener,
+                handle,
+                Some(allowed),
+            ));
+
+            let uri = format!("http://{socket_address}")
+                .parse::<Uri>()
+                .unwrap_or_else(|e| panic!("Error parsing URI: {:?}", e));
+
+            let (status, _, _) = read_from(uri, None).await;
+
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        });
+    }
+
     async fn get_available_port(listen_address: [u8; 4]) -> u16 {
         let socket_address = SocketAddr::from((listen_address, 0));
         TcpListener::bind(socket_address)


### PR DESCRIPTION
Here's my proposal for #708; very minimal change, and is a separate "advanced" opt-in interface from the usual builder.